### PR TITLE
connection: fix possible race in Connection destructor

### DIFF
--- a/crates/core/src/v1/connection.rs
+++ b/crates/core/src/v1/connection.rs
@@ -22,7 +22,7 @@ pub struct Connection {
 
 impl Drop for Connection {
     fn drop(&mut self) {
-        if Arc::get_mut(&mut self.drop_ref).is_some() {
+        if Arc::into_inner(std::mem::take(&mut self.drop_ref)).is_some() {
             unsafe { libsql_sys::ffi::sqlite3_close(self.raw) };
         }
     }


### PR DESCRIPTION
The way Connection drop() works now is as follows:
 1. If a special `drop_ref` marker is engaged, try to take its mutable reference
 2. If we have a mutable reference, sqlite3_close is called on the raw connection pointer
 3. End of custom drop(), Connection struct is destroyed

The idea behind this drop() was to make sure that we call sqlite3_close exactly once, but I think it's flawed. Nothing prevents the following race:
 a. Thread A calls (1.) and (2.) from above and yields
 b. Thread B also calls (1.) and (2.) above, because `drop_ref` is still
    not destroyed - it only gets destroyed in step (3.)
 c. We just called sqlite3_close twice. That breaks the libSQL contract
    with C code and leads to double-free.

To prevent the race from happening, drop() is now implemented as follows:
 1. We take `drop_ref` by value and call `Arc::into_inner()` on it. It only returns the inner value when called on the last held reference, otherwise it does nothing.
 2. If we succeeded in calling `into_inner()`, we're now in exclusive possesion of the value and we're sure nobody else will ever see it.
 3. Now we call `sqlite3_close` and nobody else will, because that's the contract `Arc::into_inner` gives us.

Refs (and probably fixes, but I couldn't reproduce it) #419