### PR TITLE
core: make sure sqlite3_close is not called twice

### DIFF
--- a/crates/core/src/replication/connection.rs
+++ b/crates/core/src/replication/connection.rs
@@ -202,7 +202,7 @@ impl Conn for RemoteConnection {
         self.state.lock().last_insert_rowid
     }
 
-    fn close(&self) {
+    fn close(&mut self) {
         self.local.close()
     }
 }

--- a/crates/core/src/v1/connection.rs
+++ b/crates/core/src/v1/connection.rs
@@ -22,9 +22,7 @@ pub struct Connection {
 
 impl Drop for Connection {
     fn drop(&mut self) {
-        if Arc::get_mut(&mut self.drop_ref).is_some() {
-            unsafe { libsql_sys::ffi::sqlite3_close(self.raw) };
-        }
+        self.disconnect()
     }
 }
 
@@ -80,9 +78,9 @@ impl Connection {
     }
 
     /// Disconnect from the database.
-    pub fn disconnect(&self) {
-        unsafe {
-            ffi::sqlite3_close_v2(self.raw);
+    pub fn disconnect(&mut self) {
+        if Arc::get_mut(&mut self.drop_ref).is_some() {
+            unsafe { libsql_sys::ffi::sqlite3_close_v2(self.raw) };
         }
     }
 

--- a/crates/core/src/v2/hrana.rs
+++ b/crates/core/src/v2/hrana.rs
@@ -330,7 +330,7 @@ impl Conn for Client {
         self.last_insert_rowid.load(Ordering::SeqCst)
     }
 
-    fn close(&self) {
+    fn close(&mut self) {
         todo!()
     }
 }

--- a/crates/core/src/v2/mod.rs
+++ b/crates/core/src/v2/mod.rs
@@ -246,7 +246,7 @@ pub(crate) trait Conn {
 
     fn last_insert_rowid(&self) -> i64;
 
-    fn close(&self);
+    fn close(&mut self);
 }
 
 #[derive(Clone)]
@@ -300,8 +300,10 @@ impl Connection {
         self.conn.last_insert_rowid()
     }
 
-    pub fn close(&self) {
-        self.conn.close()
+    pub fn close(&mut self) {
+        if let Some(conn) = Arc::get_mut(&mut self.conn) {
+            conn.close()
+        }
     }
 }
 
@@ -353,7 +355,7 @@ impl Conn for LibsqlConnection {
         self.conn.last_insert_rowid()
     }
 
-    fn close(&self) {
+    fn close(&mut self) {
         self.conn.disconnect()
     }
 }


### PR DESCRIPTION
We had two interfaces for calling sqlite3_close C function:
 - drop()
 - disconnect()

In drop() we checked for `drop_ref` to make sure we only call it once for a raw pointer, but the check was missing for `disconnect()`. Now the behavior is unified.
As a result, we need to take a mutable reference on `fn close()`, but that sounds reasonable - we need to own the connection to be able to close it, since it renders it unusable for other users.

Refs (and maybe fixes) #419