### PR TITLE
libsql: Add `BEGIN READONLY` support

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -13,3 +13,5 @@ members = [
 codegen-units = 1
 panic = "abort"
 
+[patch.crates-io]
+sqlite3-parser = { git = "https://github.com/LucioFranco/lemon-rs" }

--- a/crates/core/examples/transaction.rs
+++ b/crates/core/examples/transaction.rs
@@ -19,14 +19,23 @@ async fn main() {
     )
     .await
     .unwrap();
+
+    db.sync().await.unwrap();
+
     let conn = db.connect().unwrap();
+
+    conn.execute("BEGIN READONLY", ()).await.unwrap();
+    conn.query("SELECT 1", ()).await.unwrap();
+    conn.query("COMMIT", ()).await.unwrap();
 
     let tx = conn
         .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
         .await
         .unwrap();
 
-    tx.execute("SELECT 1", ()).await.unwrap();
+    tx.execute("INSERT INTO foo (x) VALUES (?1)", ["hello world"])
+        .await
+        .unwrap();
 
     tx.commit().await.unwrap();
 }

--- a/crates/core/src/v1/transaction.rs
+++ b/crates/core/src/v1/transaction.rs
@@ -2,10 +2,12 @@ use crate::v1::Connection;
 use crate::{params::Params, Result};
 use std::ops::Deref;
 
+#[derive(Debug)]
 pub enum TransactionBehavior {
     Deferred,
     Immediate,
     Exclusive,
+    ReadOnly,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,6 +60,7 @@ impl Transaction {
             TransactionBehavior::Deferred => "BEGIN DEFERRED",
             TransactionBehavior::Immediate => "BEGIN IMMEDIATE",
             TransactionBehavior::Exclusive => "BEGIN EXCLUSIVE",
+            TransactionBehavior::ReadOnly => "BEGIN READONLY",
         };
         let _ = conn.execute(begin_stmt, Params::None)?;
         Ok(Self {

--- a/crates/core/src/v2/mod.rs
+++ b/crates/core/src/v2/mod.rs
@@ -260,14 +260,17 @@ pub struct Connection {
 // TODO(lucio): Convert to using tryinto params
 impl Connection {
     pub async fn execute(&self, sql: &str, params: impl IntoParams) -> Result<u64> {
+        tracing::trace!("executing `{}`", sql);
         self.conn.execute(sql, params.into_params()?).await
     }
 
     pub async fn execute_batch(&self, sql: &str) -> Result<()> {
+        tracing::trace!("executing batch `{}`", sql);
         self.conn.execute_batch(sql).await
     }
 
     pub async fn prepare(&self, sql: &str) -> Result<Statement> {
+        tracing::trace!("preparing `{}`", sql);
         self.conn.prepare(sql).await
     }
 
@@ -279,6 +282,7 @@ impl Connection {
 
     /// Begin a new transaction in DEFERRED mode, which is the default.
     pub async fn transaction(&self) -> Result<Transaction> {
+        tracing::trace!("starting deferred transaction");
         self.transaction_with_behavior(TransactionBehavior::Deferred)
             .await
     }
@@ -288,6 +292,7 @@ impl Connection {
         &self,
         tx_behavior: TransactionBehavior,
     ) -> Result<Transaction> {
+        tracing::trace!("starting {:?} transaction", tx_behavior);
         self.conn.transaction(tx_behavior).await
     }
 

--- a/crates/core/src/v2/statement.rs
+++ b/crates/core/src/v2/statement.rs
@@ -36,10 +36,12 @@ impl Statement {
     }
 
     pub async fn execute(&mut self, params: impl IntoParams) -> Result<usize> {
+        tracing::trace!("execute for prepared statement");
         self.inner.execute(&params.into_params()?).await
     }
 
     pub async fn query(&mut self, params: impl IntoParams) -> Result<Rows> {
+        tracing::trace!("query for prepared statement");
         self.inner.query(&params.into_params()?).await
     }
 

--- a/src/parse.y
+++ b/src/parse.y
@@ -165,6 +165,12 @@ transtype(A) ::= .             {A = TK_DEFERRED;}
 transtype(A) ::= DEFERRED(X).  {A = @X; /*A-overwrites-X*/}
 transtype(A) ::= IMMEDIATE(X). {A = @X; /*A-overwrites-X*/}
 transtype(A) ::= EXCLUSIVE(X). {A = @X; /*A-overwrites-X*/}
+// FIXME: READONLY transactions map directly to DEFERRED transactions
+// as currently the syntax is only used by libsql's rust library to 
+// force the connection to be in an interactive read local mode. In the
+// future we should extend this by impmenting readonly features within
+// the database impl of libsql.
+transtype(A) ::= READONLY.     {A = TK_DEFERRED; /*A-overwrites-X*/}
 cmd ::= COMMIT|END(X) trans_opt.   {sqlite3EndTransaction(pParse,@X);}
 cmd ::= ROLLBACK(X) trans_opt.     {sqlite3EndTransaction(pParse,@X);}
 
@@ -256,7 +262,7 @@ columnname(A) ::= nm(A) typetoken(Y). {sqlite3AddColumn(pParse,A,Y);}
   CONFLICT DATABASE DEFERRED DESC DETACH DO
   EACH END EXCLUSIVE EXPLAIN FAIL FOR FUNCTION
   IGNORE IMMEDIATE INITIALLY INSTEAD LANGUAGE LIKE_KW MATCH NO PLAN
-  QUERY KEY OF OFFSET PRAGMA RAISE RANDOM RECURSIVE RELEASE REPLACE RESTRICT ROW ROWS
+  QUERY KEY OF OFFSET PRAGMA RAISE RANDOM READONLY RECURSIVE RELEASE REPLACE RESTRICT ROW ROWS
   ROLLBACK SAVEPOINT TEMP TRIGGER VACUUM VIEW VIRTUAL WITH WITHOUT
   NULLS FIRST LAST
 %ifdef SQLITE_OMIT_COMPOUND_SELECT

--- a/tool/mkkeywordhash.c
+++ b/tool/mkkeywordhash.c
@@ -282,6 +282,7 @@ static Keyword aKeywordTable[] = {
   { "RAISE",            "TK_RAISE",        TRIGGER,          1      },
   { "RANDOM",           "TK_RANDOM",       ALWAYS,           1      },
   { "RANGE",            "TK_RANGE",        WINDOWFUNC,       3      },
+  { "READONLY",         "TK_READONLY",     ALWAYS,           1      },
   { "RECURSIVE",        "TK_RECURSIVE",    CTE,              3      },
   { "REFERENCES",       "TK_REFERENCES",   FKEY,             1      },
   { "REGEXP",           "TK_LIKE_KW",      ALWAYS,           3      },


### PR DESCRIPTION
This adds prelimary `BEGIN READONLY` support for embedded replica's. Within libsql this syntax just converts into an `IMMEDIATE` transaction but when used with embedded replica's this will force the transaction to be local only and will reject any sql commands that write.