### PR TITLE
libsql-categorizer: initial commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "bottomless",
   "bottomless-cli",
   "libsql-sys-tmp",
+  "libsql-categorizer",
 
   "vendored/rusqlite",
 ]

--- a/libsql-categorizer/Cargo.toml
+++ b/libsql-categorizer/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "libsql-categorizer"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+pest = "2.7.4"
+pest_derive = "2.7.4"
+tracing = "0.1.37"

--- a/libsql-categorizer/src/lib.rs
+++ b/libsql-categorizer/src/lib.rs
@@ -1,8 +1,4 @@
-extern crate pest;
-#[macro_use]
-extern crate pest_derive;
-
-#[derive(Parser)]
+#[derive(pest_derive::Parser)]
 #[grammar = "libsql.pest"]
 pub struct LibsqlParser;
 

--- a/libsql-categorizer/src/lib.rs
+++ b/libsql-categorizer/src/lib.rs
@@ -1,0 +1,223 @@
+extern crate pest;
+#[macro_use]
+extern crate pest_derive;
+
+#[derive(Parser)]
+#[grammar = "libsql.pest"]
+pub struct LibsqlParser;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum StmtKind {
+    TxnBegin,
+    TxnEnd,
+    Read,
+    Write,
+    Savepoint,
+    Release,
+    Other,
+}
+
+fn is_reserved_tbl(name: &str) -> bool {
+    let n = name.to_lowercase();
+    n == "_litestream_seq" || n == "_litestream_lock" || n == "libsql_wasm_func_table"
+}
+
+fn write_if_not_reserved(name: &str) -> Option<StmtKind> {
+    (!is_reserved_tbl(name)).then_some(StmtKind::Write)
+}
+
+impl StmtKind {
+    pub fn kind(stmt: &str) -> Option<Self> {
+        use pest::Parser;
+
+        let cmd = match LibsqlParser::parse(Rule::stmt, stmt) {
+            Ok(mut parsed) => parsed.next().unwrap(),
+            Err(_) => return None,
+        };
+
+        let inner = cmd.into_inner().next().unwrap();
+        let cmd = match inner.as_rule() {
+            Rule::explain => {
+                let cmd = inner.into_inner().next().unwrap();
+                match cmd.as_rule() {
+                    Rule::pragma | Rule::vacuum => cmd,
+                    _ => return Some(StmtKind::Other),
+                }
+            }
+            Rule::explain_query_plan => return Some(StmtKind::Other),
+            Rule::cmd => inner.into_inner().next().unwrap(),
+            _ => return None,
+        };
+
+        match cmd.as_rule() {
+            Rule::begin => Some(StmtKind::TxnBegin),
+            Rule::commit => Some(StmtKind::TxnEnd),
+            Rule::rollback => match cmd.into_inner().next().map(|r| r.as_rule()) {
+                Some(Rule::to_savepoint) => Some(StmtKind::Release),
+                Some(_) => None,
+                None => Some(StmtKind::TxnEnd),
+            },
+            Rule::savepoint => Some(StmtKind::Savepoint),
+            Rule::select => Some(StmtKind::Read),
+            Rule::insert | Rule::update | Rule::delete => {
+                let name = cmd.into_inner().next().unwrap().as_str();
+                write_if_not_reserved(name)
+            }
+            Rule::create_table
+            | Rule::create_view
+            | Rule::create_function
+            | Rule::create_index
+            | Rule::create_trigger => {
+                let mut inner = cmd.into_inner();
+                let is_temp = matches!(inner.next().map(|r| r.as_rule()), Some(Rule::temp));
+                if is_temp {
+                    None
+                } else {
+                    Some(StmtKind::Write)
+                }
+            }
+            Rule::alter_table | Rule::drop_table | Rule::drop_view => {
+                let name = cmd.into_inner().next().unwrap().as_str();
+                write_if_not_reserved(name)
+            }
+            Rule::drop_index | Rule::drop_trigger => Some(StmtKind::Write),
+            Rule::pragma => {
+                let mut inner = cmd.into_inner();
+                let name = inner.next().unwrap().into_inner().next().unwrap().as_str();
+                let has_body = inner.next().is_some();
+                Self::pragma_kind(name, has_body)
+            }
+            _ => None,
+        }
+    }
+
+    fn pragma_kind(name: &str, has_body: bool) -> Option<Self> {
+        match name {
+            // always ok to be served by primary or replicas - pure readonly pragmas
+            "table_list" | "index_list" | "table_info" | "table_xinfo" | "index_xinfo"
+            | "pragma_list" | "compile_options" | "database_list" | "function_list"
+            | "module_list" => Some(Self::Read),
+            // special case for `encoding` - it's effectively readonly for connections
+            // that already created a database, which is always the case for sqld
+            "encoding" => Some(Self::Read),
+            // always ok to be served by primary
+            "foreign_keys" | "foreign_key_list" | "foreign_key_check" | "collation_list"
+            | "data_version" | "freelist_count" | "integrity_check" | "legacy_file_format"
+            | "page_count" | "quick_check" | "stats" | "user_version" => Some(Self::Write),
+            // ok to be served by primary without args
+            "analysis_limit"
+            | "application_id"
+            | "auto_vacuum"
+            | "automatic_index"
+            | "busy_timeout"
+            | "cache_size"
+            | "cache_spill"
+            | "cell_size_check"
+            | "checkpoint_fullfsync"
+            | "defer_foreign_keys"
+            | "fullfsync"
+            | "hard_heap_limit"
+            | "journal_mode"
+            | "journal_size_limit"
+            | "legacy_alter_table"
+            | "locking_mode"
+            | "max_page_count"
+            | "mmap_size"
+            | "page_size"
+            | "query_only"
+            | "read_uncommitted"
+            | "recursive_triggers"
+            | "reverse_unordered_selects"
+            | "schema_version"
+            | "secure_delete"
+            | "soft_heap_limit"
+            | "synchronous"
+            | "temp_store"
+            | "threads"
+            | "trusted_schema"
+            | "wal_autocheckpoint" => {
+                if has_body {
+                    None
+                } else {
+                    Some(Self::Write)
+                }
+            }
+            // changes the state of the connection, and can't be allowed rn:
+            "case_sensitive_like" | "ignore_check_constraints" | "incremental_vacuum"
+                // TODO: check if optimize can be safely performed
+                | "optimize"
+                | "parser_trace"
+                | "shrink_memory"
+                | "wal_checkpoint" => None,
+            _ => {
+                tracing::debug!("Unknown pragma: {name}");
+                None
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const STMTS: &[&str] = &[
+        "SELECT * FROM foo",
+        "SELECT * FROM foo WHERE bar = 1",
+        "INSERT INTO foo VALUES (5, 2)",
+        "INSERT INTO foo VALUES (5, 2), (3, 4)",
+        "VACUUM yourself",
+        "EXPLAIN VACUUM yourself",
+        "CREATE FUNCTION xyz LANGUAGE wasm AS '0xdeadbabe'",
+        "PRAGMA foreign_keys=on",
+        "PRAGMA foreign_keys",
+        "PRAGMA journal_mode",
+        "PRAGMA journal_mode=delete",
+        "PRAGMA pragma_list",
+        "CREATE TABLE t(id, v int primary key)",
+        "SAVEPOINT abc",
+        "ROLLBACK TO SAVEPOINT abc",
+        "ROLLBACK",
+        "CREATE TEMPORARY TABLE abc(def)",
+        "CREATE TEMP TABLE abc(def)",
+        "BEGIN IMMEDIATE",
+        "BEGIN READONLY",
+        "BEGIN DEFERRED",
+        "BEGIN",
+        "COMMIT",
+        "END",
+    ];
+
+    #[test]
+    fn test_parse0() {
+        use pest::Parser;
+
+        for stmt in STMTS {
+            let now = std::time::Instant::now();
+            let parsed = LibsqlParser::parse(Rule::stmt, stmt)
+                .unwrap()
+                .next()
+                .unwrap();
+            let elapsed = now.elapsed().as_micros();
+            println!(
+                "{:?}: {:?}",
+                parsed.as_rule(),
+                parsed
+                    .into_inner()
+                    .next()
+                    .unwrap()
+                    .into_inner()
+                    .next()
+                    .unwrap()
+            );
+            println!("\tparsed in {elapsed}μs");
+        }
+    }
+
+    #[test]
+    fn test_categorize0() {
+        for stmt in STMTS {
+            println!("{:?}:\n\t{:?}", stmt, StmtKind::kind(stmt));
+        }
+    }
+}

--- a/libsql-categorizer/src/libsql.pest
+++ b/libsql-categorizer/src/libsql.pest
@@ -1,0 +1,99 @@
+// *Simplified* libSQL grammar for a *single* query.
+// Parses just enough to be able to qualify if an operation is a read, write, transaction start, etc.
+// Accepts a superset of SQL, including incorrect libSQL/SQLite statements!
+// Inspired by https://github.com/gwenn/sqlpest
+
+stmt = { explain_query_plan | explain | cmd }
+explain_query_plan = { ^"explain" ~ ^"query" ~ ^"plan" ~ cmd }
+explain = { ^"explain" ~ cmd }
+
+cmd = {
+    alter_table |
+    analyze |
+    attach |
+    begin |
+    commit |
+    create_function |
+    create_index |
+    create_table |
+    create_trigger |
+    create_view |
+    delete |
+    detach |
+    drop_function |
+    drop_index |
+    drop_table |
+    drop_trigger |
+    drop_view |
+    insert |
+    pragma |
+    reindex |
+    release |
+    rollback |
+    savepoint |
+    select |
+    update |
+    vacuum
+}
+
+transaction = { ^"transaction" ~ name? }
+transaction_type = { ^"deferred" | ^"immediate" | ^"exclusive" | ^"readonly" }
+begin = { ^"begin" ~ transaction_type? ~ transaction? }
+commit = { (^"commit" | ^"end") ~ transaction? }
+to_savepoint = { ^"to" ~ ^"savepoint"? ~ name }
+rollback = { ^"rollback" ~ transaction? ~ to_savepoint? }
+savepoint = { ^"savepoint" ~ name }
+release = { ^"release" ~ ^"savepoint"? ~ name }
+
+temp = { ^"temporary" | ^"temp" }
+
+create_table = { ^"create" ~ temp? ~ ^"table" ~ ANY* }
+drop_table = { ^"drop" ~ ^"table" ~ ANY* }
+
+create_view = { ^"create" ~ temp? ~ ^"view" ~ ANY* }
+drop_view = { ^"drop" ~ ^"view" ~ ANY* }
+
+select = { with? ~ ^"select" ~ ANY* }
+delete = { with? ~ ^"delete" ~ ^"from" ~ name ~ ANY* }
+update = { with? ~ ^"update" ~ name ~ ANY* }
+insert = { with? ~ ^"insert" ~^"into" ~ name ~ ANY* }
+
+create_index = { ^"create" ~ ^"unique"? ~ ^"index" ~ ANY*}
+drop_index = { ^"drop" ~ ^"index" ~ ANY* }
+
+create_function = { ^"create" ~ ^"function" ~ ANY* }
+drop_function = { ^"drop" ~ ^"function" ~ ANY* }
+
+vacuum = { ^"vacuum" ~ name? }
+
+qualified_name = ${ (name ~ ".")? ~ name }
+pragma = { ^"pragma" ~ qualified_name ~ pragma_body? }
+pragma_body = { "=" ~ ANY* }
+
+create_trigger = { ^"create" ~ temp? ~ ^"trigger" ~ ANY* }
+drop_trigger = { ^"drop" ~ ^"trigger" ~ ANY* }
+
+attach = { ^"attach" ~ ^"database"? ~ ANY* }
+detach = { ^"detach" ~ ^"database"? ~ ANY* }
+reindex = { ^"reindex" ~ ANY* }
+analyze = { ^"analyze" ~ ANY* }
+alter_table = { ^"alter" ~ ^"table" ~ ANY* }
+
+create_vtab = { ^"create" ~ ^"virtual" ~ ^"table" ~ ANY*}
+
+sort_order = { ^"asc" | ^"desc" }
+indexed_column = { name ~ (^"collate" ~ name)? ~ sort_order? }
+with = { ^"with" ~ ^"recursive"? ~ with_query ~ ("," ~ with_query)* }
+with_query = { name ~ ("(" ~ indexed_column ~ ("," ~ indexed_column)* ~ ")")? ~ ^"as" ~ "(" ~ select ~ ")" }
+
+name = @{
+    ('A'..'Z' | "_" | 'a'..'z') ~ ("$" | '0'..'9' | 'A'..'Z' | "_" | 'a'..'z')* |
+    // empty Id ("") is OK
+    // A keyword in double-quotes is an identifier.
+    "\"" ~ ("\"\"" | !"\"" ~ ANY)* ~ "\"" |
+    // A keyword enclosed in grave accents (ASCII code 96) is an identifier. This is not standard SQL.
+    "`" ~ ("``" | !"`" ~ ANY)* ~ "`" |
+    // A keyword enclosed in square brackets is an identifier. This is not standard SQL.
+    "[" ~ (!"]" ~ ANY)* ~ "]"
+}
+WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/libsql-categorizer/src/libsql.pest
+++ b/libsql-categorizer/src/libsql.pest
@@ -38,20 +38,20 @@ cmd = {
 
 transaction = { ^"transaction" ~ name? }
 transaction_type = { ^"deferred" | ^"immediate" | ^"exclusive" | ^"readonly" }
-begin = { ^"begin" ~ transaction_type? ~ transaction? }
-commit = { (^"commit" | ^"end") ~ transaction? }
+begin = { ^"begin" ~ transaction_type? ~ transaction? ~ ANY* }
+commit = { (^"commit" | ^"end") ~ transaction? ~ ANY* }
 to_savepoint = { ^"to" ~ ^"savepoint"? ~ name }
-rollback = { ^"rollback" ~ transaction? ~ to_savepoint? }
-savepoint = { ^"savepoint" ~ name }
-release = { ^"release" ~ ^"savepoint"? ~ name }
+rollback = { ^"rollback" ~ transaction? ~ to_savepoint? ~ ANY* }
+savepoint = { ^"savepoint" ~ name ~ ANY* }
+release = { ^"release" ~ ^"savepoint"? ~ name ~ ANY* }
 
 temp = { ^"temporary" | ^"temp" }
 
 create_table = { ^"create" ~ temp? ~ ^"table" ~ ANY* }
-drop_table = { ^"drop" ~ ^"table" ~ ANY* }
+drop_table = { ^"drop" ~ ^"table" ~ name ~ ANY* }
 
 create_view = { ^"create" ~ temp? ~ ^"view" ~ ANY* }
-drop_view = { ^"drop" ~ ^"view" ~ ANY* }
+drop_view = { ^"drop" ~ ^"view" ~ name ~ ANY* }
 
 select = { with? ~ ^"select" ~ ANY* }
 delete = { with? ~ ^"delete" ~ ^"from" ~ name ~ ANY* }
@@ -59,7 +59,7 @@ update = { with? ~ ^"update" ~ name ~ ANY* }
 insert = { with? ~ ^"insert" ~^"into" ~ name ~ ANY* }
 
 create_index = { ^"create" ~ ^"unique"? ~ ^"index" ~ ANY*}
-drop_index = { ^"drop" ~ ^"index" ~ ANY* }
+drop_index = { ^"drop" ~ ^"index" ~ name ~ ANY* }
 
 create_function = { ^"create" ~ ^"function" ~ ANY* }
 drop_function = { ^"drop" ~ ^"function" ~ ANY* }
@@ -77,7 +77,7 @@ attach = { ^"attach" ~ ^"database"? ~ ANY* }
 detach = { ^"detach" ~ ^"database"? ~ ANY* }
 reindex = { ^"reindex" ~ ANY* }
 analyze = { ^"analyze" ~ ANY* }
-alter_table = { ^"alter" ~ ^"table" ~ ANY* }
+alter_table = { ^"alter" ~ ^"table" ~ name ~ ANY* }
 
 create_vtab = { ^"create" ~ ^"virtual" ~ ^"table" ~ ANY*}
 


### PR DESCRIPTION
This initial commit shows how we could approach categorizing queries. Currently there's code duplication between crates/core and sqld, and both of those solutions are based on sqlite3-parser crate, which is a little too heavy for what we need.

The new approach I propose here is a largely simplified parser wrote in pest, which only extracts the information we need to categorize queries as reads, writes, transaction control statements, etc. It will happily accept "queries" like "SELECT blah", which aren't correct, but it's not really a concern of a client - a server will refuse them later anyway. On top of simplification, one more perk is that we can now easily extend the categorization with libSQL syntax, e.g. understand CREATE FUNCTION statements or READONLY transactions.

Run `cargo test -- --nocapture` for a short demo!

If the approach looks acceptable, the next natural step is to migrate crates/core and sqld to it, deduplicating the contents of query_analysis.