### PR TITLE
sqld: turn off wasm functions by default

### DIFF
--- a/libsql-server/sqld/Cargo.toml
+++ b/libsql-server/sqld/Cargo.toml
@@ -95,7 +95,7 @@ tonic-build = "0.10"
 vergen = { version = "8", features = ["build", "git", "gitcl"] }
 
 [features]
-default = ["wasm-udfs"]
+default = []
 unix-excl-vfs = ["sqld-libsql-bindings/unix-excl-vfs"]
 debug-tools = ["console-subscriber", "rusqlite/trace", "tokio/tracing"]
 sim-tests = ["libsql"]


### PR DESCRIPTION
It also transiently fixes the "malformed db" issue with embedded replicas. Those replicas didn't create a "libsql_wasm_func_table" when first connecting, and sqld did, due to having wasm functions enabled.
But, since our sqld parser still doesn't accept CREATE FUNCTION yet, there's no harm in disabling the support.