### PR TITLE
Per-query stats

### DIFF
--- a/libsql-server/src/hrana/proto.rs
+++ b/libsql-server/src/hrana/proto.rs
@@ -43,6 +43,23 @@ pub struct NamedArg {
 }
 
 #[derive(Serialize, prost::Message)]
+pub struct StmtResultStats {
+    #[prost(int32, required, tag = "1")]
+    pub rows_read: i32,
+    #[prost(int32, required, tag = "2")]
+    pub rows_written: i32,
+}
+
+impl From<crate::query_result_builder::QueryStats> for StmtResultStats {
+    fn from(stats: crate::query_result_builder::QueryStats) -> Self {
+        StmtResultStats {
+            rows_read: stats.rows_read,
+            rows_written: stats.rows_written,
+        }
+    }
+}
+
+#[derive(Serialize, prost::Message)]
 pub struct StmtResult {
     #[prost(message, repeated, tag = "1")]
     pub cols: Vec<Col>,
@@ -55,6 +72,8 @@ pub struct StmtResult {
     pub last_insert_rowid: Option<i64>,
     #[prost(uint64, optional, tag = "5")]
     pub replication_index: Option<u64>,
+    #[prost(message, optional, tag = "6")]
+    pub stats: Option<StmtResultStats>,
 }
 
 #[derive(Serialize, prost::Message)]

--- a/libsql-server/src/http/user/result_builder.rs
+++ b/libsql-server/src/http/user/result_builder.rs
@@ -24,7 +24,6 @@ pub struct JsonHttpPayloadBuilder {
     step_row_count: usize,
     is_step_error: bool,
     is_step_empty: bool,
-    stats: QueryStats,
 }
 
 #[derive(Default)]
@@ -112,7 +111,6 @@ impl JsonHttpPayloadBuilder {
             step_row_count: 0,
             is_step_error: false,
             is_step_empty: false,
-            stats: Default::default(),
         }
     }
 }
@@ -275,7 +273,14 @@ impl QueryResultBuilder for JsonHttpPayloadBuilder {
     }
 
     fn update_stats(&mut self, stats: QueryStats) -> Result<(), QueryResultBuilderError> {
-        self.stats += stats;
+        assert!(!self.is_step_error);
+        self.formatter.serialize_key_value(
+            &mut self.buffer,
+            "stats",
+            &serde_json::to_value(&stats)
+                .map_err(|e| QueryResultBuilderError::Internal(e.into()))?,
+            false,
+        )?;
         Ok(())
     }
 

--- a/libsql-server/src/http/user/result_builder.rs
+++ b/libsql-server/src/http/user/result_builder.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::Ordering;
 
 use crate::query_result_builder::{
     Column, JsonFormatter, QueryBuilderConfig, QueryResultBuilder, QueryResultBuilderError,
-    TOTAL_RESPONSE_SIZE,
+    QueryStats, TOTAL_RESPONSE_SIZE,
 };
 use crate::replication::FrameNo;
 
@@ -24,6 +24,7 @@ pub struct JsonHttpPayloadBuilder {
     step_row_count: usize,
     is_step_error: bool,
     is_step_empty: bool,
+    stats: QueryStats,
 }
 
 #[derive(Default)]
@@ -111,6 +112,7 @@ impl JsonHttpPayloadBuilder {
             step_row_count: 0,
             is_step_error: false,
             is_step_empty: false,
+            stats: Default::default(),
         }
     }
 }
@@ -269,6 +271,11 @@ impl QueryResultBuilder for JsonHttpPayloadBuilder {
         )?;
         self.row_value_count += 1;
 
+        Ok(())
+    }
+
+    fn update_stats(&mut self, stats: QueryStats) -> Result<(), QueryResultBuilderError> {
+        self.stats += stats;
         Ok(())
     }
 

--- a/libsql-server/src/query_result_builder.rs
+++ b/libsql-server/src/query_result_builder.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::AtomicUsize;
 
 use crate::replication::FrameNo;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Serialize)]
 pub struct QueryStats {
     pub rows_read: i32,
     pub rows_written: i32,

--- a/libsql-server/src/rpc/proxy.rs
+++ b/libsql-server/src/rpc/proxy.rs
@@ -10,7 +10,7 @@ use crate::connection::Connection;
 use crate::database::{Database, PrimaryConnection};
 use crate::namespace::{NamespaceStore, PrimaryNamespaceMaker};
 use crate::query_result_builder::{
-    Column, QueryBuilderConfig, QueryResultBuilder, QueryResultBuilderError,
+    Column, QueryBuilderConfig, QueryResultBuilder, QueryResultBuilderError, QueryStats,
 };
 use crate::replication::FrameNo;
 
@@ -302,6 +302,7 @@ struct ExecuteResultBuilder {
     max_size: u64,
     current_size: u64,
     current_step_size: u64,
+    stats: QueryStats,
 }
 
 impl QueryResultBuilder for ExecuteResultBuilder {
@@ -419,6 +420,11 @@ impl QueryResultBuilder for ExecuteResultBuilder {
 
         self.current_row.values.push(value);
 
+        Ok(())
+    }
+
+    fn update_stats(&mut self, stats: QueryStats) -> Result<(), QueryResultBuilderError> {
+        self.stats = stats;
         Ok(())
     }
 


### PR DESCRIPTION
Users need to be able to check how much resources their queries cost. For that, we return stats we already gather internally:
 - rows read
 - rows written

, per statement.

Draft, because:
1. We need to agree on that protocol change first
2. After agreeing, we need to officially specify this protocol extension in docs
3. We need to decide how to make these stats opt-in, **or** just always return them and let the users decide whether to use them (there's some throughput penalty on that)