### PR TITLE
snapshot on scale to zero and shutdown

### DIFF
--- a/libsql-server/src/database.rs
+++ b/libsql-server/src/database.rs
@@ -4,13 +4,20 @@ use crate::connection::libsql::LibSqlConnection;
 use crate::connection::write_proxy::{RpcStream, WriteProxyConnection};
 use crate::connection::{Connection, MakeConnection, TrackedConnection};
 use crate::replication::{ReplicationLogger, ReplicationLoggerHook};
+use async_trait::async_trait;
 
+pub type Result<T> = anyhow::Result<T>;
+
+#[async_trait]
 pub trait Database: Sync + Send + 'static {
     /// The connection type of the database
     type Connection: Connection;
 
     fn connection_maker(&self) -> Arc<dyn MakeConnection<Connection = Self::Connection>>;
-    fn shutdown(&self);
+
+    fn destroy(self);
+
+    async fn shutdown(self) -> Result<()>;
 }
 
 pub struct ReplicaDatabase {
@@ -18,6 +25,7 @@ pub struct ReplicaDatabase {
         Arc<dyn MakeConnection<Connection = TrackedConnection<WriteProxyConnection<RpcStream>>>>,
 }
 
+#[async_trait]
 impl Database for ReplicaDatabase {
     type Connection = TrackedConnection<WriteProxyConnection<RpcStream>>;
 
@@ -25,7 +33,11 @@ impl Database for ReplicaDatabase {
         self.connection_maker.clone()
     }
 
-    fn shutdown(&self) {}
+    fn destroy(self) {}
+
+    async fn shutdown(self) -> Result<()> {
+        Ok(())
+    }
 }
 
 pub type PrimaryConnection = TrackedConnection<LibSqlConnection<ReplicationLoggerHook>>;
@@ -35,6 +47,7 @@ pub struct PrimaryDatabase {
     pub connection_maker: Arc<dyn MakeConnection<Connection = PrimaryConnection>>,
 }
 
+#[async_trait]
 impl Database for PrimaryDatabase {
     type Connection = PrimaryConnection;
 
@@ -42,7 +55,18 @@ impl Database for PrimaryDatabase {
         self.connection_maker.clone()
     }
 
-    fn shutdown(&self) {
+    fn destroy(self) {
         self.logger.closed_signal.send_replace(true);
+    }
+
+    async fn shutdown(self) -> Result<()> {
+        self.logger.closed_signal.send_replace(true);
+        if let Some(replicator) = &self.logger.bottomless_replicator {
+            let replicator = replicator.lock().unwrap().take();
+            if let Some(mut replicator) = replicator {
+                replicator.wait_until_snapshotted().await?;
+            }
+        }
+        Ok(())
     }
 }

--- a/libsql-server/src/error.rs
+++ b/libsql-server/src/error.rs
@@ -82,7 +82,6 @@ pub enum Error {
     Fork(#[from] ForkError),
     #[error("Fatal replication error")]
     FatalReplicationError,
-
     #[error("Connection with primary broken")]
     PrimaryStreamDisconnect,
     #[error("Proxy protocal misuse")]
@@ -91,6 +90,8 @@ pub enum Error {
     PrimaryStreamInterupted,
     #[error("Wrong URL: {0}")]
     UrlParseError(#[from] url::ParseError),
+    #[error("Namespace store has shutdown")]
+    NamespaceStoreShutdown,
 }
 
 trait ResponseError: std::error::Error {
@@ -148,6 +149,7 @@ impl IntoResponse for Error {
             PrimaryStreamMisuse => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             PrimaryStreamInterupted => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             UrlParseError(_) => self.format_err(StatusCode::BAD_REQUEST),
+            NamespaceStoreShutdown => self.format_err(StatusCode::SERVICE_UNAVAILABLE),
         }
     }
 }

--- a/libsql-server/src/replication/primary/logger.rs
+++ b/libsql-server/src/replication/primary/logger.rs
@@ -4,9 +4,10 @@ use std::io::Write;
 use std::mem::size_of;
 use std::os::unix::prelude::FileExt;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, MutexGuard};
 
 use anyhow::{bail, ensure};
+use bottomless::replicator::Replicator;
 use bytemuck::{bytes_of, pod_read_unaligned, Pod, Zeroable};
 use bytes::{Bytes, BytesMut};
 use libsql_replication::frame::{Frame, FrameHeader, FrameMut};
@@ -51,7 +52,7 @@ pub enum ReplicationLoggerHook {}
 pub struct ReplicationLoggerHookCtx {
     buffer: Vec<WalPage>,
     logger: Arc<ReplicationLogger>,
-    bottomless_replicator: Option<Arc<std::sync::Mutex<bottomless::replicator::Replicator>>>,
+    bottomless_replicator: Option<Arc<std::sync::Mutex<Option<Replicator>>>>,
 }
 
 /// This implementation of WalHook intercepts calls to `on_frame`, and writes them to a
@@ -83,6 +84,21 @@ unsafe impl WalHook for ReplicationLoggerHook {
         let last_valid_frame = wal.hdr.mxFrame;
         tracing::trace!("Last valid frame before applying: {last_valid_frame}");
         let ctx = Self::wal_extract_ctx(wal);
+
+        let mut binding = ctx.bottomless_replicator.clone();
+        let replicator_mutex: Option<&mut Replicator>;
+        let mut replicator_lock: MutexGuard<Option<Replicator>>;
+        if let Some(replicator) = binding.as_mut() {
+            replicator_lock = replicator.lock().unwrap();
+            if replicator_lock.is_none() {
+                tracing::error!("fatal error: expected a replicator, exiting");
+                return SQLITE_IOERR;
+            } else {
+                replicator_mutex = Option::from(replicator_lock.as_mut().unwrap());
+            }
+        } else {
+            replicator_mutex = None;
+        }
 
         let mut frame_count = 0;
         for (page_no, data) in PageHdrIter::new(page_headers, page_size as _) {
@@ -118,8 +134,7 @@ unsafe impl WalHook for ReplicationLoggerHook {
 
             // do backup after log replication as we don't want to replicate potentially
             // inconsistent frames
-            if let Some(replicator) = ctx.bottomless_replicator.as_mut() {
-                let mut replicator = replicator.lock().unwrap();
+            if let Some(replicator) = replicator_mutex {
                 replicator.register_last_valid_frame(last_valid_frame);
                 if let Err(e) = replicator.set_page_size(page_size as usize) {
                     tracing::error!("fatal error during backup: {e}, exiting");
@@ -162,12 +177,16 @@ unsafe impl WalHook for ReplicationLoggerHook {
             let ctx = Self::wal_extract_ctx(wal);
             if let Some(replicator) = ctx.bottomless_replicator.as_mut() {
                 let last_valid_frame = unsafe { *wal_data };
-                let mut replicator = replicator.lock().unwrap();
-                let prev_valid_frame = replicator.peek_last_valid_frame();
-                tracing::trace!(
+                if let Some(replicator) = replicator.lock().unwrap().as_mut() {
+                    let prev_valid_frame = replicator.peek_last_valid_frame();
+                    tracing::trace!(
                     "Savepoint: rolling back from frame {prev_valid_frame} to {last_valid_frame}",
                 );
-                replicator.rollback_to_frame(last_valid_frame);
+                    replicator.rollback_to_frame(last_valid_frame);
+                } else {
+                    tracing::error!("fatal error: expected a replicator, exiting");
+                    return SQLITE_IOERR;
+                }
             }
         }
 
@@ -215,29 +234,36 @@ unsafe impl WalHook for ReplicationLoggerHook {
             let ctx = Self::wal_extract_ctx(wal);
             let runtime = tokio::runtime::Handle::current();
             if let Some(replicator) = ctx.bottomless_replicator.as_mut() {
-                let mut replicator = replicator.lock().unwrap();
-                let last_known_frame = replicator.last_known_frame();
-                replicator.request_flush();
-                if last_known_frame == 0 {
-                    tracing::debug!("No committed changes in this generation, not snapshotting");
-                    replicator.skip_snapshot_for_current_generation();
-                    return SQLITE_OK;
-                }
-                if let Err(e) = runtime.block_on(replicator.wait_until_committed(last_known_frame))
-                {
-                    tracing::error!(
-                        "Failed to wait for S3 replicator to confirm {} frames backup: {}",
-                        last_known_frame,
-                        e
-                    );
-                    return SQLITE_IOERR_WRITE;
-                }
-                if let Err(e) = runtime.block_on(replicator.wait_until_snapshotted()) {
-                    tracing::error!(
+                if let Some(replicator) = replicator.lock().unwrap().as_mut() {
+                    let last_known_frame = replicator.last_known_frame();
+                    replicator.request_flush();
+                    if last_known_frame == 0 {
+                        tracing::debug!(
+                            "No committed changes in this generation, not snapshotting"
+                        );
+                        replicator.skip_snapshot_for_current_generation();
+                        return SQLITE_OK;
+                    }
+                    if let Err(e) =
+                        runtime.block_on(replicator.wait_until_committed(last_known_frame))
+                    {
+                        tracing::error!(
+                            "Failed to wait for S3 replicator to confirm {} frames backup: {}",
+                            last_known_frame,
+                            e
+                        );
+                        return SQLITE_IOERR_WRITE;
+                    }
+                    if let Err(e) = runtime.block_on(replicator.wait_until_snapshotted()) {
+                        tracing::error!(
                         "Failed to wait for S3 replicator to confirm database snapshot backup: {}",
                         e
                     );
-                    return SQLITE_IOERR_WRITE;
+                        return SQLITE_IOERR_WRITE;
+                    }
+                } else {
+                    tracing::error!("fatal error: expected a replicator, exiting");
+                    return SQLITE_IOERR;
                 }
             }
         }
@@ -266,13 +292,19 @@ unsafe impl WalHook for ReplicationLoggerHook {
             let ctx = Self::wal_extract_ctx(wal);
             let runtime = tokio::runtime::Handle::current();
             if let Some(replicator) = ctx.bottomless_replicator.as_mut() {
-                let mut replicator = replicator.lock().unwrap();
-                let _prev = replicator.new_generation();
-                if let Err(e) =
-                    runtime.block_on(async move { replicator.snapshot_main_db_file().await })
-                {
-                    tracing::error!("Failed to snapshot the main db file during checkpoint: {e}");
-                    return SQLITE_IOERR_WRITE;
+                if let Some(replicator) = replicator.lock().unwrap().as_mut() {
+                    let _prev = replicator.new_generation();
+                    if let Err(e) =
+                        runtime.block_on(async move { replicator.snapshot_main_db_file().await })
+                    {
+                        tracing::error!(
+                            "Failed to snapshot the main db file during checkpoint: {e}"
+                        );
+                        return SQLITE_IOERR_WRITE;
+                    }
+                } else {
+                    tracing::error!("fatal error: expected a replicator, exiting");
+                    return SQLITE_IOERR;
                 }
             }
         }
@@ -291,7 +323,7 @@ pub struct WalPage {
 impl ReplicationLoggerHookCtx {
     pub fn new(
         logger: Arc<ReplicationLogger>,
-        bottomless_replicator: Option<Arc<std::sync::Mutex<bottomless::replicator::Replicator>>>,
+        bottomless_replicator: Option<Arc<std::sync::Mutex<Option<Replicator>>>>,
     ) -> Self {
         if bottomless_replicator.is_some() {
             tracing::trace!("bottomless replication enabled");
@@ -783,6 +815,7 @@ pub struct ReplicationLogger {
     pub new_frame_notifier: watch::Sender<Option<FrameNo>>,
     pub closed_signal: watch::Sender<bool>,
     pub auto_checkpoint: u32,
+    pub bottomless_replicator: Option<Arc<std::sync::Mutex<Option<Replicator>>>>,
 }
 
 impl ReplicationLogger {
@@ -793,6 +826,7 @@ impl ReplicationLogger {
         dirty: bool,
         auto_checkpoint: u32,
         callback: SnapshotCallback,
+        bottomless_replicator: Option<Arc<std::sync::Mutex<Option<Replicator>>>>,
     ) -> anyhow::Result<Self> {
         let log_path = db_path.join("wallog");
         let data_path = db_path.join("data");
@@ -828,9 +862,21 @@ impl ReplicationLogger {
         };
 
         if should_recover {
-            Self::recover(log_file, data_path, callback, auto_checkpoint)
+            Self::recover(
+                log_file,
+                data_path,
+                callback,
+                auto_checkpoint,
+                bottomless_replicator,
+            )
         } else {
-            Self::from_log_file(db_path.to_path_buf(), log_file, callback, auto_checkpoint)
+            Self::from_log_file(
+                db_path.to_path_buf(),
+                log_file,
+                callback,
+                auto_checkpoint,
+                bottomless_replicator,
+            )
         }
     }
 
@@ -839,6 +885,7 @@ impl ReplicationLogger {
         log_file: LogFile,
         callback: SnapshotCallback,
         auto_checkpoint: u32,
+        bottomless_replicator: Option<Arc<std::sync::Mutex<Option<Replicator>>>>,
     ) -> anyhow::Result<Self> {
         let header = log_file.header();
         let generation_start_frame_no = header.last_frame_no();
@@ -872,6 +919,7 @@ impl ReplicationLogger {
             closed_signal,
             new_frame_notifier,
             auto_checkpoint,
+            bottomless_replicator,
         })
     }
 
@@ -880,6 +928,7 @@ impl ReplicationLogger {
         mut data_path: PathBuf,
         callback: SnapshotCallback,
         auto_checkpoint: u32,
+        bottomless_replicator: Option<Arc<std::sync::Mutex<Option<Replicator>>>>,
     ) -> anyhow::Result<Self> {
         // It is necessary to checkpoint before we restore the replication log, since the WAL may
         // contain pages that are not in the database file.
@@ -912,7 +961,13 @@ impl ReplicationLogger {
 
         assert!(data_path.pop());
 
-        Self::from_log_file(data_path, log_file, callback, auto_checkpoint)
+        Self::from_log_file(
+            data_path,
+            log_file,
+            callback,
+            auto_checkpoint,
+            bottomless_replicator,
+        )
     }
 
     pub fn log_id(&self) -> Uuid {
@@ -1057,6 +1112,7 @@ mod test {
             false,
             DEFAULT_AUTO_CHECKPOINT,
             Box::new(|_| Ok(())),
+            None,
         )
         .unwrap();
 
@@ -1093,6 +1149,7 @@ mod test {
             false,
             DEFAULT_AUTO_CHECKPOINT,
             Box::new(|_| Ok(())),
+            None,
         )
         .unwrap();
         let log_file = logger.log_file.write();
@@ -1110,6 +1167,7 @@ mod test {
             false,
             DEFAULT_AUTO_CHECKPOINT,
             Box::new(|_| Ok(())),
+            None,
         )
         .unwrap();
         let entry = WalPage {
@@ -1177,6 +1235,7 @@ mod test {
                 false,
                 100000,
                 Box::new(|_| Ok(())),
+                None,
             )
             .unwrap(),
         );


### PR DESCRIPTION
closes https://github.com/libsql/sqld/issues/757

- I renamed `Database.shutdown` to `Database.destroy`, which sends only the close signal. The new `Database.shutdown` now sends the close signal + waits for snapshot to complete