### PR TITLE
make libsql client a valid target for cloudflare workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .vscode/
+.idea/
 *.sqld

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -985,6 +985,28 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1369bc6b9e9a7dfdae2055f6ec151fe9c554a9d23d357c0237cee2e25eaabb7"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f5ebdc942f57ed96d560a6d1a459bae5851102a25d5bf89dc04ae453e31ecf"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -2156,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2262,6 +2284,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "worker",
 ]
 
 [[package]]
@@ -2359,6 +2382,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9376a4f0340565ad675d11fc1419227faf5f60cd7ac9cb2e7185a471f30af833"
 
 [[package]]
 name = "matchit"
@@ -2700,6 +2729,15 @@ dependencies = [
  "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "parse-zoneinfo"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -3574,6 +3612,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4693,9 +4742,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4703,9 +4752,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
@@ -4718,9 +4767,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4730,9 +4779,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote 1.0.33",
  "wasm-bindgen-macro-support",
@@ -4740,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
@@ -4753,15 +4802,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+
+[[package]]
+name = "wasm-streams"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4984,6 +5046,78 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "worker"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd7ad167392bdd707a963356f3478844019c74fc89f6af0dfc656914b30af24"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "chrono-tz",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "js-sys",
+ "matchit 0.4.6",
+ "pin-project",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tokio",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "worker-kv",
+ "worker-macros",
+ "worker-sys",
+]
+
+[[package]]
+name = "worker-kv"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4b9fe1a87b7aef252fceb4f30bf6303036a5de329c81ccad9be9c35d1fdbc7"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "worker-macros"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306c6b6fc316ce129de9cc393dc614b244afb37d43d8ae7a4dccf45d6f8a5ff5"
+dependencies = [
+ "async-trait",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.38",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-macro-support",
+ "worker-sys",
+]
+
+[[package]]
+name = "worker-sys"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5db3bd0e45980dbcefe567c978b4930e4526e864cd9e70482252a60229ddd7"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-js-sys = "0.3.64"
-libsql = { path = "../../libsql", default_features = false, features = ["core"] }
-wasm-bindgen = "0.2"
+js-sys = "0.3"
+libsql = { path = "../../libsql", default_features = false, features = ["core", "cloudflare-worker"] }
+wasm-bindgen = "0.2.86"

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -8,5 +8,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 js-sys = "0.3"
-libsql = { path = "../../libsql", default_features = false, features = ["core", "hrana-cf"] }
+libsql = { path = "../../libsql", default_features = false, features = ["core", "cloudflare"] }
 wasm-bindgen = "0.2.86"

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -8,5 +8,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 js-sys = "0.3"
-libsql = { path = "../../libsql", default_features = false, features = ["core", "cloudflare-worker"] }
+libsql = { path = "../../libsql", default_features = false, features = ["core", "hrana-cf"] }
 wasm-bindgen = "0.2.86"

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -55,7 +55,7 @@ prost-build = "0.12"
 
 
 [features]
-default = ["core", "replication", "hrana"]
+default = ["core", "replication", "remote"]
 core = [
   "libsql-sys",
   "dep:bitflags",
@@ -88,16 +88,19 @@ replication = [
 ]
 hrana = [
   "serde",
-  "http",
   "dep:base64",
   "dep:serde_json",
+]
+remote = [
+  "hrana",
+  "http",
   "dep:tower",
-  "dep:hyper-rustls"
+  "dep:hyper-rustls",
 ]
 serde = ["dep:serde"]
 http = ["dep:tower", "dep:hyper", "dep:http", "dep:tokio"]
 cloudflare = [
-  "core",
+  "libsql-sys",
   "hrana",
   "dep:worker",
 ]

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -96,7 +96,7 @@ hrana = [
 ]
 serde = ["dep:serde"]
 http = ["dep:tower", "dep:hyper", "dep:http", "dep:tokio"]
-cloudflare-worker = ["dep:worker"]
+hrana-cf = ["dep:worker"]
 
 [[bench]]
 name = "benchmark"

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -96,7 +96,11 @@ hrana = [
 ]
 serde = ["dep:serde"]
 http = ["dep:tower", "dep:hyper", "dep:http", "dep:tokio"]
-hrana-cf = ["dep:worker"]
+cloudflare = [
+  "core",
+  "hrana",
+  "dep:worker",
+]
 
 [[bench]]
 name = "benchmark"

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -36,6 +36,7 @@ tonic-web = { version = "0.10.2" , optional = true }
 tower-http = { version = "0.4.4", features = ["trace", "util"], optional = true }
 prost = { version = "0.12", optional = true }
 http = { version = "0.2", optional = true }
+worker = { version = "0.0.18", optional = true }
 
 sqlite3-parser = { path = "../vendored/sqlite3-parser", version = "0.11", optional = true }
 fallible-iterator = { version = "0.3", optional = true }
@@ -95,6 +96,7 @@ hrana = [
 ]
 serde = ["dep:serde"]
 http = ["dep:tower", "dep:hyper", "dep:http", "dep:tokio"]
+cloudflare-worker = ["dep:worker"]
 
 [[bench]]
 name = "benchmark"

--- a/libsql/examples/replica.rs
+++ b/libsql/examples/replica.rs
@@ -59,10 +59,10 @@ async fn main() {
         println!("--------");
     };
 
-    #[cfg(not(feature = "cloudflare-worker"))]
+    #[cfg(not(feature = "hrana-cf"))]
     let mut jh = tokio::spawn(fut);
 
-    #[cfg(feature = "cloudflare-worker")]
+    #[cfg(feature = "hrana-cf")]
     let mut jh = tokio::task::spawn_local(fut);
 
     loop {

--- a/libsql/examples/replica.rs
+++ b/libsql/examples/replica.rs
@@ -59,10 +59,10 @@ async fn main() {
         println!("--------");
     };
 
-    #[cfg(not(feature = "hrana-cf"))]
+    #[cfg(not(feature = "cloudflare"))]
     let mut jh = tokio::spawn(fut);
 
-    #[cfg(feature = "hrana-cf")]
+    #[cfg(feature = "cloudflare")]
     let mut jh = tokio::task::spawn_local(fut);
 
     loop {

--- a/libsql/src/connection.rs
+++ b/libsql/src/connection.rs
@@ -6,7 +6,8 @@ use crate::statement::Statement;
 use crate::transaction::Transaction;
 use crate::{Result, TransactionBehavior};
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
 pub(crate) trait Conn {
     async fn execute(&self, sql: &str, params: Params) -> Result<u64>;
 

--- a/libsql/src/connection.rs
+++ b/libsql/src/connection.rs
@@ -6,8 +6,8 @@ use crate::statement::Statement;
 use crate::transaction::Transaction;
 use crate::{Result, TransactionBehavior};
 
-#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
+#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
 pub(crate) trait Conn {
     async fn execute(&self, sql: &str, params: Params) -> Result<u64>;
 

--- a/libsql/src/connection.rs
+++ b/libsql/src/connection.rs
@@ -6,8 +6,8 @@ use crate::statement::Statement;
 use crate::transaction::Transaction;
 use crate::{Result, TransactionBehavior};
 
-#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 pub(crate) trait Conn {
     async fn execute(&self, sql: &str, params: Params) -> Result<u64>;
 

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -35,7 +35,7 @@ enum DbType {
     Remote {
         url: String,
         auth_token: String,
-        #[cfg(not(feature = "cloudflare-worker"))]
+        #[cfg(not(feature = "hrana-cf"))]
         connector: crate::util::ConnectorService,
     },
 }
@@ -165,7 +165,7 @@ cfg_replication! {
 
 cfg_hrana! {
     impl Database {
-        #[cfg(not(feature = "cloudflare-worker"))]
+        #[cfg(not(feature = "hrana-cf"))]
         pub fn open_remote(url: impl Into<String>, auth_token: impl Into<String>) -> Result<Self> {
             let mut connector = hyper::client::HttpConnector::new();
             connector.enforce_http(false);
@@ -173,7 +173,7 @@ cfg_hrana! {
             Self::open_remote_with_connector(url, auth_token, connector)
         }
 
-        #[cfg(feature = "cloudflare-worker")]
+        #[cfg(feature = "hrana-cf")]
         pub fn open_remote(url: impl Into<String>, auth_token: impl Into<String>) -> Result<Self> {
             Ok(Database {
                 db_type: DbType::Remote {
@@ -185,7 +185,7 @@ cfg_hrana! {
 
         // For now, only expose this for sqld testing purposes
         #[doc(hidden)]
-        #[cfg(not(feature = "cloudflare-worker"))]
+        #[cfg(not(feature = "hrana-cf"))]
         pub fn open_remote_with_connector<C>(
             url: impl Into<String>,
             auth_token: impl Into<String>,
@@ -261,7 +261,7 @@ impl Database {
                 Ok(Connection { conn })
             }
 
-            #[cfg(all(feature = "hrana", not(feature = "cloudflare-worker")))]
+            #[cfg(all(feature = "hrana", not(feature = "hrana-cf")))]
             DbType::Remote {
                 url,
                 auth_token,
@@ -274,7 +274,7 @@ impl Database {
                 )),
             }),
 
-            #[cfg(all(feature = "hrana", feature = "cloudflare-worker"))]
+            #[cfg(all(feature = "hrana", feature = "hrana-cf"))]
             DbType::Remote { url, auth_token } => Ok(Connection {
                 conn: std::sync::Arc::new(crate::hrana::Client::new(url, auth_token)),
             }),

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -31,7 +31,7 @@ enum DbType {
     File { path: String, flags: OpenFlags },
     #[cfg(feature = "replication")]
     Sync { db: crate::local::Database },
-    #[cfg(feature = "hrana")]
+    #[cfg(feature = "remote")]
     Remote {
         url: String,
         auth_token: String,
@@ -51,7 +51,7 @@ impl fmt::Debug for DbType {
             Self::File { .. } => write!(f, "File"),
             #[cfg(feature = "replication")]
             Self::Sync { .. } => write!(f, "Sync"),
-            #[cfg(feature = "hrana")]
+            #[cfg(feature = "remote")]
             Self::Remote { .. } => write!(f, "Remote"),
             #[cfg(all(target_family = "wasm", feature = "cloudflare"))]
             Self::Cloudflare { .. } => write!(f, "Cloudflare"),
@@ -168,7 +168,7 @@ cfg_replication! {
 
 cfg_hrana! {
     impl Database {
-        #[cfg(feature = "hrana")]
+        #[cfg(feature = "remote")]
         pub fn open_remote(url: impl Into<String>, auth_token: impl Into<String>) -> Result<Self> {
             let mut connector = hyper::client::HttpConnector::new();
             connector.enforce_http(false);
@@ -178,7 +178,7 @@ cfg_hrana! {
 
         // For now, only expose this for sqld testing purposes
         #[doc(hidden)]
-        #[cfg(feature = "hrana")]
+        #[cfg(feature = "remote")]
         pub fn open_remote_with_connector<C>(
             url: impl Into<String>,
             auth_token: impl Into<String>,
@@ -264,7 +264,7 @@ impl Database {
                 Ok(Connection { conn })
             }
 
-            #[cfg(feature = "hrana")]
+            #[cfg(feature = "remote")]
             DbType::Remote {
                 url,
                 auth_token,

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -37,7 +37,7 @@ enum DbType {
         auth_token: String,
         connector: crate::util::ConnectorService,
     },
-    #[cfg(feature = "cloudflare")]
+    #[cfg(all(target_family = "wasm", feature = "cloudflare"))]
     Cloudflare { url: String, auth_token: String },
 }
 
@@ -53,7 +53,7 @@ impl fmt::Debug for DbType {
             Self::Sync { .. } => write!(f, "Sync"),
             #[cfg(feature = "hrana")]
             Self::Remote { .. } => write!(f, "Remote"),
-            #[cfg(feature = "cloudflare")]
+            #[cfg(all(target_family = "wasm", feature = "cloudflare"))]
             Self::Cloudflare { .. } => write!(f, "Cloudflare"),
             _ => write!(f, "no database type set"),
         }
@@ -203,11 +203,8 @@ cfg_hrana! {
                 },
             })
         }
-    }
-}
 
-cfg_cloudflare! {
-    impl Database {
+        #[cfg(all(target_family = "wasm", feature = "cloudflare"))]
         pub fn open_cloudflare(url: impl Into<String>, auth_token: impl Into<String>) -> Result<Self> {
             Ok(Database {
                 db_type: DbType::Cloudflare {

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -3,7 +3,6 @@
 mod pipeline;
 mod proto;
 
-use crate::util::coerce_url_scheme;
 use pipeline::{
     ClientMsg, Response, ServerMsg, StreamBatchReq, StreamExecuteReq, StreamRequest,
     StreamResponse, StreamResponseError, StreamResponseOk,
@@ -167,7 +166,7 @@ impl Client {
 
     fn with_inner(url: String, token: String, inner: InnerClient) -> Self {
         // The `libsql://` protocol is an alias for `https://`.
-        let base_url = coerce_url_scheme(&url);
+        let base_url = crate::util::coerce_url_scheme(&url);
         let url_for_queries = format!("{base_url}/v2/pipeline");
         Self {
             inner,

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -138,12 +138,12 @@ pub enum HranaError {
     Api(String),
     #[error("http error: `{0}`")]
     Http(#[from] hyper::Error),
-    #[cfg(feature = "cloudflare")]
+    #[cfg(all(target_family = "wasm", feature = "cloudflare"))]
     #[error("http error: `{0}`")]
     Cloudflare(String),
 }
 
-#[cfg(feature = "cloudflare")]
+#[cfg(all(target_family = "wasm", feature = "cloudflare"))]
 impl From<worker::Error> for HranaError {
     fn from(value: worker::Error) -> Self {
         HranaError::Cloudflare(value.to_string())

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -327,7 +327,8 @@ impl Client {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
 impl Conn for Client {
     async fn execute(&self, sql: &str, params: Params) -> crate::Result<u64> {
         let mut stmt = self.prepare(sql).await?;
@@ -380,7 +381,8 @@ pub struct Statement {
     inner: Stmt,
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
 impl super::statement::Stmt for Statement {
     fn finalize(&mut self) {}
 

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -73,6 +73,16 @@ macro_rules! cfg_hrana {
     }
 }
 
+macro_rules! cfg_cloudflare {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "cloudflare")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "cloudflare")))]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_http {
     ($($item:item)*) => {
         $(
@@ -130,7 +140,7 @@ pub use self::{
 
 pub type Result<T> = std::result::Result<T, errors::Error>;
 
-#[cfg(not(feature = "hrana-cf"))]
+#[cfg(not(target_family = "wasm"))]
 pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync>;
-#[cfg(feature = "hrana-cf")]
+#[cfg(target_family = "wasm")]
 pub(crate) type BoxError = Box<dyn std::error::Error>;

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -98,6 +98,7 @@ cfg_replication! {
 
 cfg_core! {
     pub use libsql_sys::ffi;
+    pub use self::database::OpenFlags;
 }
 
 mod util;
@@ -122,7 +123,7 @@ cfg_hrana! {
 
 pub use self::{
     connection::Connection,
-    database::{Database, OpenFlags},
+    database::Database,
     rows::{Column, Row, Rows},
     statement::Statement,
     transaction::{Transaction, TransactionBehavior},

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -130,7 +130,7 @@ pub use self::{
 
 pub type Result<T> = std::result::Result<T, errors::Error>;
 
-#[cfg(not(feature = "cloudflare-worker"))]
+#[cfg(not(feature = "hrana-cf"))]
 pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync>;
-#[cfg(feature = "cloudflare-worker")]
+#[cfg(feature = "hrana-cf")]
 pub(crate) type BoxError = Box<dyn std::error::Error>;

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -129,4 +129,8 @@ pub use self::{
 };
 
 pub type Result<T> = std::result::Result<T, errors::Error>;
+
+#[cfg(not(feature = "cloudflare-worker"))]
 pub(crate) type BoxError = Box<dyn std::error::Error + Send + Sync>;
+#[cfg(feature = "cloudflare-worker")]
+pub(crate) type BoxError = Box<dyn std::error::Error>;

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -73,16 +73,6 @@ macro_rules! cfg_hrana {
     }
 }
 
-macro_rules! cfg_cloudflare {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "cloudflare")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "cloudflare")))]
-            $item
-        )*
-    }
-}
-
 macro_rules! cfg_http {
     ($($item:item)*) => {
         $(

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -15,8 +15,8 @@ pub(crate) struct LibsqlConnection {
     pub(crate) conn: super::Connection,
 }
 
-#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl Conn for LibsqlConnection {
     async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
         self.conn.execute(sql, params)
@@ -66,8 +66,8 @@ impl Conn for LibsqlConnection {
 
 pub(crate) struct LibsqlStmt(pub(super) crate::local::Statement);
 
-#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl Stmt for LibsqlStmt {
     fn finalize(&mut self) {
         self.0.finalize();
@@ -108,8 +108,8 @@ impl Stmt for LibsqlStmt {
 
 pub(super) struct LibsqlTx(pub(super) Option<crate::local::Transaction>);
 
-#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl Tx for LibsqlTx {
     async fn commit(&mut self) -> Result<()> {
         let tx = self.0.take().expect("Tx already dropped");

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -15,7 +15,8 @@ pub(crate) struct LibsqlConnection {
     pub(crate) conn: super::Connection,
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
 impl Conn for LibsqlConnection {
     async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
         self.conn.execute(sql, params)
@@ -65,7 +66,8 @@ impl Conn for LibsqlConnection {
 
 pub(crate) struct LibsqlStmt(pub(super) crate::local::Statement);
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
 impl Stmt for LibsqlStmt {
     fn finalize(&mut self) {
         self.0.finalize();
@@ -106,7 +108,8 @@ impl Stmt for LibsqlStmt {
 
 pub(super) struct LibsqlTx(pub(super) Option<crate::local::Transaction>);
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
 impl Tx for LibsqlTx {
     async fn commit(&mut self) -> Result<()> {
         let tx = self.0.take().expect("Tx already dropped");

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -15,8 +15,8 @@ pub(crate) struct LibsqlConnection {
     pub(crate) conn: super::Connection,
 }
 
-#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
+#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
 impl Conn for LibsqlConnection {
     async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
         self.conn.execute(sql, params)
@@ -66,8 +66,8 @@ impl Conn for LibsqlConnection {
 
 pub(crate) struct LibsqlStmt(pub(super) crate::local::Statement);
 
-#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
+#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
 impl Stmt for LibsqlStmt {
     fn finalize(&mut self) {
         self.0.finalize();
@@ -108,8 +108,8 @@ impl Stmt for LibsqlStmt {
 
 pub(super) struct LibsqlTx(pub(super) Option<crate::local::Transaction>);
 
-#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
+#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
 impl Tx for LibsqlTx {
     async fn commit(&mut self) -> Result<()> {
         let tx = self.0.take().expect("Tx already dropped");

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -231,8 +231,8 @@ impl RemoteConnection {
         }
     }
 }
-#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl Conn for RemoteConnection {
     async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
         let stmts = parser::Statement::parse(sql).collect::<Result<Vec<_>>>()?;
@@ -445,8 +445,8 @@ async fn fetch_metas(
     Ok(metas)
 }
 
-#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl Stmt for RemoteStatement {
     fn finalize(&mut self) {}
 
@@ -667,8 +667,8 @@ impl RemoteTx {
     }
 }
 
-#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 impl Tx for RemoteTx {
     async fn commit(&mut self) -> Result<()> {
         let conn = self.0.take().expect("Tx already dropped");

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -231,8 +231,8 @@ impl RemoteConnection {
         }
     }
 }
-#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
+#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
 impl Conn for RemoteConnection {
     async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
         let stmts = parser::Statement::parse(sql).collect::<Result<Vec<_>>>()?;
@@ -445,8 +445,8 @@ async fn fetch_metas(
     Ok(metas)
 }
 
-#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
+#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
 impl Stmt for RemoteStatement {
     fn finalize(&mut self) {}
 
@@ -667,8 +667,8 @@ impl RemoteTx {
     }
 }
 
-#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
+#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
 impl Tx for RemoteTx {
     async fn commit(&mut self) -> Result<()> {
         let conn = self.0.take().expect("Tx already dropped");

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -231,8 +231,8 @@ impl RemoteConnection {
         }
     }
 }
-
-#[async_trait::async_trait]
+#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
 impl Conn for RemoteConnection {
     async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
         let stmts = parser::Statement::parse(sql).collect::<Result<Vec<_>>>()?;
@@ -445,7 +445,8 @@ async fn fetch_metas(
     Ok(metas)
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
 impl Stmt for RemoteStatement {
     fn finalize(&mut self) {}
 
@@ -666,7 +667,8 @@ impl RemoteTx {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
 impl Tx for RemoteTx {
     async fn commit(&mut self) -> Result<()> {
         let conn = self.0.take().expect("Tx already dropped");

--- a/libsql/src/statement.rs
+++ b/libsql/src/statement.rs
@@ -5,7 +5,8 @@ use crate::{Error, Result};
 
 use crate::{Row, Rows};
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
 pub(crate) trait Stmt {
     fn finalize(&mut self);
 

--- a/libsql/src/statement.rs
+++ b/libsql/src/statement.rs
@@ -5,8 +5,8 @@ use crate::{Error, Result};
 
 use crate::{Row, Rows};
 
-#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
+#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
 pub(crate) trait Stmt {
     fn finalize(&mut self);
 

--- a/libsql/src/statement.rs
+++ b/libsql/src/statement.rs
@@ -5,8 +5,8 @@ use crate::{Error, Result};
 
 use crate::{Row, Rows};
 
-#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 pub(crate) trait Stmt {
     fn finalize(&mut self);
 

--- a/libsql/src/transaction.rs
+++ b/libsql/src/transaction.rs
@@ -36,8 +36,8 @@ impl Deref for Transaction {
     }
 }
 
-#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
+#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
 pub(crate) trait Tx {
     async fn commit(&mut self) -> Result<()>;
     async fn rollback(&mut self) -> Result<()>;

--- a/libsql/src/transaction.rs
+++ b/libsql/src/transaction.rs
@@ -36,7 +36,8 @@ impl Deref for Transaction {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(feature = "cloudflare-worker", async_trait::async_trait(?Send))]
+#[cfg_attr(not(feature = "cloudflare-worker"), async_trait::async_trait)]
 pub(crate) trait Tx {
     async fn commit(&mut self) -> Result<()>;
     async fn rollback(&mut self) -> Result<()>;

--- a/libsql/src/transaction.rs
+++ b/libsql/src/transaction.rs
@@ -36,8 +36,8 @@ impl Deref for Transaction {
     }
 }
 
-#[cfg_attr(feature = "hrana-cf", async_trait::async_trait(?Send))]
-#[cfg_attr(not(feature = "hrana-cf"), async_trait::async_trait)]
+#[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
 pub(crate) trait Tx {
     async fn commit(&mut self) -> Result<()>;
     async fn rollback(&mut self) -> Result<()>;


### PR DESCRIPTION
This PR introduces new feature: `cloudflare-worker`, which enables Hrana protocol to be served over Cloudflare workers.