### PR TITLE
libsql-server: track slowest queries too

### DIFF
--- a/libsql-server/src/http/admin/stats.rs
+++ b/libsql-server/src/http/admin/stats.rs
@@ -7,7 +7,7 @@ use axum::Json;
 
 use crate::namespace::{MakeNamespace, NamespaceName};
 use crate::replication::FrameNo;
-use crate::stats::{Stats, TopQuery};
+use crate::stats::{SlowestQuery, Stats, TopQuery};
 
 use super::AppState;
 
@@ -19,6 +19,7 @@ pub struct StatsResponse {
     pub write_requests_delegated: u64,
     pub replication_index: FrameNo,
     pub top_queries: Vec<TopQuery>,
+    pub slowest_queries: Vec<SlowestQuery>,
 }
 
 impl From<&Stats> for StatsResponse {
@@ -31,6 +32,13 @@ impl From<&Stats> for StatsResponse {
             replication_index: stats.get_current_frame_no(),
             top_queries: stats
                 .top_queries()
+                .read()
+                .unwrap()
+                .iter()
+                .cloned()
+                .collect(),
+            slowest_queries: stats
+                .slowest_queries()
                 .read()
                 .unwrap()
                 .iter()

--- a/libsql-server/src/rpc/proxy.rs
+++ b/libsql-server/src/rpc/proxy.rs
@@ -455,7 +455,9 @@ pub async fn garbage_collect(clients: &mut HashMap<Uuid, Arc<PrimaryConnection>>
     let limit = std::time::Duration::from_secs(30);
 
     clients.retain(|_, db| db.idle_time() < limit);
-    tracing::trace!("gc: remaining client handles count: {}", clients.len());
+    if !clients.is_empty() {
+        tracing::trace!("gc: remaining client handles count: {}", clients.len());
+    }
 }
 
 #[tonic::async_trait]

--- a/libsql-server/src/stats.rs
+++ b/libsql-server/src/stats.rs
@@ -153,9 +153,9 @@ impl Stats {
         top_queries.insert(query);
         if top_queries.len() > 10 {
             top_queries.pop_first();
+            self.top_query_threshold
+                .store(top_queries.first().unwrap().weight, Ordering::Relaxed);
         }
-        self.top_query_threshold
-            .store(top_queries.first().unwrap().weight, Ordering::Relaxed);
     }
 
     pub(crate) fn qualifies_as_top_query(&self, weight: i64) -> bool {
@@ -172,11 +172,11 @@ impl Stats {
         slowest_queries.insert(query);
         if slowest_queries.len() > 10 {
             slowest_queries.pop_first();
+            self.slowest_query_threshold.store(
+                slowest_queries.first().unwrap().elapsed_ms,
+                Ordering::Relaxed,
+            );
         }
-        self.slowest_query_threshold.store(
-            slowest_queries.first().unwrap().elapsed_ms,
-            Ordering::Relaxed,
-        );
     }
 
     pub(crate) fn qualifies_as_slowest_query(&self, elapsed_ms: u64) -> bool {

--- a/libsql-server/src/stats.rs
+++ b/libsql-server/src/stats.rs
@@ -30,6 +30,25 @@ impl TopQuery {
     }
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SlowestQuery {
+    pub elapsed_ms: u64,
+    pub query: String,
+    pub rows_written: i32,
+    pub rows_read: i32,
+}
+
+impl SlowestQuery {
+    pub fn new(query: String, elapsed_ms: u64, rows_read: i32, rows_written: i32) -> Self {
+        Self {
+            elapsed_ms,
+            query,
+            rows_read,
+            rows_written,
+        }
+    }
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Stats {
     #[serde(default)]
@@ -48,6 +67,11 @@ pub struct Stats {
     top_query_threshold: AtomicI64,
     #[serde(default)]
     top_queries: Arc<RwLock<BTreeSet<TopQuery>>>,
+    // Lowest value in currently stored slowest queries
+    #[serde(default)]
+    slowest_query_threshold: AtomicU64,
+    #[serde(default)]
+    slowest_queries: Arc<RwLock<BTreeSet<SlowestQuery>>>,
 }
 
 impl Stats {
@@ -140,6 +164,27 @@ impl Stats {
 
     pub(crate) fn top_queries(&self) -> &Arc<RwLock<BTreeSet<TopQuery>>> {
         &self.top_queries
+    }
+
+    pub(crate) fn add_slowest_query(&self, query: SlowestQuery) {
+        let mut slowest_queries = self.slowest_queries.write().unwrap();
+        tracing::debug!("slowest query: {}: {}", query.elapsed_ms, query.query);
+        slowest_queries.insert(query);
+        if slowest_queries.len() > 10 {
+            slowest_queries.pop_first();
+        }
+        self.slowest_query_threshold.store(
+            slowest_queries.first().unwrap().elapsed_ms,
+            Ordering::Relaxed,
+        );
+    }
+
+    pub(crate) fn qualifies_as_slowest_query(&self, elapsed_ms: u64) -> bool {
+        elapsed_ms >= self.slowest_query_threshold.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn slowest_queries(&self) -> &Arc<RwLock<BTreeSet<SlowestQuery>>> {
+        &self.slowest_queries
     }
 }
 


### PR DESCRIPTION
This PoC adds another stats entry - slowest queries, since they do not necessarily match the *most expensive* queries we count right now.

Ideas to entertain:
 - tracking aggregated query time
 - tracking the number of times the query was received (to ignore oneshot hyperlong queries as less interesting than lots of fairly-long queries)

Example:
```
$ curl -s http://localhost:8081/v1/namespaces/default/stats | jq '.slowest_queries' | jtbl
  elapsed_ms  query
------------  ------------------------------
          44  SELECT count (*) FROM t;
          63  SELECT count (*) FROM t;
        3483  INSERT INTO t SELECT * FROM t;
```