### PR TITLE
Run apt update on sqld runtime image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN cargo build -p sqld --release
 
 # runtime
 FROM debian:bullseye-slim
+RUN apt update
 
 EXPOSE 5001 8080
 VOLUME [ "/var/lib/sqld" ]


### PR DESCRIPTION
This is a best effort attempt to run sqld with the same libraries that
it was built with. If anyone bases their images on this one and runs
apt update, and then install dependencies (e.g. because they need it
for extensions), then they risk running sqld with different dependencies
then it was built with.

Publishing the image with apt index updated allows images that depend
on this one to install further dependencies with the same version sqld
was built with. Of course apt update from the chef layer may get out
of sync with the runtime one, but this is a problem that we can solve,
since we control the life cycle of the image.