### PR TITLE
admin: allow resetting top and slowest queries

### DIFF
--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -84,6 +84,10 @@ where
         )
         .route("/v1/namespaces/:namespace", delete(handle_delete_namespace))
         .route("/v1/namespaces/:namespace/stats", get(stats::handle_stats))
+        .route(
+            "/v1/namespaces/:namespace/stats/:stats_type",
+            delete(stats::handle_delete_stats),
+        )
         .route("/v1/diagnostics", get(handle_diagnostics))
         .route("/metrics", get(handle_metrics))
         .with_state(Arc::new(AppState {

--- a/libsql-server/src/http/admin/stats.rs
+++ b/libsql-server/src/http/admin/stats.rs
@@ -66,3 +66,20 @@ pub(super) async fn handle_stats<M: MakeNamespace, C>(
 
     Ok(Json(resp))
 }
+
+pub(super) async fn handle_delete_stats<M: MakeNamespace, C>(
+    State(app_state): State<Arc<AppState<M, C>>>,
+    Path((namespace, stats_type)): Path<(String, String)>,
+) -> crate::Result<()> {
+    let stats = app_state
+        .namespaces
+        .stats(NamespaceName::from_string(namespace)?)
+        .await?;
+    match stats_type.as_str() {
+        "top" => stats.reset_top_queries(),
+        "slowest" => stats.reset_slowest_queries(),
+        _ => return Err(crate::error::Error::Internal("Invalid stats type".into())),
+    }
+
+    Ok(())
+}

--- a/libsql-server/src/stats.rs
+++ b/libsql-server/src/stats.rs
@@ -166,6 +166,11 @@ impl Stats {
         &self.top_queries
     }
 
+    pub(crate) fn reset_top_queries(&self) {
+        self.top_queries.write().unwrap().clear();
+        self.top_query_threshold.store(0, Ordering::Relaxed);
+    }
+
     pub(crate) fn add_slowest_query(&self, query: SlowestQuery) {
         let mut slowest_queries = self.slowest_queries.write().unwrap();
         tracing::debug!("slowest query: {}: {}", query.elapsed_ms, query.query);
@@ -185,6 +190,11 @@ impl Stats {
 
     pub(crate) fn slowest_queries(&self) -> &Arc<RwLock<BTreeSet<SlowestQuery>>> {
         &self.slowest_queries
+    }
+
+    pub(crate) fn reset_slowest_queries(&self) {
+        self.slowest_queries.write().unwrap().clear();
+        self.slowest_query_threshold.store(0, Ordering::Relaxed);
     }
 }
 


### PR DESCRIPTION
Without being able to reset the queries manually, they can be forever clogged by some outliers that happened a long time ago. Long term, Prometheus should gather all kinds of these stats, but until it does, let's have a way of resetting them.