### PR TITLE
prefix metrics with libsql_server_

### DIFF
--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -679,9 +679,9 @@ impl<W: WalHook> Connection<W> {
         } else {
             rows_read
         };
-        self.stats.inc_rows_read(rows_read as u64);
-        self.stats.inc_rows_written(rows_written as u64);
-        let weight = (rows_read + rows_written) as u64;
+        self.stats.inc_rows_read(rows_read);
+        self.stats.inc_rows_written(rows_written);
+        let weight = rows_read + rows_written;
         if self.stats.qualifies_as_top_query(weight) {
             self.stats.add_top_query(crate::stats::TopQuery::new(
                 sql.clone(),

--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -271,7 +271,10 @@ impl<T: WalHook> TxnSlot<T> {
         // we have a lock on the connection, we don't need mode than a
         // Relaxed store.
         conn.rollback();
-        histogram!("write_txn_duration", self.created_at.elapsed())
+        histogram!(
+            "libsql_server_write_txn_duration",
+            self.created_at.elapsed()
+        )
         // WRITE_TXN_DURATION.record(self.created_at.elapsed());
     }
 }
@@ -606,7 +609,7 @@ impl<W: WalHook> Connection<W> {
             }
             builder.finish_row()?;
         }
-        histogram!("returned_bytes", values_total_bytes as f64);
+        histogram!("libsql_server_returned_bytes", values_total_bytes as f64);
 
         builder.finish_rows()?;
 
@@ -642,7 +645,7 @@ impl<W: WalHook> Connection<W> {
         self.conn
             .query_row("PRAGMA wal_checkpoint(TRUNCATE)", (), |_| Ok(()))?;
         WAL_CHECKPOINT_COUNT.increment(1);
-        histogram!("wal_checkpoint_time", start.elapsed());
+        histogram!("libsql_server_wal_checkpoint_time", start.elapsed());
         Ok(())
     }
 
@@ -665,12 +668,12 @@ impl<W: WalHook> Connection<W> {
     }
 
     fn update_stats(&self, sql: String, stmt: &rusqlite::Statement, elapsed: Duration) {
-        histogram!("statement_execution_time", elapsed);
+        histogram!("libsql_server_statement_execution_time", elapsed);
         let elapsed = elapsed.as_millis() as u64;
         let rows_read = stmt.get_status(StatementStatus::RowsRead) as u64;
         let rows_written = stmt.get_status(StatementStatus::RowsWritten) as u64;
         let mem_used = stmt.get_status(StatementStatus::MemUsed) as u64;
-        histogram!("statement_mem_used_bytes", mem_used as f64);
+        histogram!("libsql_server_statement_mem_used_bytes", mem_used as f64);
         let rows_read = if rows_read == 0 && rows_written == 0 {
             1
         } else {

--- a/libsql-server/src/connection/mod.rs
+++ b/libsql-server/src/connection/mod.rs
@@ -285,7 +285,10 @@ impl<F: MakeConnection> MakeConnection for MakeThrottledConnection<F> {
 
         CONCCURENT_CONNECTIONS_COUNT.increment(1.0);
         // CONNECTION_CREATE_TIME.record(before_create.elapsed());
-        histogram!("connection_create_time", before_create.elapsed());
+        histogram!(
+            "libsql_server_connection_create_time",
+            before_create.elapsed()
+        );
 
         Ok(TrackedConnection {
             permit,
@@ -308,7 +311,10 @@ pub struct TrackedConnection<DB> {
 impl<T> Drop for TrackedConnection<T> {
     fn drop(&mut self) {
         CONCCURENT_CONNECTIONS_COUNT.decrement(1.0);
-        histogram!("connection_create_time", self.created_at.elapsed());
+        histogram!(
+            "libsql_server_connection_create_time",
+            self.created_at.elapsed()
+        );
         // CONNECTION_ALIVE_DURATION.record();
     }
 }

--- a/libsql-server/src/metrics.rs
+++ b/libsql-server/src/metrics.rs
@@ -6,73 +6,73 @@ use metrics::{
 use once_cell::sync::Lazy;
 
 pub static WRITE_QUERY_COUNT: Lazy<Counter> = Lazy::new(|| {
-    const NAME: &str = "writes_count";
+    const NAME: &str = "libsql_server_writes_count";
     describe_counter!(NAME, "number of write statements");
     register_counter!(NAME)
 });
 pub static READ_QUERY_COUNT: Lazy<Counter> = Lazy::new(|| {
-    const NAME: &str = "read_count";
+    const NAME: &str = "libsql_server_reads_count";
     describe_counter!(NAME, "number of read statements");
     register_counter!(NAME)
 });
 pub static REQUESTS_PROXIED: Lazy<Counter> = Lazy::new(|| {
-    const NAME: &str = "requests_proxied";
+    const NAME: &str = "libsql_server_requests_proxied";
     describe_counter!(NAME, "number of proxied requests");
     register_counter!(NAME)
 });
 pub static CONCCURENT_CONNECTIONS_COUNT: Lazy<Gauge> = Lazy::new(|| {
-    const NAME: &str = "conccurent_connections";
+    const NAME: &str = "libsql_server_concurrent_connections";
     describe_gauge!(NAME, "number of conccurent connections");
     register_gauge!(NAME)
 });
 pub static NAMESPACE_LOAD_LATENCY: Lazy<Histogram> = Lazy::new(|| {
-    const NAME: &str = "namespace_load_latency";
+    const NAME: &str = "libsql_server_namespace_load_latency";
     describe_histogram!(NAME, "latency is us when loading a namespace");
     register_histogram!(NAME)
 });
 pub static CONNECTION_CREATE_TIME: Lazy<Histogram> = Lazy::new(|| {
-    const NAME: &str = "connection_create_time";
+    const NAME: &str = "libsql_server_connection_create_time";
     describe_histogram!(NAME, "time to create a connection");
     register_histogram!(NAME)
 });
 pub static CONNECTION_ALIVE_DURATION: Lazy<Histogram> = Lazy::new(|| {
-    const NAME: &str = "connection_alive_duration";
+    const NAME: &str = "libsql_server_connection_alive_duration";
     describe_histogram!(NAME, "duration for which a connection was kept alive");
     register_histogram!(NAME)
 });
 pub static WRITE_TXN_DURATION: Lazy<Histogram> = Lazy::new(|| {
-    const NAME: &str = "write_txn_duration";
+    const NAME: &str = "libsql_server_write_txn_duration";
     describe_histogram!(NAME, "duration for which a write transaction was kept open");
     register_histogram!(NAME)
 });
 
 pub static STATEMENT_EXECUTION_TIME: Lazy<Histogram> = Lazy::new(|| {
-    const NAME: &str = "statement_execution_time";
+    const NAME: &str = "libsql_server_statement_execution_time";
     describe_histogram!(NAME, "time to execute a statement");
     register_histogram!(NAME)
 });
 pub static VACUUM_COUNT: Lazy<Counter> = Lazy::new(|| {
-    const NAME: &str = "vacuum_count";
+    const NAME: &str = "libsql_server_vacuum_count";
     describe_counter!(NAME, "number of vacuum operations");
     register_counter!(NAME)
 });
 pub static WAL_CHECKPOINT_TIME: Lazy<Histogram> = Lazy::new(|| {
-    const NAME: &str = "wal_checkpoint_time";
+    const NAME: &str = "libsql_server_wal_checkpoint_time";
     describe_histogram!(NAME, "time to checkpoint the WAL");
     register_histogram!(NAME)
 });
 pub static WAL_CHECKPOINT_COUNT: Lazy<Counter> = Lazy::new(|| {
-    const NAME: &str = "wal_checkpoint_count";
+    const NAME: &str = "libsql_server_wal_checkpoint_count";
     describe_counter!(NAME, "number of WAL checkpoints");
     register_counter!(NAME)
 });
 pub static STATEMENT_MEM_USED_BYTES: Lazy<Histogram> = Lazy::new(|| {
-    const NAME: &str = "statement_mem_used_bytes";
+    const NAME: &str = "libsql_server_statement_mem_used_bytes";
     describe_histogram!(NAME, "memory used by a prepared statement");
     register_histogram!(NAME)
 });
 pub static RETURNED_BYTES: Lazy<Histogram> = Lazy::new(|| {
-    const NAME: &str = "returned_bytes";
+    const NAME: &str = "libsql_server_returned_bytes";
     describe_histogram!(NAME, "number of bytes of values returned to the client");
     register_histogram!(NAME)
 });

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -456,7 +456,10 @@ impl<M: MakeNamespace> NamespaceStore<M> {
             lock.insert(namespace, ns);
 
             // NAMESPACE_LOAD_LATENCY.record(before_load.elapsed());
-            histogram!("namespace_load_latency", before_load.elapsed());
+            histogram!(
+                "libsql_server_namespace_load_latency",
+                before_load.elapsed()
+            );
 
             Ok(ret)
         }

--- a/libsql-server/src/stats.rs
+++ b/libsql-server/src/stats.rs
@@ -106,18 +106,18 @@ impl Stats {
 
     /// increments the number of written rows by n
     pub fn inc_rows_written(&self, n: u64) {
-        counter!("rows_written", n, "namespace" => self.namespace.to_string());
+        counter!("libsql_server_rows_written", n, "namespace" => self.namespace.to_string());
         self.rows_written.fetch_add(n, Ordering::Relaxed);
     }
 
     /// increments the number of read rows by n
     pub fn inc_rows_read(&self, n: u64) {
-        counter!("rows_read", n, "namespace" => self.namespace.to_string());
+        counter!("libsql_server_rows_read", n, "namespace" => self.namespace.to_string());
         self.rows_read.fetch_add(n, Ordering::Relaxed);
     }
 
     pub fn set_storage_bytes_used(&self, n: u64) {
-        gauge!("storage", n as f64, "namespace" => self.namespace.to_string());
+        gauge!("libsql_server_storage", n as f64, "namespace" => self.namespace.to_string());
         self.storage_bytes_used.store(n, Ordering::Relaxed);
     }
 
@@ -138,7 +138,7 @@ impl Stats {
 
     /// increments the number of the write requests which were delegated from a replica to primary
     pub fn inc_write_requests_delegated(&self) {
-        increment_counter!("write_requests_delegated", "namespace" => self.namespace.to_string());
+        increment_counter!("libsql_server_write_requests_delegated", "namespace" => self.namespace.to_string());
         self.write_requests_delegated
             .fetch_add(1, Ordering::Relaxed);
     }
@@ -148,7 +148,7 @@ impl Stats {
     }
 
     pub fn set_current_frame_no(&self, fno: FrameNo) {
-        gauge!("current_frame_no", fno as f64, "namespace" => self.namespace.to_string());
+        gauge!("libsql_server_current_frame_no", fno as f64, "namespace" => self.namespace.to_string());
         self.current_frame_no.store(fno, Ordering::Relaxed);
     }
 
@@ -219,11 +219,11 @@ impl Stats {
         mem_used: u64,
         elapsed: u64,
     ) {
-        increment_counter!("query_count", "namespace" => self.namespace.to_string(), "query" => sql.clone());
-        counter!("query_latency", elapsed, "namespace" => self.namespace.to_string(), "query" => sql.clone());
-        counter!("query_rows_read", rows_read, "namespace" => self.namespace.to_string(), "query" => sql.clone());
-        counter!("query_rows_written", rows_written, "namespace" => self.namespace.to_string(), "query" => sql.clone());
-        counter!("query_mem_used", mem_used, "namespace" => self.namespace.to_string(), "query" => sql.clone());
+        increment_counter!("libsql_server_query_count", "namespace" => self.namespace.to_string(), "query" => sql.clone());
+        counter!("libsql_server_query_latency", elapsed, "namespace" => self.namespace.to_string(), "query" => sql.clone());
+        counter!("libsql_server_query_rows_read", rows_read, "namespace" => self.namespace.to_string(), "query" => sql.clone());
+        counter!("libsql_server_query_rows_written", rows_written, "namespace" => self.namespace.to_string(), "query" => sql.clone());
+        counter!("libsql_server_query_mem_used", mem_used, "namespace" => self.namespace.to_string(), "query" => sql.clone());
     }
 }
 


### PR DESCRIPTION
Otherwise they aren't distinguishable from other Prometheus sources.