### PR TITLE
make http api v0 docs consistent with code in libsql-server/src/http/user/mod.rs:339 (impl UserApi<M, A, O, S>, configure)

### DIFF
--- a/libsql-server/docs/http_api.md
+++ b/libsql-server/docs/http_api.md
@@ -46,7 +46,7 @@ Where `T` is the type of the payload in case of success.
 #### Queries
 
 ```
-POST /queries
+POST /
 ```
 
 This endpoint supports sending batches of queries to the database. All of the statements in the batch are executed as part of a transaction. If any statement in the batch fails, an error is returned and the transaction is aborted, resulting in no change to the database.
@@ -70,7 +70,7 @@ Queries are either simple strings or `ParamQuery` that accept parameter bindings
 
 ##### Response Format
 
-On success, a request to `POST /query` returns a response with an HTTP 200 code and a JSON body with the following structure:
+On success, a request to `POST /` returns a response with an HTTP 200 code and a JSON body with the following structure:
 ```
 type BatchResponse = {
     results: Array<QueryResult>,


### PR DESCRIPTION
This pull resolves disparity between http api v0 libsql-server docs and libsql-server/src/http/user/mod.rs:339

The following is the relevant snippet from libsql-server/src/http/user/mod.rs
```rs

            let app = Router::new()
                .route("/", post(handle_query))
                .route("/", get(handle_upgrade))
                .route("/version", get(handle_version))
                .route("/console", get(show_console))
                .route("/health", get(handle_health))
                .route("/dump", get(dump::handle_dump))
```

However  libsql-server/docs/http_api.md mentions `POST /queries` and `POST /query`.