### PR TITLE
scripts: add a dockerized prometheus helper

### DIFF
--- a/libsql-server/scripts/prometheus_docker.yml
+++ b/libsql-server/scripts/prometheus_docker.yml
@@ -1,0 +1,14 @@
+# my global config
+global:
+  scrape_interval: 5s 
+  evaluation_interval: 5s
+  scrape_timeout: 4s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["127.0.0.1:9090"]
+  - job_name: "sqld"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["host.docker.internal:8081"]

--- a/libsql-server/scripts/run_prometheus_docker.sh
+++ b/libsql-server/scripts/run_prometheus_docker.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+docker run --net=host --rm --name libsql-server-prometheus -v $(dirname $0)/prometheus_docker.yml:/etc/prometheus/prometheus.yml prom/prometheus


### PR DESCRIPTION
It makes metrics development easier, with the prometheus image already seeded with configuration that scrapes events from localhost:8081.

Runs properly with `cargo run -- --admin-listen-addr 0.0.0.0:8081`.

My grand plan is to also create a dev grafana dashboard based on Prometheus data, but one step at a time :innocent: 