### PR TITLE
add missing flags to libsql-sys configure

### DIFF
--- a/libsql-sys/build.rs
+++ b/libsql-sys/build.rs
@@ -9,6 +9,7 @@ const LIB_NAME: &str = "libsql";
 fn run_make() {
     Command::new("./configure")
         .current_dir(SQLITE_DIR)
+        .env("CFLAGS", "-DSQLITE_ENABLE_COLUMN_METADATA=1")
         .output()
         .unwrap();
     Command::new("make")


### PR DESCRIPTION
Without this flag, we cannot run `cargo test` from a fresh build.
