### PR TITLE
retrocompatible proxy proto

### DIFF
--- a/libsql-replication/proto/replication_log.proto
+++ b/libsql-replication/proto/replication_log.proto
@@ -5,9 +5,15 @@ message LogOffset {
     uint64 next_offset = 1;
 }
 
-message HelloRequest {}
+message HelloRequest {
+    optional uint64 handshake_version = 1;
+}
 
 message HelloResponse {
+    /// Uuid of the current generation
+    string generation_id = 1;
+    /// First frame_no in the current generation
+    uint64 generation_start_index = 2;
     /// id of the replicated log
     string log_id = 3;
     /// string-encoded Uuid v4 token for the current session, changes on each restart, and must be passed in subsequent requests header.string

--- a/libsql-replication/src/generated/wal_log.rs
+++ b/libsql-replication/src/generated/wal_log.rs
@@ -6,10 +6,19 @@ pub struct LogOffset {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct HelloRequest {}
+pub struct HelloRequest {
+    #[prost(uint64, optional, tag = "1")]
+    pub handshake_version: ::core::option::Option<u64>,
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HelloResponse {
+    /// / Uuid of the current generation
+    #[prost(string, tag = "1")]
+    pub generation_id: ::prost::alloc::string::String,
+    /// / First frame_no in the current generation
+    #[prost(uint64, tag = "2")]
+    pub generation_start_index: u64,
     /// / id of the replicated log
     #[prost(string, tag = "3")]
     pub log_id: ::prost::alloc::string::String,

--- a/libsql-replication/src/rpc.rs
+++ b/libsql-replication/src/rpc.rs
@@ -24,4 +24,12 @@ pub mod replication {
 
         Ok(())
     }
+
+    impl HelloRequest {
+        pub fn new() -> Self {
+            Self {
+                handshake_version: Some(1),
+            }
+        }
+    }
 }

--- a/libsql-server/src/replication/replicator_client.rs
+++ b/libsql-server/src/replication/replicator_client.rs
@@ -85,7 +85,7 @@ impl ReplicatorClient for Client {
 
     async fn handshake(&mut self) -> Result<(), Error> {
         tracing::info!("Attempting to perform handshake with primary.");
-        let req = self.make_request(HelloRequest::default());
+        let req = self.make_request(HelloRequest::new());
         match self.client.hello(req).await {
             Ok(resp) => {
                 let hello = resp.into_inner();

--- a/libsql/src/replication/remote_client.rs
+++ b/libsql/src/replication/remote_client.rs
@@ -55,7 +55,7 @@ impl ReplicatorClient for RemoteClient {
     /// Perform handshake with remote
     async fn handshake(&mut self) -> Result<(), Error> {
         tracing::info!("Attempting to perform handshake with primary.");
-        let req = self.make_request(HelloRequest::default());
+        let req = self.make_request(HelloRequest::new());
         match self.remote.replication.hello(req).await {
             Ok(resp) => {
                 let hello = resp.into_inner();


### PR DESCRIPTION
make sqld compatible with old clients. Older clients should migrate ASAP to the new version. The old proto is not meant to support embedded replicas.
