### PR TITLE
libsql: fix deferred txn with embedded replicas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .vscode/
 *.sqld
+*.db

--- a/libsql-server/src/rpc/proxy.rs
+++ b/libsql-server/src/rpc/proxy.rs
@@ -510,12 +510,16 @@ impl Proxy for ProxyService {
 
         tracing::debug!("executing request for {client_id}");
 
+        tracing::trace!(?pgm, "executing program");
+
         let builder = ExecuteResultBuilder::default();
         let (results, state) = db
             .execute_program(pgm, auth, builder, None)
             .await
             // TODO: this is no necessarily a permission denied error!
             .map_err(|e| tonic::Status::new(tonic::Code::PermissionDenied, e.to_string()))?;
+
+        tracing::trace!(end_state=?state, "done executing program");
 
         let current_frame_no = *new_frame_notifier.borrow();
         Ok(tonic::Response::new(ExecuteResults {

--- a/libsql-server/tests/common/net.rs
+++ b/libsql-server/tests/common/net.rs
@@ -10,7 +10,6 @@ use hyper::server::accept::Accept as HyperAccept;
 use hyper::Uri;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower::Service;
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use sqld::net::Accept;
 use sqld::net::AddrStream;
@@ -140,6 +139,8 @@ pub trait SimServer {
 #[async_trait::async_trait]
 impl SimServer for TestServer {
     async fn start_sim(mut self, user_api_port: usize) -> anyhow::Result<()> {
+        init_tracing();
+
         // We need to ensure that libsql's init code runs before we do anything
         // with rusqlite in sqld. This is because libsql has saftey checks and
         // needs to configure the sqlite api. Thus if we init sqld first
@@ -163,10 +164,5 @@ impl SimServer for TestServer {
 
 pub fn init_tracing() {
     static INIT_TRACING: Once = Once::new();
-    INIT_TRACING.call_once(|| {
-        tracing_subscriber::registry()
-            .with(fmt::layer())
-            .with(EnvFilter::from_default_env())
-            .init();
-    });
+    INIT_TRACING.call_once(|| tracing_subscriber::fmt::init());
 }

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -59,12 +59,14 @@ impl State {
             | (State::TxnDeferred, StmtKind::TxnEnd) => State::Init,
 
             // Savepoint only makes sense within a transaction and doesn't change the transaction kind
+            (State::TxnDeferred, StmtKind::Savepoint) => State::TxnDeferred,
             (State::TxnReadOnly, StmtKind::Savepoint) => State::TxnReadOnly,
             (State::Txn, StmtKind::Savepoint) => State::Txn,
             (_, StmtKind::Savepoint) => State::Invalid,
 
             // Releasing a savepoint only makes sense inside a transaction and it doesn't change its state
             (State::TxnReadOnly, StmtKind::Release) => State::TxnReadOnly,
+            (State::TxnDeferred, StmtKind::Release) => State::TxnDeferred,
             (State::Txn, StmtKind::Release) => State::Txn,
             (_, StmtKind::Release) => State::Invalid,
 

--- a/libsql/src/replication/parser.rs
+++ b/libsql/src/replication/parser.rs
@@ -22,6 +22,7 @@ pub enum StmtKind {
     /// The begining of a transaction
     TxnBegin,
     TxnBeginReadOnly,
+    TxnBeginDeferred,
     /// The end of a transaction
     TxnEnd,
     Read,
@@ -52,6 +53,9 @@ impl StmtKind {
             Cmd::ExplainQueryPlan(_) => Some(Self::Other),
             Cmd::Stmt(Stmt::Begin(Some(TransactionType::ReadOnly), _)) => {
                 Some(Self::TxnBeginReadOnly)
+            }
+            Cmd::Stmt(Stmt::Begin(Some(TransactionType::Deferred), _)) => {
+                Some(Self::TxnBeginDeferred)
             }
             Cmd::Stmt(Stmt::Begin { .. }) => Some(Self::TxnBegin),
             Cmd::Stmt(


### PR DESCRIPTION
This fixes an issue where embedded replica based connections would have issues dispatching executes on deferred statements. This is due to sqld using `sqlite3_txn_state` to return the connection's state. While this works for other transactions, in a deferred transaction the connection does not change its state to be in a transaction. This is due to the nature of a deferred transaction. The problem is that the connection does set `is_autocommit` to `false`. This means that sqld is returning that it is not in a txn state which is used by clients to set its `is_autocommit` state. For now the work around is to track when the client is in a `DEFERRED` transaction and to handle remote state transition's in such a way that it ignores the value from the server if it is currently in the deferred state.