### PR TITLE
Allow custom heartbeat url for namespace

### DIFF
--- a/libsql-server/src/config.rs
+++ b/libsql-server/src/config.rs
@@ -192,7 +192,7 @@ impl DbConfig {
 }
 
 pub struct HeartbeatConfig {
-    pub heartbeat_url: String,
+    pub heartbeat_url: Option<String>,
     pub heartbeat_period: Duration,
     pub heartbeat_auth: Option<String>,
 }

--- a/libsql-server/src/connection/config.rs
+++ b/libsql-server/src/connection/config.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fs, io};
+use url::Url;
 
 use crate::error::Error;
 use crate::{Result, LIBSQL_PAGE_SIZE};
@@ -26,6 +27,8 @@ pub struct DatabaseConfig {
     /// maximum db size (in pages)
     #[serde(default = "default_max_size")]
     pub max_db_pages: u64,
+    #[serde(default)]
+    pub heartbeat_url: Option<Url>,
 }
 
 const fn default_max_size() -> u64 {
@@ -39,6 +42,7 @@ impl Default for DatabaseConfig {
             block_writes: Default::default(),
             block_reason: Default::default(),
             max_db_pages: default_max_size(),
+            heartbeat_url: None,
         }
     }
 }

--- a/libsql-server/src/error.rs
+++ b/libsql-server/src/error.rs
@@ -89,6 +89,8 @@ pub enum Error {
     PrimaryStreamMisuse,
     #[error("Proxy request interupted")]
     PrimaryStreamInterupted,
+    #[error("Wrong URL: {0}")]
+    UrlParseError(#[from] url::ParseError),
 }
 
 trait ResponseError: std::error::Error {
@@ -145,6 +147,7 @@ impl IntoResponse for Error {
             PrimaryStreamDisconnect => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             PrimaryStreamMisuse => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             PrimaryStreamInterupted => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
+            UrlParseError(_) => self.format_err(StatusCode::BAD_REQUEST),
         }
     }
 }

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -152,6 +152,7 @@ async fn handle_get_config<M: MakeNamespace, C: Connector>(
         block_writes: config.block_writes,
         block_reason: config.block_reason.clone(),
         max_db_size: Some(max_db_size),
+        heartbeat_url: config.heartbeat_url.clone().map(|u| u.into()),
     };
 
     Ok(Json(resp))
@@ -192,6 +193,8 @@ struct HttpDatabaseConfig {
     block_reason: Option<String>,
     #[serde(default)]
     max_db_size: Option<bytesize::ByteSize>,
+    #[serde(default)]
+    heartbeat_url: Option<String>,
 }
 
 async fn handle_post_config<M: MakeNamespace, C>(
@@ -210,6 +213,9 @@ async fn handle_post_config<M: MakeNamespace, C>(
     if let Some(size) = req.max_db_size {
         config.max_db_pages = size.as_u64() / LIBSQL_PAGE_SIZE;
     }
+    if let Some(url) = req.heartbeat_url {
+        config.heartbeat_url = Some(Url::parse(&url)?);
+    }
 
     store.store(config)?;
 
@@ -220,6 +226,7 @@ async fn handle_post_config<M: MakeNamespace, C>(
 struct CreateNamespaceReq {
     dump_url: Option<Url>,
     max_db_size: Option<bytesize::ByteSize>,
+    heartbeat_url: Option<String>,
 }
 
 async fn handle_create_namespace<M: MakeNamespace, C: Connector>(
@@ -237,12 +244,15 @@ async fn handle_create_namespace<M: MakeNamespace, C: Connector>(
     let namespace = NamespaceName::from_string(namespace)?;
     app_state.namespaces.create(namespace.clone(), dump).await?;
 
+    let store = app_state.namespaces.config_store(namespace).await?;
+    let mut config = (*store.get()).clone();
     if let Some(max_db_size) = req.max_db_size {
-        let store = app_state.namespaces.config_store(namespace).await?;
-        let mut config = (*store.get()).clone();
         config.max_db_pages = max_db_size.as_u64() / LIBSQL_PAGE_SIZE;
-        store.store(config)?;
     }
+    if let Some(url) = req.heartbeat_url {
+        config.heartbeat_url = Some(Url::parse(&url)?)
+    }
+    store.store(config)?;
 
     Ok(())
 }

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -323,14 +323,17 @@ where
             Some(ref config) => {
                 tracing::info!(
                     "Server sending heartbeat to URL {} every {:?}",
-                    config.heartbeat_url,
+                    config.heartbeat_url.as_deref().unwrap_or("<not supplied>"),
                     config.heartbeat_period,
                 );
                 join_set.spawn({
                     let heartbeat_auth = config.heartbeat_auth.clone();
                     let heartbeat_period = config.heartbeat_period;
-                    let heartbeat_url =
-                        Url::from_str(&config.heartbeat_url).context("invalid heartbeat URL")?;
+                    let heartbeat_url = if let Some(url) = &config.heartbeat_url {
+                        Some(Url::from_str(&url).context("invalid heartbeat URL")?)
+                    } else {
+                        None
+                    };
                     async move {
                         heartbeat::server_heartbeat(
                             heartbeat_url,

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -439,7 +439,7 @@ async fn make_rpc_client_config(config: &Cli) -> anyhow::Result<Option<RpcClient
 
 fn make_hearbeat_config(config: &Cli) -> Option<HeartbeatConfig> {
     Some(HeartbeatConfig {
-        heartbeat_url: config.heartbeat_url.clone()?,
+        heartbeat_url: config.heartbeat_url.clone(),
         heartbeat_period: Duration::from_secs(config.heartbeat_period_s),
         heartbeat_auth: config.heartbeat_auth.clone(),
     })


### PR DESCRIPTION
This is needed for putting namespaces for different users on the same cluster and still correctly reporting the usage.