### PR TITLE
libsql: Add ability to use column name as index

### DIFF
--- a/libsql-sys/src/statement.rs
+++ b/libsql-sys/src/statement.rs
@@ -111,6 +111,17 @@ impl Statement {
         Some(raw_name)
     }
 
+    pub fn column_index(&self, column_name: &str) -> Option<i32> {
+        let count = self.column_count();
+        for i in 0..count {
+            let name = self.column_name(i);
+            if name.is_some() && name.unwrap() == column_name {
+                return Some(i);
+            }
+        }
+        None
+    }
+
     pub fn column_origin_name(&self, idx: i32) -> Option<&str> {
         let raw_name = unsafe { crate::ffi::sqlite3_column_origin_name(self.raw_stmt, idx) };
 

--- a/libsql-sys/src/statement.rs
+++ b/libsql-sys/src/statement.rs
@@ -115,7 +115,7 @@ impl Statement {
         let count = self.column_count();
         for i in 0..count {
             let name = self.column_name(i);
-            if name.is_some() && name.unwrap() == column_name {
+            if name.is_some_and(|name| name == column_name) {
                 return Some(i);
             }
         }

--- a/libsql/benches/benchmark.rs
+++ b/libsql/benches/benchmark.rs
@@ -55,7 +55,7 @@ fn bench(c: &mut Criterion) {
         b.to_async(&rt).iter(|| async {
             let mut rows = conn.query("SELECT 1", ()).await.unwrap();
             let row = rows.next().unwrap().unwrap();
-            assert_eq!(row.get::<i32>(0).unwrap(), 1);
+            assert_eq!(row.get::<i32, _>(0).unwrap(), 1);
         });
     });
 
@@ -94,7 +94,7 @@ fn bench(c: &mut Criterion) {
             |mut stmt| async move {
                 let mut rows = stmt.query(()).await.unwrap();
                 let row = rows.next().unwrap().unwrap();
-                assert_eq!(row.get::<i32>(0).unwrap(), 1);
+                assert_eq!(row.get::<i32, _>(0).unwrap(), 1);
                 stmt.reset();
             },
             BatchSize::SmallInput,
@@ -114,7 +114,7 @@ fn bench(c: &mut Criterion) {
             |mut stmt| async move {
                 let mut rows = stmt.query(()).await.unwrap();
                 let row = rows.next().unwrap().unwrap();
-                assert_eq!(row.get::<i32>(0).unwrap(), 1);
+                assert_eq!(row.get::<i32, _>(0).unwrap(), 1);
                 stmt.reset();
             },
             BatchSize::SmallInput,
@@ -129,7 +129,7 @@ fn bench(c: &mut Criterion) {
                 |mut stmt| async move {
                     let mut rows = stmt.query(()).await.unwrap();
                     let row = rows.next().unwrap().unwrap();
-                    assert_eq!(row.get::<i32>(0).unwrap(), 1);
+                    assert_eq!(row.get::<i32, _>(0).unwrap(), 1);
                     stmt.reset();
                 },
                 BatchSize::SmallInput,
@@ -147,7 +147,7 @@ fn bench(c: &mut Criterion) {
         b.to_async(&rt).iter(|| async {
             let mut rows = conn.query("SELECT 1", ()).await.unwrap();
             let row = rows.next().unwrap().unwrap();
-            assert_eq!(row.get::<i32>(0).unwrap(), 1);
+            assert_eq!(row.get::<i32, _>(0).unwrap(), 1);
         });
     });
 
@@ -157,7 +157,7 @@ fn bench(c: &mut Criterion) {
             |mut stmt| async move {
                 let mut rows = stmt.query(()).await.unwrap();
                 let row = rows.next().unwrap().unwrap();
-                assert_eq!(row.get::<i32>(0).unwrap(), 1);
+                assert_eq!(row.get::<i32, _>(0).unwrap(), 1);
                 stmt.reset();
             },
             BatchSize::SmallInput,
@@ -189,7 +189,7 @@ fn bench(c: &mut Criterion) {
                 |mut stmt| async move {
                     let mut rows = stmt.query(()).await.unwrap();
                     let row = rows.next().unwrap().unwrap();
-                    assert_eq!(row.get::<i32>(0).unwrap(), 1);
+                    assert_eq!(row.get::<i32, _>(0).unwrap(), 1);
                     stmt.reset();
                 },
                 BatchSize::SmallInput,
@@ -205,7 +205,7 @@ fn bench(c: &mut Criterion) {
                 |mut stmt| async move {
                     let mut rows = stmt.query(()).await.unwrap();
                     let row = rows.next().unwrap().unwrap();
-                    assert_eq!(row.get::<i32>(0).unwrap(), 1);
+                    assert_eq!(row.get::<i32, _>(0).unwrap(), 1);
                     stmt.reset();
                 },
                 BatchSize::SmallInput,

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -430,6 +430,13 @@ impl RowInner for Row {
             .map(|s| s.as_str())
     }
 
+    fn column_index(&self, name: &str) -> Option<i32> {
+        self.cols
+            .iter()
+            .position(|c| c.name.as_ref().map_or(false, |s| s == name))
+            .map(|idx| idx as i32)
+    }
+
     fn column_str(&self, _idx: i32) -> crate::Result<&str> {
         todo!()
     }

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use std::fmt;
+use std::sync::Arc;
 
 use crate::{
     connection::Conn,
@@ -153,6 +153,10 @@ impl RowInner for LibsqlRow {
 
     fn column_name(&self, idx: i32) -> Option<&str> {
         self.0.column_name(idx)
+    }
+
+    fn column_index(&self, name: &str) -> Option<i32> {
+        self.0.column_index(name)
     }
 
     fn column_str(&self, idx: i32) -> Result<&str> {

--- a/libsql/src/local/rows.rs
+++ b/libsql/src/local/rows.rs
@@ -4,9 +4,9 @@ use crate::{errors, Error, Result};
 use crate::{Value, ValueRef};
 use libsql_sys::ValueType;
 
-use std::fmt;
 use std::cell::RefCell;
 use std::ffi::c_char;
+use std::fmt;
 /// Query result rows.
 #[derive(Debug, Clone)]
 pub struct Rows {
@@ -144,6 +144,10 @@ impl Row {
         self.stmt.inner.column_name(idx)
     }
 
+    pub fn column_index(&self, name: &str) -> Option<i32> {
+        self.stmt.inner.column_index(name)
+    }
+
     pub fn get_ref(&self, idx: i32) -> Result<ValueRef<'_>> {
         Ok(crate::local::Statement::value_ref(
             &self.stmt.inner,
@@ -165,7 +169,9 @@ impl fmt::Debug for Row {
                         ValueRef::Null => dbg_map.value(&(value_type, ())),
                         ValueRef::Integer(i) => dbg_map.value(&(value_type, i)),
                         ValueRef::Real(f) => dbg_map.value(&(value_type, f)),
-                        ValueRef::Text(s) => dbg_map.value(&(value_type, String::from_utf8_lossy(s))),
+                        ValueRef::Text(s) => {
+                            dbg_map.value(&(value_type, String::from_utf8_lossy(s)))
+                        }
                         ValueRef::Blob(b) => dbg_map.value(&(value_type, b.len())),
                     };
                 }

--- a/libsql/src/rows.rs
+++ b/libsql/src/rows.rs
@@ -37,6 +37,42 @@ impl Column<'_> {
     }
 }
 
+pub trait ColumnIndex: fmt::Debug {
+    fn index(self, row: &Row) -> Result<i32>;
+}
+
+impl ColumnIndex for &str {
+    fn index(self, row: &Row) -> Result<i32> {
+        row.column_index(self)
+            .ok_or_else(|| crate::Error::InvalidColumnName(self.to_string()))
+    }
+}
+
+impl ColumnIndex for String {
+    fn index(self, row: &Row) -> Result<i32> {
+        row.column_index(&self)
+            .ok_or_else(|| crate::Error::InvalidColumnName(self))
+    }
+}
+
+impl ColumnIndex for i32 {
+    fn index(self, _: &Row) -> Result<i32> {
+        Ok(self)
+    }
+}
+
+impl ColumnIndex for i64 {
+    fn index(self, _: &Row) -> Result<i32> {
+        Ok(self as i32)
+    }
+}
+
+impl ColumnIndex for usize {
+    fn index(self, _: &Row) -> Result<i32> {
+        Ok(self as i32)
+    }
+}
+
 pub(crate) trait RowsInner {
     fn next(&mut self) -> Result<Option<Row>>;
 
@@ -72,23 +108,6 @@ impl Rows {
 
 pub struct Row {
     pub(crate) inner: Box<dyn RowInner + Send + Sync>,
-}
-
-pub trait ColumnIndex: fmt::Debug {
-    fn index(&self, row: &Row) -> Result<i32>;
-}
-
-impl ColumnIndex for &str {
-    fn index(&self, row: &Row) -> Result<i32> {
-        row.column_index(*self)
-            .ok_or_else(|| crate::Error::InvalidColumnName(self.to_string()))
-    }
-}
-
-impl ColumnIndex for i32 {
-    fn index(&self, _: &Row) -> Result<i32> {
-        Ok(*self)
-    }
 }
 
 impl Row {

--- a/libsql/src/rows.rs
+++ b/libsql/src/rows.rs
@@ -74,29 +74,60 @@ pub struct Row {
     pub(crate) inner: Box<dyn RowInner + Send + Sync>,
 }
 
+pub trait ColumnIndex: fmt::Debug {
+    fn index(&self, row: &Row) -> Result<i32>;
+}
+
+impl ColumnIndex for &str {
+    fn index(&self, row: &Row) -> Result<i32> {
+        row.column_index(*self)
+            .ok_or_else(|| crate::Error::InvalidColumnName(self.to_string()))
+    }
+}
+
+impl ColumnIndex for i32 {
+    fn index(&self, _: &Row) -> Result<i32> {
+        Ok(*self)
+    }
+}
+
 impl Row {
-    pub fn get<T>(&self, idx: i32) -> Result<T>
+    pub fn get<T, I>(&self, idx: I) -> Result<T>
     where
         T: FromValue,
+        I: ColumnIndex,
     {
-        let val = self.inner.column_value(idx)?;
+        let val = self.inner.column_value(idx.index(self)?)?;
         T::from_sql(val)
     }
 
-    pub fn get_value(&self, idx: i32) -> Result<Value> {
-        self.inner.column_value(idx)
+    pub fn get_value<I>(&self, idx: I) -> Result<Value>
+    where
+        I: ColumnIndex,
+    {
+        self.inner.column_value(idx.index(self)?)
     }
 
-    pub fn get_str(&self, idx: i32) -> Result<&str> {
-        self.inner.column_str(idx)
+    pub fn get_str<I>(&self, idx: I) -> Result<&str>
+    where
+        I: ColumnIndex,
+    {
+        self.inner.column_str(idx.index(self)?)
     }
 
     pub fn column_name(&self, idx: i32) -> Option<&str> {
         self.inner.column_name(idx)
     }
 
-    pub fn column_type(&self, idx: i32) -> Result<ValueType> {
-        self.inner.column_type(idx)
+    pub fn column_index(&self, name: &str) -> Option<i32> {
+        self.inner.column_index(name)
+    }
+
+    pub fn column_type<I>(&self, idx: I) -> Result<ValueType>
+    where
+        I: ColumnIndex,
+    {
+        self.inner.column_type(idx.index(self)?)
     }
 }
 
@@ -218,5 +249,6 @@ pub(crate) trait RowInner: fmt::Debug {
     fn column_value(&self, idx: i32) -> Result<Value>;
     fn column_str(&self, idx: i32) -> Result<&str>;
     fn column_name(&self, idx: i32) -> Option<&str>;
+    fn column_index(&self, name: &str) -> Option<i32>;
     fn column_type(&self, idx: i32) -> Result<ValueType>;
 }

--- a/libsql/tests/integration_tests.rs
+++ b/libsql/tests/integration_tests.rs
@@ -30,8 +30,8 @@ async fn connection_query() {
         .unwrap();
     let mut rows = conn.query("SELECT * FROM users", ()).await.unwrap();
     let row = rows.next().unwrap().unwrap();
-    assert_eq!(row.get::<i32>(0).unwrap(), 2);
-    assert_eq!(row.get::<String>(1).unwrap(), "Alice");
+    assert_eq!(row.get::<i32, _>(0).unwrap(), 2);
+    assert_eq!(row.get::<String, _>(1).unwrap(), "Alice");
 }
 
 #[tokio::test]
@@ -62,13 +62,13 @@ async fn connection_execute_batch() {
         .unwrap();
 
     let row = rows.next().unwrap().unwrap();
-    assert_eq!(row.get::<String>(0).unwrap(), "users");
+    assert_eq!(row.get::<String, _>(0).unwrap(), "users");
 
     let row = rows.next().unwrap().unwrap();
-    assert_eq!(row.get::<String>(0).unwrap(), "foo");
+    assert_eq!(row.get::<String, _>(0).unwrap(), "foo");
 
     let row = rows.next().unwrap().unwrap();
-    assert_eq!(row.get::<String>(0).unwrap(), "bar");
+    assert_eq!(row.get::<String, _>(0).unwrap(), "bar");
 }
 
 #[tokio::test]
@@ -123,20 +123,20 @@ async fn statement_query() {
     let mut rows = stmt.query(&params).await.unwrap();
     let row = rows.next().unwrap().unwrap();
 
-    assert_eq!(row.get::<i32>(0).unwrap(), 2);
-    assert_eq!(row.get::<String>(1).unwrap(), "Alice");
+    assert_eq!(row.get::<i32, _>(0).unwrap(), 2);
+    assert_eq!(row.get::<String, _>(1).unwrap(), "Alice");
 
     stmt.reset();
 
     let row = stmt.query_row(&params).await.unwrap();
 
-    assert_eq!(row.get::<i32>(0).unwrap(), 2);
-    assert_eq!(row.get::<String>(1).unwrap(), "Alice");
+    assert_eq!(row.get::<i32, _>(0).unwrap(), 2);
+    assert_eq!(row.get::<String, _>(1).unwrap(), "Alice");
 
     stmt.reset();
 
     let mut names = stmt
-        .query_map(&params, |r: libsql::Row| r.get::<String>(1))
+        .query_map(&params, |r: libsql::Row| r.get::<String, _>(1))
         .await
         .unwrap();
 
@@ -255,8 +255,8 @@ async fn check_insert(conn: &Connection, sql: &str, params: impl IntoParams) {
     let row = rows.next().unwrap().unwrap();
     // Use two since if you forget to insert an id it will automatically
     // be set to 1 which defeats the purpose of checking it here.
-    assert_eq!(row.get::<i32>(0).unwrap(), 2);
-    assert_eq!(row.get::<String>(1).unwrap(), "Alice");
+    assert_eq!(row.get::<i32, _>(0).unwrap(), 2);
+    assert_eq!(row.get::<String, _>(1).unwrap(), "Alice");
 }
 
 #[tokio::test]
@@ -268,8 +268,8 @@ async fn nulls() {
         .unwrap();
     let mut rows = conn.query("SELECT * FROM users", ()).await.unwrap();
     let row = rows.next().unwrap().unwrap();
-    assert!(row.get::<i32>(0).is_err());
-    assert!(row.get::<String>(1).is_err());
+    assert!(row.get::<i32, _>(0).is_err());
+    assert!(row.get::<String, _>(1).is_err());
 }
 
 #[tokio::test]
@@ -289,7 +289,7 @@ async fn blob() {
     let mut rows = conn.query("SELECT * FROM bbb", ()).await.unwrap();
     let row = rows.next().unwrap().unwrap();
 
-    let out = row.get::<Vec<u8>>(1).unwrap();
+    let out = row.get::<Vec<u8>, _>(1).unwrap();
     assert_eq!(&out, &bytes);
 }
 
@@ -306,8 +306,8 @@ async fn transaction() {
     tx.rollback().await.unwrap();
     let mut rows = conn.query("SELECT * FROM users", ()).await.unwrap();
     let row = rows.next().unwrap().unwrap();
-    assert_eq!(row.get::<i32>(0).unwrap(), 2);
-    assert_eq!(row.get::<String>(1).unwrap(), "Alice");
+    assert_eq!(row.get::<i32, _>(0).unwrap(), 2);
+    assert_eq!(row.get::<String, _>(1).unwrap(), "Alice");
     assert!(rows.next().unwrap().is_none());
 }
 


### PR DESCRIPTION
This PR adds the ability to use the column name as an index with the use of generics (anything that implements `ColumnIndex` can be used).

The only breaking change is that if you specify the generic type you want the column value to return, you need to specify an additional empty generic parameter:
```rust
row.get::<String, _>("column")
```
however this pattern is already widely used (`sqlx` for example), so i don't think its a major concern.