### PR TITLE
vendored/sqlite3-parser: support RANDOM ROWID

### DIFF
--- a/libsql-server/tests/standalone/mod.rs
+++ b/libsql-server/tests/standalone/mod.rs
@@ -201,3 +201,25 @@ fn execute_transaction() {
 
     sim.run().unwrap();
 }
+
+#[test]
+fn random_rowid() {
+    let mut sim = turmoil::Builder::new().build();
+
+    sim.host("primary", make_standalone_server);
+
+    sim.client("test", async {
+        let db = Database::open_remote_with_connector("http://primary:8080", "", TurmoilConnector)?;
+        let conn = db.connect()?;
+
+        conn.execute(
+            "CREATE TABLE shopping_list(item text, quantity int) RANDOM ROWID",
+            (),
+        )
+        .await?;
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -2038,6 +2038,9 @@ impl ToTokens for CreateTableBody {
                 if options.contains(TableOptions::WITHOUT_ROWID) {
                     s.append(TK_WITHOUT, None)?;
                     s.append(TK_ID, Some("ROWID"))?;
+                } else if options.contains(TableOptions::RANDOM_ROWID) {
+                    s.append(TK_ID, Some("RANDOM"))?;
+                    s.append(TK_ID, Some("ROWID"))?;
                 }
                 if options.contains(TableOptions::STRICT) {
                     s.append(TK_ID, Some("STRICT"))?;
@@ -2327,6 +2330,7 @@ bitflags::bitflags! {
         const NONE = 0;
         const WITHOUT_ROWID = 1;
         const STRICT = 2;
+        const RANDOM_ROWID = 3;
     }
 }
 

--- a/vendored/sqlite3-parser/src/parser/parse.y
+++ b/vendored/sqlite3-parser/src/parser/parse.y
@@ -149,6 +149,15 @@ table_option(A) ::= WITHOUT nm(X). {
     self.ctx.sqlite3_error_msg(&msg);
   }
 }
+table_option(A) ::= nm(X) nm(Y). {
+  if "random".eq_ignore_ascii_case(&X.0) && "rowid".eq_ignore_ascii_case(&Y.0) {
+    A = TableOptions::RANDOM_ROWID;
+  }else{
+    A = TableOptions::NONE;
+    let msg = format!("unknown table option: {} {}", &X, &Y);
+    self.ctx.sqlite3_error_msg(&msg);
+  }
+}
 table_option(A) ::= nm(X). {
   if "strict".eq_ignore_ascii_case(&X.0) {
     A = TableOptions::STRICT;


### PR DESCRIPTION
It's done in a hacky way, similarly to how "STRICT" is already handled. Sad, but I tried making it work properly with a registered RANDOM keyword and it failed. There's precedence in using this runtime string comparisons (like in STRICT case), so I guess it's here for a reason.

Tested locally, properly activates random rowid.

Fixes #333