### PR TITLE
fix bug in lock-stealing

### DIFF
--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -938,10 +938,12 @@ where
 #[cfg(test)]
 mod test {
     use itertools::Itertools;
+    use rand::Rng;
     use sqld_libsql_bindings::wal_hook::TRANSPARENT_METHODS;
     use tempfile::tempdir;
     use tokio::task::JoinSet;
 
+    use crate::connection::Connection as _;
     use crate::query_result_builder::test::{test_driver, TestBuilder};
     use crate::query_result_builder::QueryResultBuilder;
     use crate::DEFAULT_AUTO_CHECKPOINT;
@@ -1137,5 +1139,79 @@ mod test {
 
         let epsilon = Duration::from_millis(100);
         assert!((wait_time..wait_time + epsilon).contains(&elapsed));
+    }
+
+    /// The goal of this test is to run many conccurent transaction and hopefully catch a bug in
+    /// the lock stealing code. If this test becomes flaky check out the lock stealing code.
+    #[tokio::test]
+    async fn test_many_conccurent() {
+        let tmp = tempdir().unwrap();
+        let make_conn = MakeLibSqlConn::new(
+            tmp.path().into(),
+            &TRANSPARENT_METHODS,
+            || (),
+            Default::default(),
+            Arc::new(DatabaseConfigStore::load(tmp.path()).unwrap()),
+            Arc::new([]),
+            100000000,
+            100000000,
+            DEFAULT_AUTO_CHECKPOINT,
+            watch::channel(None).1,
+        )
+        .await
+        .unwrap();
+        let auth = Authenticated::Authorized(Authorized {
+            namespace: None,
+            permission: Permission::FullAccess,
+        });
+
+        let conn = make_conn.make_connection().await.unwrap();
+        conn.execute_program(
+            Program::seq(&["CREATE TABLE test (x)"]),
+            auth.clone(),
+            TestBuilder::default(),
+            None,
+        )
+        .await
+        .unwrap();
+        let run_conn = |maker: Arc<MakeLibSqlConn<TransparentMethods>>| {
+            let auth = auth.clone();
+            async move {
+                for _ in 0..1000 {
+                    let conn = maker.make_connection().await.unwrap();
+                    let pgm = Program::seq(&["BEGIN IMMEDIATE", "INSERT INTO test VALUES (42)"]);
+                    let res = conn
+                        .execute_program(pgm, auth.clone(), TestBuilder::default(), None)
+                        .await
+                        .unwrap()
+                        .into_ret();
+                    for result in res {
+                        result.unwrap();
+                    }
+                    // with 99% change, commit the txn
+                    if rand::thread_rng().gen_range(0..100) > 1 {
+                        let pgm = Program::seq(&["INSERT INTO test VALUES (43)", "COMMIT"]);
+                        let res = conn
+                            .execute_program(pgm, auth.clone(), TestBuilder::default(), None)
+                            .await
+                            .unwrap()
+                            .into_ret();
+                        for result in res {
+                            result.unwrap();
+                        }
+                    }
+                }
+            }
+        };
+
+        let maker = Arc::new(make_conn);
+        let mut join_set = JoinSet::new();
+        for _ in 0..3 {
+            join_set.spawn(run_conn(maker.clone()));
+        }
+
+        while let Some(next) = join_set.join_next().await {
+            next.unwrap();
+        }
     }
 }

--- a/libsql-server/src/connection/mod.rs
+++ b/libsql-server/src/connection/mod.rs
@@ -23,7 +23,10 @@ pub mod libsql;
 pub mod program;
 pub mod write_proxy;
 
+#[cfg(not(test))]
 const TXN_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const TXN_TIMEOUT: Duration = Duration::from_millis(100);
 
 #[async_trait::async_trait]
 pub trait Connection: Send + Sync + 'static {


### PR DESCRIPTION
This PR fixes a bug in lock stealing that was two-fold:

- When downgrading a transaction we took the state slot without making sure that the state lock was ours, so we could end up taking some other txn slot instead, leaving an empty slot.
- When stealing a txn, we didn't make sure that the slot we stole was the same slot as the one we intended to steal.

This fix was tested by running the following code for 1M iterations:
<details>
  <summary>Click me</summary>
  
  ```rust
#![allow(dead_code)]

use rand::Rng;
use serde::{ Deserialize,Serialize };
use tokio::task::JoinSet;

type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;


impl From<&[&str]> for Req {
    fn from(s: &[&str]) -> Self {
        let requests = s.into_iter().map(|&s| Op::Execute { stmt: Sql { sql: s.into() } }).collect();
        Req {
            baton: None,
            requests,
        }
    }
}

#[derive(Serialize)]
struct Req {
    baton: Option<String>,
    requests: Vec<Op>,
}

#[derive(Serialize)]
#[serde(tag = "type", rename_all = "camelCase")]
enum Op {
    Execute {
        stmt: Sql,
    },
    Close(CloseReq),
}

#[derive(Serialize)]
struct CloseReq {}

#[derive(Serialize)]
struct Sql {
    sql: String,
}


#[derive(Deserialize, Debug)]
#[serde(untagged)]
enum RespOrError {
    Resp {
        #[serde(flatten)]
        resp: Resp
    },
    Error {
        error: String,
    }
}

#[derive(Deserialize, Debug)]
struct Resp {
    baton: Option<String>,
    base_url: Option<String>,
    results: Vec<RespResult>,
}

#[derive(Deserialize, Debug)]
#[serde(tag = "type", rename_all = "camelCase")]
enum RespResult {
    Ok {
        response: OpResult,
    }
}

#[derive(Deserialize, Debug)]
#[serde(tag = "type", rename_all = "camelCase")]
enum OpResult {
    Execute {
        result: ExecuteResult,
    },
    Close,
}

#[derive(Deserialize, Debug)]
struct ExecuteResult {
    cols: Vec<Col>,
    rows: Vec<Row>,
    affected_row_count: u64,
    last_inserted_row_id: Option<i64>,
    replication_index: u64,
}

#[derive(Deserialize, Debug)]
struct Col {
    name: String,
    decltype: Option<String>,
}

type Row = ();

async fn send_request(s: &[&str], url: &str, baton: Option<String>, close: bool, client: &reqwest::Client) -> Result<Resp> {
    let mut req = Req::from(s);
    req.baton = baton;

    if close {
        req.requests.push(Op::Close(CloseReq {  }));
    }
    let resp = client.post(url).json(&req).send().await?;
    

    let body = resp.text().await?;
    // pcintln!("{body}\n");
    let json = serde_json::from_str::<RespOrError>(&body)?;
    match json {
        RespOrError::Resp { resp } => Ok(resp),
        RespOrError::Error { error } => {
            println!("{error}");
            panic!();
        }
    }
}

async fn make_txn(host: &str, client: &reqwest::Client) -> Result<()> {
    let ret = send_request(&["begin immediate", "insert into test values (11)"], host, None, false, client).await?;
    let baton = ret.baton.unwrap();
    let rand = rand::thread_rng().gen_range(0..100);
    if rand > 1 {
        send_request(&["insert into test values (11)", "commit"], host, Some(baton), true, client).await?;
    }

    Ok(())
}

#[tokio::main]
async fn main() -> Result<()> {
    let host = "http://localhost:8080/v2/pipeline";
    let mut join_set = JoinSet::new();
    let (send, mut rcv) = tokio::sync::mpsc::unbounded_channel::<()>();
    join_set.spawn(async move {
        let mut count = 0;
        while let Some(_) = rcv.recv().await {
            count += 1;

            print!("\rrequest count: {count:>8}");
            
        }

    });

    for _ in 0..3 {
        join_set.spawn({
            let snd = send.clone();
            async move {
                let client = reqwest::Client::new();
                loop  {
                    make_txn(host, &client).await.unwrap();
                    let _ = snd.send(());
                }
            } 
        });
    } 

    join_set.join_next().await.unwrap().unwrap();

    Ok(())
}
```
</details>