### PR TITLE
libsql-sys: fix path to sqlite3.c in build.rs

### DIFF
--- a/libsql-sys/build.rs
+++ b/libsql-sys/build.rs
@@ -13,10 +13,9 @@ fn main() {
 }
 
 pub fn build_bundled(out_dir: &str, out_path: &Path) {
-    let bindings_dir = if std::env::var("LIBSQL_REGENERATE_BINDINGS").is_ok() {
+    if std::env::var("LIBSQL_REGENERATE_BINDINGS").is_ok() {
         let header = HeaderLocation::FromPath(format!("bundled/src/sqlite3.h"));
         bindings::write_to_out_dir(header, out_path);
-        out_path.display().to_string()
     } else {
         let bindgen_rs_path = if cfg!(feature = "session") {
             "bundled/bindings/session_bindgen.rs"
@@ -25,9 +24,9 @@ pub fn build_bundled(out_dir: &str, out_path: &Path) {
         };
         let dir = env!("CARGO_MANIFEST_DIR");
         std::fs::copy(format!("{dir}/{bindgen_rs_path}"), out_path).unwrap();
-        "bundled/src".to_string()
-    };
+    }
 
+    let bindings_dir = "bundled/src".to_string();
     println!("cargo:rerun-if-changed={bindings_dir}/sqlite3.c");
     let mut cfg = cc::Build::new();
     cfg.file(format!("{bindings_dir}/sqlite3.c"))


### PR DESCRIPTION
I encountered this error when trying to use the `LIBSQL_REGENERATE_BINDINGS` environment variable:

```
$ cargo clean ; LIBSQL_REGENERATE_BINDINGS=1 cargo build -p libsql-sys -vv --jobs 1
  running: "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "-m64" "-arch" "x86_64" "-DSQLITE_CORE" "-DSQLITE_DEFAULT_FOREIGN_KEYS=1" "-DSQLITE_ENABLE_API_ARMOR" "-DSQLITE_ENABLE_COLUMN_METADATA" "-DSQLITE_ENABLE_DBSTAT_VTAB" "-DSQLITE_ENABLE_FTS3" "-DSQLITE_ENABLE_FTS3_PARENTHESIS" "-DSQLITE_ENABLE_FTS5" "-DSQLITE_ENABLE_JSON1" "-DSQLITE_ENABLE_LOAD_EXTENSION=1" "-DSQLITE_ENABLE_MEMORY_MANAGEMENT" "-DSQLITE_ENABLE_RTREE" "-DSQLITE_ENABLE_STAT2" "-DSQLITE_ENABLE_STAT4" "-DSQLITE_SOUNDEX" "-DSQLITE_THREADSAFE=1" "-DSQLITE_USE_URI" "-DHAVE_USLEEP=1" "-D_POSIX_THREAD_SAFE_FUNCTIONS" "-o" "/Users/pjhades/code/libsql-fork/target/debug/build/libsql-sys-b2ee620484b70a9f/out/dfbe636691d815b1-sqlite3.o" "-c" "/Users/pjhades/code/libsql-fork/target/debug/build/libsql-sys-b2ee620484b70a9f/out/bindgen.rs/sqlite3.c"
  cargo:warning=clang: error: no such file or directory: '/Users/pjhades/code/libsql-fork/target/debug/build/libsql-sys-b2ee620484b70a9f/out/bindgen.rs/sqlite3.c'

  cargo:warning=clang: error: no input files
```
Apparently the path to `sqlite3.c` is incorrect. If I understand correctly, based on #561, the environment variable only controls if `bindgen.rs` should be generated on the fly. This PR attempts to fix it.