### PR TITLE
Replica delegate request until in sync

### DIFF
--- a/libsql-replication/proto/replication_log.proto
+++ b/libsql-replication/proto/replication_log.proto
@@ -19,6 +19,7 @@ message HelloResponse {
     /// string-encoded Uuid v4 token for the current session, changes on each restart, and must be passed in subsequent requests header.string
     /// If the header session token fails to match the current session token, a NO_HELLO error is returned
     bytes session_token = 4;
+    optional uint64 current_replication_index = 5;
 }
 
 message Frame {

--- a/libsql-replication/src/generated/wal_log.rs
+++ b/libsql-replication/src/generated/wal_log.rs
@@ -26,6 +26,8 @@ pub struct HelloResponse {
     /// / If the header session token fails to match the current session token, a NO_HELLO error is returned
     #[prost(bytes = "bytes", tag = "4")]
     pub session_token: ::prost::bytes::Bytes,
+    #[prost(uint64, optional, tag = "5")]
+    pub current_replication_index: ::core::option::Option<u64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/libsql-replication/src/replicator.rs
+++ b/libsql-replication/src/replicator.rs
@@ -148,7 +148,7 @@ impl<C: ReplicatorClient> Replicator<C> {
         }
     }
 
-    async fn try_perform_handshake(&mut self) -> Result<(), Error> {
+    pub async fn try_perform_handshake(&mut self) -> Result<(), Error> {
         let mut error_printed = false;
         for _ in 0..HANDSHAKE_MAX_RETRIES {
             tracing::info!("Attempting to perform handshake with primary.");

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -578,6 +578,10 @@ impl Namespace<ReplicaDatabase> {
         )
         .await?;
 
+        // force a handshake now, to retrieve the primary's current replication index
+        replicator.try_perform_handshake().await?;
+        let primary_current_replicatio_index = replicator.client_mut().primary_replication_index;
+
         let mut join_set = JoinSet::new();
         let namespace = name.clone();
         join_set.spawn(async move {
@@ -646,6 +650,7 @@ impl Namespace<ReplicaDatabase> {
             config.max_response_size,
             config.max_total_response_size,
             name.clone(),
+            primary_current_replicatio_index,
         )
         .await?
         .throttled(

--- a/libsql-server/src/rpc/replication_log.rs
+++ b/libsql-server/src/rpc/replication_log.rs
@@ -256,6 +256,7 @@ impl ReplicationLog for ReplicationLogService {
             session_token: self.session_token.clone(),
             generation_id: self.generation_id.to_string(),
             generation_start_index: 0,
+            current_replication_index: *logger.new_frame_notifier.borrow(),
         };
 
         Ok(tonic::Response::new(response))


### PR DESCRIPTION
With this PR, the replicas will delegate their request until they have caught up with their primary's replication index at the moment the replica's namespace has been loaded.
