### PR TITLE
Add client version reporting metrics

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,6 +113,10 @@ jobs:
       with:
         tool: protoc@${{ env.PROTOC_VERSION }}
 
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: nextest
+
     - uses: actions/checkout@v3
 
     - name: Set up cargo cache
@@ -129,10 +133,7 @@ jobs:
         restore-keys: ${{ runner.os }}-cargo-
 
     - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose
+      run: cargo nextest run
       env:
         LIBSQL_BOTTOMLESS_AWS_ACCESS_KEY_ID: minioadmin
         LIBSQL_BOTTOMLESS_AWS_SECRET_ACCESS_KEY: minioadmin
@@ -140,8 +141,6 @@ jobs:
         LIBSQL_BOTTOMLESS_BUCKET: bottomless
         LIBSQL_BOTTOMLESS_ENDPOINT: http://localhost:9000
 
-  # TODO(lucio): Enable this, for some reason github doesn't like this
-  # but won't tell me why...
   # test-rust-wasm:
   #   runs-on: ubuntu-latest
   #   name: Run Rust Wasm Tests
@@ -176,4 +175,4 @@ jobs:
   #         restore-keys: ${{ runner.os }}-cargo-
 
   #     - name: Run check
-  #       command: cargo check --verbose -p libsql --target wasm32-unknown-unknown --no-default-features --features cloudflare
+  #       run: cargo check --verbose -p libsql --target wasm32-unknown-unknown --no-default-features --features cloudflare

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3817,6 +3817,7 @@ dependencies = [
  "futures",
  "futures-core",
  "hmac",
+ "http-body",
  "hyper",
  "hyper-rustls 0.24.1",
  "hyper-tungstenite",

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -70,6 +70,7 @@ tower-http = { version = "0.3.5", features = ["compression-full", "cors", "trace
 tracing = "0.1.37"
 tracing-panic = "0.1"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+http-body = "0.4"
 url = { version = "2.3", features = ["serde"] }
 uuid = { version = "1.3", features = ["v4", "serde"] }
 

--- a/libsql-server/src/metrics.rs
+++ b/libsql-server/src/metrics.rs
@@ -5,6 +5,8 @@ use metrics::{
 };
 use once_cell::sync::Lazy;
 
+pub static CLIENT_VERSION: &str = "libsql_client_version";
+
 pub static WRITE_QUERY_COUNT: Lazy<Counter> = Lazy::new(|| {
     const NAME: &str = "libsql_server_writes_count";
     describe_counter!(NAME, "number of write statements");

--- a/libsql-server/tests/common/mod.rs
+++ b/libsql-server/tests/common/mod.rs
@@ -64,6 +64,12 @@ impl MetricsSnapshot {
         None
     }
 
+    pub fn snapshot(
+        &self,
+    ) -> &HashMap<CompositeKey, (Option<Unit>, Option<SharedString>, DebugValue)> {
+        &self.snapshot
+    }
+
     #[track_caller]
     pub fn assert_gauge(&self, metric_name: &str, value: f64) -> &Self {
         let val = self.get_gauge(metric_name).expect("metric does not exist");

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "1.4.0", features = ["v4", "serde"], optional = true }
 tokio-stream = { version = "0.1.14", optional = true }
 tonic = { version = "0.10.2", features = ["tls", "tls-roots", "tls-webpki-roots"], optional = true}
 tonic-web = { version = "0.10.2" , optional = true }
-tower-http = { version = "0.4.4", features = ["trace", "util"], optional = true }
+tower-http = { version = "0.4.4", features = ["trace", "set-header", "util"], optional = true }
 http = { version = "0.2", optional = true }
 
 sqlite3-parser = { path = "../vendored/sqlite3-parser", version = "0.11", optional = true }

--- a/libsql/src/hrana/connection.rs
+++ b/libsql/src/hrana/connection.rs
@@ -20,10 +20,14 @@ struct Cookie {
 #[derive(Debug)]
 pub struct HttpConnection<T>(Arc<InnerClient<T>>);
 
-impl<T> Clone for HttpConnection<T> {
-    fn clone(&self) -> Self {
-        HttpConnection(self.0.clone())
-    }
+#[derive(Debug)]
+struct InnerClient<T> {
+    inner: T,
+    cookies: RwLock<HashMap<u64, Cookie>>,
+    url_for_queries: String,
+    auth: String,
+    affected_row_count: AtomicU64,
+    last_insert_rowid: AtomicI64,
 }
 
 impl<T> HttpConnection<T>
@@ -222,12 +226,8 @@ where
     }
 }
 
-#[derive(Debug)]
-struct InnerClient<T> {
-    inner: T,
-    cookies: RwLock<HashMap<u64, Cookie>>,
-    url_for_queries: String,
-    auth: String,
-    affected_row_count: AtomicU64,
-    last_insert_rowid: AtomicI64,
+impl<T> Clone for HttpConnection<T> {
+    fn clone(&self) -> Self {
+        HttpConnection(self.0.clone())
+    }
 }


### PR DESCRIPTION
This commit adds a new `x-libsql-client-version` header emitted by clients. The server will collect these values and emit them as a `libsql_client_version{version="libsql-hrana-0.1.11"}`. This also exposes special doc hidden functions that our other clients that use the rust one to emit their own metric.

Closes #546