### PR TITLE
sql-experimental: update example.c to match rust

### DIFF
--- a/.github/workflows/c-bindings.yml
+++ b/.github/workflows/c-bindings.yml
@@ -1,0 +1,40 @@
+name: C bindings tests CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  merge_group:
+    branches: [ "main" ]
+
+jobs:
+  c-bindings:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v2
+
+    - name: Set up cargo cache
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-
+
+    - name: Build crates
+      run: cargo build
+
+    - name: Build C bindings example
+      working-directory: bindings/c
+      run: make

--- a/bindings/c/Makefile
+++ b/bindings/c/Makefile
@@ -1,0 +1,13 @@
+OS := $(shell uname)
+CFLAGS := -Iinclude
+LDFLAGS := -lm
+
+ifeq ($(OS),Darwin)
+	CFLAGS += -framework Security -framework CoreServices
+endif
+
+.PHONY: all
+all: example
+
+example: example.c
+	$(CC) -o $@ $(CFLAGS) $< ../../target/debug/libsql_experimental.a $(LDFLAGS)


### PR DESCRIPTION
This PR updates the example of the C bindings to make it match the generated header (and thus Rust).

```
$ pwd
/Users/.../code/libsql-fork/bindings/c
$ clang -o example -I include/ example.c ../../target/debug/libsql_experimental.a -framework Security -framework CoreServices && ./example
1
```

Resolves #592 