### PR TITLE
bottomless: send .meta file later in the process and temporarily bypass CRC verification

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -730,8 +730,6 @@ impl Replicator {
             }
         };
 
-        self.store_metadata(wal.page_size(), wal.checksum()).await?;
-
         let frame_count = wal.frame_count().await;
         tracing::trace!("Local WAL pages: {}", frame_count);
         self.submit_frames(frame_count);
@@ -745,6 +743,7 @@ impl Replicator {
                 pending_frames
             );
         }
+        self.store_metadata(wal.page_size(), wal.checksum()).await?;
         tracing::info!("Local WAL replicated");
         Ok(())
     }

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -186,7 +186,7 @@ impl Options {
         let use_compression =
             CompressionKind::parse(&env_var_or("LIBSQL_BOTTOMLESS_COMPRESSION", "zstd"))
                 .map_err(|e| anyhow!("unknown compression kind: {}", e))?;
-        let verify_crc = match env_var_or("LIBSQL_BOTTOMLESS_VERIFY_CRC", true)
+        let verify_crc = match env_var_or("LIBSQL_BOTTOMLESS_VERIFY_CRC", false)
             .to_lowercase()
             .as_ref()
         {


### PR DESCRIPTION
Refs https://github.com/tursodatabase/libsql/issues/598 - our additional crc verification proved to prevent restore, and put sqld machines in an infinite restart loop because of that.

Alternatives to skipping crc:
1. Try another, previous generation
2. Only apply the main db file, and skip the WAL frames that are potentially incorrect (because they don't pass crc checks)