### PR TITLE
add test for savepoint with replication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,7 @@ dependencies = [
  "aws-sdk-s3",
  "bytes",
  "chrono",
+ "futures-core",
  "rand",
  "sqld-libsql-bindings",
  "tokio",
@@ -831,10 +832,12 @@ name = "bottomless-cli"
 version = "0.1.14"
 dependencies = [
  "anyhow",
+ "async-compression 0.4.4",
  "aws-config",
  "aws-sdk-s3",
  "aws-smithy-types",
  "bottomless",
+ "bytes",
  "chrono",
  "clap 4.4.7",
  "rusqlite",

--- a/libsql-sys-tmp/src/lib.rs
+++ b/libsql-sys-tmp/src/lib.rs
@@ -3,7 +3,11 @@
 pub mod ffi;
 pub mod wal_hook;
 
-use std::{ffi::CString, ops::Deref, time::Duration};
+use std::{
+    ffi::CString,
+    ops::{Deref, DerefMut},
+    time::Duration,
+};
 
 pub use crate::wal_hook::WalMethodsHook;
 pub use once_cell::sync::Lazy;
@@ -38,6 +42,12 @@ impl<W: WalHook> Deref for Connection<W> {
 
     fn deref(&self) -> &Self::Target {
         &self.conn
+    }
+}
+
+impl<W: WalHook> DerefMut for Connection<W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.conn
     }
 }
 


### PR DESCRIPTION
This pr adds tests that ensure replica consistency when savepoints an rollback are used. The result is not ideal since stale frames are written to the shadow wal, but at least the replica remains consistent. I'm not investing more efforts on that right now since this will be fixed by unification soon.
