### PR TITLE
adding rocky-9.2 as supported platform in scripts/install-deps.sh

### DIFF
--- a/libsql-server/scripts/install-deps.sh
+++ b/libsql-server/scripts/install-deps.sh
@@ -15,7 +15,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
       libpq-dev \
       libsqlite3-dev \
       nodejs \
-      protobuf-compiler 
+      protobuf-compiler
   elif [ "$ID" = "fedora" ]; then
     dnf install -y \
       libpq-devel \
@@ -26,8 +26,18 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
       rubygem-bundler \
       rubygem-sqlite3 \
       ruby-devel
+  elif [ "$ID" = "rocky" ] || [ "$VERION_ID" = "9.2" ]; then
+    dnf install -y \
+      libpq-devel \
+      libsqlite3x-devel \
+      nodejs \
+      npm \
+      protobuf-compiler \
+      rubygem-bundler \
+      rubygem-sqlite3 \
+      ruby-devel
   else
-    echo "Linux distribution $ID is not supported by this installer."
+    echo "Linux distribution $ID-$VERSION_ID is not supported by this installer."
   fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   brew install protobuf

--- a/libsql-server/scripts/install-deps.sh
+++ b/libsql-server/scripts/install-deps.sh
@@ -26,7 +26,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
       rubygem-bundler \
       rubygem-sqlite3 \
       ruby-devel
-  elif [ "$ID" = "rocky" ] || [ "$VERION_ID" = "9.2" ]; then
+  elif [ "$ID" = "rocky" ] && [ "$VERION_ID" = "9.2" ]; then
     dnf install -y \
       libpq-devel \
       libsqlite3x-devel \


### PR DESCRIPTION
- Unlike rocky 8.x, rocky 9.2 has newer protobuf-compiler-3.14.0.
```
[me@rocky9t01a libsql-server]$ sudo scripts/install-deps.sh ;date
Last metadata expiration check: 2:15:28 ago on Sat 11 Nov 2023 09:48:46 PM CST.
Package libpq-devel-13.5-1.el9.x86_64 is already installed.
Package libsqlite3x-devel-20071018-31.el9.x86_64 is already installed.
Package nodejs-1:16.20.2-3.el9_2.x86_64 is already installed.
Package npm-1:8.19.4-1.16.20.2.3.el9_2.x86_64 is already installed.
Package protobuf-compiler-3.14.0-13.el9.x86_64 is already installed.
Package rubygem-bundler-2.2.33-160.el9_0.noarch is already installed.
Package rubygem-sqlite3-1.4.2-8.el9.x86_64 is already installed.
Package ruby-devel-3.0.4-160.el9_0.x86_64 is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Sun Nov 12 12:04:14 AM CST 2023
[me@rocky9t01a libsql-server]$

```