### PR TITLE
bottomless: fix checksumming across checkpoints

### DIFF
--- a/bottomless-cli/src/main.rs
+++ b/bottomless-cli/src/main.rs
@@ -128,14 +128,17 @@ async fn run() -> Result<()> {
             Ok(Some((page_size, checksum))) => (page_size, checksum),
             Ok(None) => {
                 println!("No local metadata found, continuing anyway");
-                (4096, 0)
+                (4096, (0, 0))
             }
             Err(e) => {
                 println!("Failed to get local metadata: {e}, continuing anyway");
-                (4096, 0)
+                (4096, (0, 0))
             }
         };
-        println!("Local metadata: page_size={page_size}, checksum={checksum:x}");
+        println!(
+            "Local metadata: page_size={page_size}, checksum={:X}-{:X}",
+            checksum.0, checksum.1
+        );
         Replicator::restore_from_local_snapshot(&from_dir, &mut db_file).await?;
         println!("Restored local snapshot to {}", database);
         let applied_frames = Replicator::apply_wal_from_local_generation(

--- a/bottomless/src/backup.rs
+++ b/bottomless/src/backup.rs
@@ -74,10 +74,11 @@ impl WalCopier {
             let mut meta_file = tokio::fs::File::create(&meta_path).await?;
             let buf = {
                 let page_size = wal.page_size();
-                let crc = wal.checksum();
+                let (checksum_1, checksum_2) = wal.checksum();
                 let mut buf = [0u8; 12];
                 buf[0..4].copy_from_slice(page_size.to_be_bytes().as_slice());
-                buf[4..].copy_from_slice(crc.to_be_bytes().as_slice());
+                buf[4..8].copy_from_slice(checksum_1.to_be_bytes().as_slice());
+                buf[8..12].copy_from_slice(checksum_2.to_be_bytes().as_slice());
                 buf
             };
             meta_file.write_all(buf.as_ref()).await?;

--- a/bottomless/src/wal.rs
+++ b/bottomless/src/wal.rs
@@ -37,26 +37,28 @@ impl WalFrameHeader {
         ])
     }
 
-    pub fn crc(&self) -> u64 {
-        u64::from_be_bytes([
-            self.0[16], self.0[17], self.0[18], self.0[19], self.0[20], self.0[21], self.0[22],
-            self.0[23],
-        ])
+    pub fn crc(&self) -> (u32, u32) {
+        (
+            u32::from_be_bytes([self.0[16], self.0[17], self.0[18], self.0[19]]),
+            u32::from_be_bytes([self.0[20], self.0[21], self.0[22], self.0[23]]),
+        )
     }
 
-    pub fn verify(&self, init_crc: u64, page_data: &[u8]) -> Result<u64> {
+    pub fn verify(&self, init_crc: (u32, u32), page_data: &[u8]) -> Result<(u32, u32)> {
         let mut crc = init_crc;
-        crc = checksum_be(crc, &self.0[0..8]);
-        crc = checksum_be(crc, page_data);
+        crc = checksum_step(crc, &self.0[0..8]);
+        crc = checksum_step(crc, page_data);
         let frame_crc = self.crc();
         if crc == frame_crc {
             Ok(crc)
         } else {
             Err(anyhow!(
-                "Frame checksum verification failed for page no. {}. Expected: {:X}. Got: {:X}",
+                "Frame checksum verification failed for page no. {}. Expected: {:X}-{:X}. Got: {:X}-{:X}",
                 self.pgno(),
-                frame_crc,
-                crc
+                frame_crc.0,
+                frame_crc.1,
+                crc.0,
+                crc.1,
             ))
         }
     }
@@ -96,7 +98,8 @@ pub(crate) struct WalHeader {
     /// A different random integer changing with each checkpoint
     pub salt_2: u32,
     /// Checksum for first 24 bytes of header
-    pub crc: u64,
+    pub checksum_1: u32,
+    pub checksum_2: u32,
 }
 
 impl WalHeader {
@@ -112,7 +115,8 @@ impl From<[u8; WalHeader::SIZE as usize]> for WalHeader {
             checkpoint_seq_no: u32::from_be_bytes([v[12], v[13], v[14], v[15]]),
             salt_1: u32::from_be_bytes([v[16], v[17], v[18], v[19]]),
             salt_2: u32::from_be_bytes([v[20], v[21], v[22], v[23]]),
-            crc: u64::from_be_bytes([v[24], v[25], v[26], v[27], v[28], v[29], v[30], v[31]]),
+            checksum_1: u32::from_be_bytes([v[24], v[25], v[26], v[27]]),
+            checksum_2: u32::from_be_bytes([v[28], v[29], v[30], v[31]]),
         }
     }
 }
@@ -143,8 +147,8 @@ impl WalFileReader {
         self.header.page_size
     }
 
-    pub fn checksum(&self) -> u64 {
-        self.header.crc
+    pub fn checksum(&self) -> (u32, u32) {
+        (self.header.checksum_1, self.header.checksum_2)
     }
 
     pub fn frame_size(&self) -> u64 {
@@ -241,18 +245,21 @@ impl AsMut<File> for WalFileReader {
 
 /// Generate or extend an 8 byte checksum based on the data in
 ///the `page` and the `init` value. `page` size must be multiple of 8.
-pub fn checksum_be(init: u64, page: &[u8]) -> u64 {
+/// FIXME: these computations are performed with host endianness,
+/// which is softly assumed to be little endian for majority of devices.
+/// However, the only proper way to do this is to get the endianness
+/// from the WAL header, as per https://www.sqlite.org/fileformat.html#checksum_algorithm
+pub fn checksum_step(init: (u32, u32), page: &[u8]) -> (u32, u32) {
     debug_assert_eq!(page.len() % 8, 0);
-    let mut s1 = (init >> 32) as u32;
-    let mut s2 = (init & u32::MAX as u64) as u32;
+    let (mut s0, mut s1) = init;
     let page = unsafe { std::slice::from_raw_parts(page.as_ptr() as *const u32, page.len() / 4) };
     let mut i = 0;
     while i < page.len() {
-        s1 = s1.wrapping_add(page[i]).wrapping_add(s2);
-        s2 = s2.wrapping_add(page[i + 1]).wrapping_add(s1);
+        s0 = s0.wrapping_add(page[i]).wrapping_add(s1);
+        s1 = s1.wrapping_add(page[i + 1]).wrapping_add(s0);
         i += 2;
     }
-    ((s1 as u64) << 32) | (s2 as u64)
+    (s0, s1)
 }
 
 #[cfg(test)]
@@ -273,7 +280,8 @@ mod test {
             checkpoint_seq_no: 0,
             salt_1: 3188076412,
             salt_2: 666853980,
-            crc: 5842868361513443485,
+            checksum_1: 1360398801,
+            checksum_2: 1700831389,
         };
         let actual = WalHeader::from(source);
         assert_eq!(actual, expected);

--- a/libsql-server/src/test/bottomless.rs
+++ b/libsql-server/src/test/bottomless.rs
@@ -49,7 +49,7 @@ async fn configure_server(
             max_response_size: 10000000 * 4096,
             max_total_response_size: 10000000 * 4096,
             snapshot_exec: None,
-            checkpoint_interval: None,
+            checkpoint_interval: Some(Duration::from_secs(3)),
         },
         admin_api_config: None,
         disable_namespaces: true,


### PR DESCRIPTION
This PR implements two things that lead to fixing #598.

1. (not direct cause) It makes the checksumming work as long as it's produced and checked on an arch with matching endianness. Most of modern machines, including the ones we run on our platform, CI, and home devices are just little endian anyway. The proper fix is to also store the checksum computation endianness in our .meta file, just like SQLite stores it in the WAL header, but that's not implemented yet.

The main change is not storing the checksum as a single u64 and using a pair of u32 instead, since that's how the SQLite algorithm is described -- and a single u64 is also more complicated on little endian, because reading a single u64 in little endian is not the same as reading two consecutive little endian u32's and merging them.

2. (direct cause) We erroneously cached the open WAL file descriptor. After a TRUNCATE checkpoint, the file is recreated, and the old descriptor just points to garbage data. The solution is to not cache and just open the new file.

Tested locally on workloads that failed checksum verification with previous code, and pass now.

The PR also comes with a test that fails before the fix is applied, and passes after the fix.