### PR TITLE
hrana/http:Handle stream close and open in a single pipeline

### DIFF
--- a/libsql-server/src/hrana/http/stream.rs
+++ b/libsql-server/src/hrana/http/stream.rs
@@ -224,6 +224,10 @@ impl<'srv, D: Connection> Guard<'srv, D> {
             None
         }
     }
+
+    pub fn closed(&self) -> bool {
+        self.stream.is_none() || self.stream.as_ref().unwrap().db.is_none()
+    }
 }
 
 impl<'srv, D> Drop for Guard<'srv, D> {


### PR DESCRIPTION
Make it possible to send requests after `CloseStream` in a pipeline.
That closes the previous stream and opens a new one before executing requests that follow `CloseStream` request in the pipeline.