### PR TITLE
Add nemesis test runner

### DIFF
--- a/.github/workflows/nemesis.yml
+++ b/.github/workflows/nemesis.yml
@@ -1,0 +1,80 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  merge_group:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  PROTOC_VERSION: 3.23.4
+  # FIXME: There are some warnings depending on certain feature flags that
+  # we need to fix before we can enable this.
+  # RUSTFLAGS: "-D warnings"
+
+jobs:
+  test-nemesis:
+    runs-on: ubuntu-latest
+    name: Run Nemesis Tests
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: hecrj/setup-rust-action@v1
+
+      - name: Install deps
+        run: sudo apt update && sudo apt install -y libclang-dev
+
+      - name: Install protoc
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc@${{ env.PROTOC_VERSION }}
+
+      - uses: actions/checkout@v3
+
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Cargo build
+        run: |
+          cargo build
+          mv ./target/debug/sqld /usr/local/bin
+          sqld --version
+
+      - name: Download MinIO binary
+        run: |
+          wget -q https://dl.min.io/server/minio/release/linux-amd64/minio -O minio
+          chmod +x minio
+          mv minio /usr/local/bin
+          minio --version
+
+      - name: Nemesis tests checkout
+        uses: actions/checkout@v3
+        with:
+          repository: tursodatabase/tursotest
+          ref: "main"
+          path: "nemesis-tests"
+          token: ${{ secrets.ACCESS_TOKEN_TURSO_TEST }}
+
+      - name: Build nemesis test
+        uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.21.4'
+      - run: |
+          cd nemesis-tests
+          go build -o ../tursotests cmd/tursotest/main.go
+
+      - name: Run nemesis tests
+        run: |
+          ./tursotests nemesis local


### PR DESCRIPTION
This PR adds a Github Workflow to run [Nemesis tests](https://github.com/tursodatabase/tursotest/tree/main/internal/nemesis) in local mode. In local mode, it spawns multiple libsql-server and minio processes and runs the test suite. 

I have added Nemesis test workflow separately than `Run Tests`. There is a possibility of false positive alert (the code is new) and separate work flow makes it easier to distinguish. 