### PR TITLE
fix snapshot compaction

### DIFF
--- a/libsql-server/src/replication/primary/logger.rs
+++ b/libsql-server/src/replication/primary/logger.rs
@@ -625,7 +625,7 @@ impl LogFile {
         tracing::info!("performing log compaction");
         // To perform the compaction, we create a new, empty file in the `to_compact` directory.
         // We will then atomically swap that file with the current log file.
-        // I case of crash, when filling the compactor job queue, if we find that we find a log
+        // In case of a crash, when filling the compactor job queue, if we find that we find a log
         // file that doesn't contains only a header, we can safely assume that it was from a
         // previous crash that happenned in the middle of this operation.
         let to_compact_id = Uuid::new_v4();


### PR DESCRIPTION
This PR fixes a bug in snapshot compaction because I changed the channel type used for compaction from a 0 sized crossbeam to a 1 sized tokio channel. This created a data race in the wallog swap, and caused the compactor to crash.

I also made the log merger non-blocking, which should improve tail latencies quite significantly for large databases.

Finally, I have added extended  testing to this feature to prevent future regression.

close #647 
