### PR TITLE
Notify all waiting connections on transaction end

### DIFF
--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -564,7 +564,7 @@ impl<W: WalHook> Connection<W> {
 
                     drop(maybe_state_slot);
 
-                    state.notify.notify_one();
+                    state.notify.notify_waiters();
                 }
                 // nothing to do
                 (_, _) => (),


### PR DESCRIPTION
This PR fixes a bug with lock-stealing when only a single connection would be notified when the lock was returned. The could cause some connections to never be notified, and only try to re-acquire the lock when the timeout had passed. Instead, we now notify all waiters, and let them wait again for a new slot.
