### PR TITLE
libsql: port row deserializer from rust client

### DIFF
--- a/libsql/src/deserialize_row.rs
+++ b/libsql/src/deserialize_row.rs
@@ -1,0 +1,99 @@
+use crate::{Row, Value};
+use serde::de::{
+    value::{Error as DeError, SeqDeserializer},
+    Error, IntoDeserializer, MapAccess, Visitor,
+};
+use serde::{Deserialize, Deserializer};
+
+struct RowDeserializer<'de> {
+    row: &'de Row,
+}
+
+impl<'de> Deserializer<'de> for RowDeserializer<'de> {
+    type Error = DeError;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(DeError::custom("Expects a struct"))
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        struct RowMapAccess<'a> {
+            row: &'a Row,
+            idx: std::ops::Range<usize>,
+            value: Option<Value>,
+        }
+
+        impl<'de> MapAccess<'de> for RowMapAccess<'de> {
+            type Error = DeError;
+
+            fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+            where
+                K: serde::de::DeserializeSeed<'de>,
+            {
+                match self.idx.next() {
+                    None => Ok(None),
+                    Some(i) => {
+                        let value = self
+                            .row
+                            .get_value(i as i32)
+                            .map_err(|e| DeError::custom(e))?;
+                        self.value = Some(value);
+                        self.row
+                            .column_name(i as i32)
+                            .map(|name| seed.deserialize(name.into_deserializer()))
+                            .transpose()
+                    }
+                }
+            }
+
+            fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+            where
+                V: serde::de::DeserializeSeed<'de>,
+            {
+                let value = self
+                    .value
+                    .take()
+                    .ok_or(DeError::custom("Expects a value but row is exhausted"))?;
+
+                match value {
+                    Value::Text(value) => seed.deserialize(value.into_deserializer()),
+                    Value::Null => seed.deserialize(().into_deserializer()),
+                    Value::Integer(value) => seed.deserialize(value.into_deserializer()),
+                    Value::Real(value) => seed.deserialize(value.into_deserializer()),
+                    Value::Blob(value) => {
+                        let seq = SeqDeserializer::new(value.iter().cloned());
+                        seed.deserialize(seq)
+                    }
+                }
+            }
+        }
+
+        visitor.visit_map(RowMapAccess {
+            row: self.row,
+            idx: 0..self.row.inner.column_count(),
+            value: None,
+        })
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map enum identifier ignored_any
+    }
+}
+
+pub fn from_row<'de, T: Deserialize<'de>>(row: &'de Row) -> Result<T, DeError> {
+    let de = RowDeserializer { row };
+    T::deserialize(de)
+}

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -190,6 +190,10 @@ impl RowInner for Row {
             Err(crate::Error::ColumnNotFound(idx))
         }
     }
+
+    fn column_count(&self) -> usize {
+        self.cols.len()
+    }
 }
 
 fn bind_params(params: Params, stmt: &mut Stmt) {

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -87,6 +87,9 @@ mod statement;
 mod transaction;
 mod value;
 
+#[cfg(feature = "serde")]
+pub mod deserialize_row;
+
 pub use value::{Value, ValueRef, ValueType};
 
 cfg_hrana! {

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -162,6 +162,10 @@ impl RowInner for LibsqlRow {
     fn column_type(&self, idx: i32) -> Result<ValueType> {
         self.0.column_type(idx).map(ValueType::from)
     }
+
+    fn column_count(&self) -> usize {
+        self.0.stmt.column_count()
+    }
 }
 
 impl fmt::Debug for LibsqlRow {

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -648,6 +648,10 @@ impl RowInner for RemoteRow {
             .map(ValueType::from)
             .ok_or(Error::InvalidColumnType)
     }
+
+    fn column_count(&self) -> usize {
+        self.1.len()
+    }
 }
 
 pub(super) struct RemoteTx(pub(super) Option<RemoteConnection>);

--- a/libsql/src/rows.rs
+++ b/libsql/src/rows.rs
@@ -219,4 +219,5 @@ pub(crate) trait RowInner: fmt::Debug {
     fn column_str(&self, idx: i32) -> Result<&str>;
     fn column_name(&self, idx: i32) -> Option<&str>;
     fn column_type(&self, idx: i32) -> Result<ValueType>;
+    fn column_count(&self) -> usize;
 }


### PR DESCRIPTION
This PR ports [de.rs](https://github.com/libsql/libsql-client-rs/blob/main/src/de.rs) from libsql-client-rs so that `Row`s can be deserialized, attempting to resolve #614.

I'm adding a `column_count` method to the `RowInner` trait because I find it convenient for telling when to stop the iteration on the `Row` inside the `MapAccess` implementation. Alternatively, we can maintain a column index and stop the iteration as soon as `row.column_value` or `row.column_name` returns `Err` or `None`. (That would require some changes on the existing `RowInner` implementations.)