### PR TITLE
wasm: add `make wasi` command

### DIFF
--- a/libsql-sqlite3/.gitignore
+++ b/libsql-sqlite3/.gitignore
@@ -61,3 +61,4 @@ libsql
 /src-verify
 /crates/target/
 /has_tclsh*
+/libsql.wasm

--- a/libsql-sqlite3/Makefile.in
+++ b/libsql-sqlite3/Makefile.in
@@ -1651,6 +1651,7 @@ clean:
 	rm -f src-verify
 	rm -f custom.rws
 	rm -f has_tclsh84 has_tclsh85
+	rm -f libsql.wasm
 
 distclean:	clean
 	rm -f sqlite_cfg.h config.log config.status libtool Makefile sqlite3.pc libsql.pc sqlite3session.h \
@@ -1679,6 +1680,27 @@ sqlite3.dll: $(REAL_LIBOBJ) sqlite3.def
 #
 fiddle: sqlite3.c shell.c
 	make -C ext/wasm fiddle emcc_opt=-Os
+
+#
+# Wasm/WASI module
+# TODO: hardcode less parameters
+# TODO: detect if wasi sysroot exists: /usr/share/wasi-sysroot
+#
+wasi: sqlite3.c sqlite3.h
+	clang --target=wasm32-unknown-wasi \
+		-DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_OMIT_DEPRECATED -DSQLITE_OMIT_UTF16 \
+		-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_SHARED_MEM=1 \
+		-DSQLITE_TEMP_STORE=2 \
+		-DSQLITE_USE_URI=1 \
+		-DSQLITE_DEFAULT_UNIX_VFS=\"unix-none\" \
+		--sysroot /usr/share/wasi-sysroot \
+		-nostartfiles \
+		-Wl,--no-entry \
+		-Wl,--export-all \
+		-o libsql.wasm \
+		-v \
+		sqlite3.c
+
 
 #
 # Spell-checking for source comments

--- a/libsql-sqlite3/src/os_unix.c
+++ b/libsql-sqlite3/src/os_unix.c
@@ -95,7 +95,7 @@
 #include <time.h>
 #include <sys/time.h>    /* amalgamator: keep */
 #include <errno.h>
-#if (!defined(SQLITE_OMIT_WAL) || SQLITE_MAX_MMAP_SIZE>0) \
+#if (!defined(SQLITE_OMIT_SHARED_MEM) || SQLITE_MAX_MMAP_SIZE>0) \
   && !defined(SQLITE_WASI)
 # include <sys/mman.h>
 #endif
@@ -535,7 +535,7 @@ static struct unix_syscall {
 #endif
 #define osGeteuid   ((uid_t(*)(void))aSyscall[21].pCurrent)
 
-#if (!defined(SQLITE_OMIT_WAL) || SQLITE_MAX_MMAP_SIZE>0) \
+#if (!defined(SQLITE_OMIT_SHARED_MEM) || SQLITE_MAX_MMAP_SIZE>0) \
   && !defined(SQLITE_WASI)
   { "mmap",         (sqlite3_syscall_ptr)mmap,            0 },
 #else
@@ -543,7 +543,7 @@ static struct unix_syscall {
 #endif
 #define osMmap ((void*(*)(void*,size_t,int,int,int,off_t))aSyscall[22].pCurrent)
 
-#if (!defined(SQLITE_OMIT_WAL) || SQLITE_MAX_MMAP_SIZE>0) \
+#if (!defined(SQLITE_OMIT_SHARED_MEM) || SQLITE_MAX_MMAP_SIZE>0) \
   && !defined(SQLITE_WASI)
   { "munmap",       (sqlite3_syscall_ptr)munmap,          0 },
 #else
@@ -551,14 +551,14 @@ static struct unix_syscall {
 #endif
 #define osMunmap ((int(*)(void*,size_t))aSyscall[23].pCurrent)
 
-#if HAVE_MREMAP && (!defined(SQLITE_OMIT_WAL) || SQLITE_MAX_MMAP_SIZE>0)
+#if HAVE_MREMAP && (!defined(SQLITE_OMIT_SHARED_MEM) || SQLITE_MAX_MMAP_SIZE>0)
   { "mremap",       (sqlite3_syscall_ptr)mremap,          0 },
 #else
   { "mremap",       (sqlite3_syscall_ptr)0,               0 },
 #endif
 #define osMremap ((void*(*)(void*,size_t,size_t,int,...))aSyscall[24].pCurrent)
 
-#if !defined(SQLITE_OMIT_WAL) || SQLITE_MAX_MMAP_SIZE>0
+#if !defined(SQLITE_OMIT_SHARED_MEM) || SQLITE_MAX_MMAP_SIZE>0
   { "getpagesize",  (sqlite3_syscall_ptr)unixGetpagesize, 0 },
 #else
   { "getpagesize",  (sqlite3_syscall_ptr)0,               0 },
@@ -3983,7 +3983,7 @@ static void unixModeBit(unixFile *pFile, unsigned char mask, int *pArg){
 
 /* Forward declaration */
 static int unixGetTempname(int nBuf, char *zBuf);
-#ifndef SQLITE_OMIT_WAL
+#ifndef SQLITE_OMIT_SHARED_MEM
  static int unixFcntlExternalReader(unixFile*, int*);
 #endif
 
@@ -4104,7 +4104,7 @@ static int unixFileControl(sqlite3_file *id, int op, void *pArg){
 #endif /* SQLITE_ENABLE_LOCKING_STYLE && defined(__APPLE__) */
 
     case SQLITE_FCNTL_EXTERNAL_READER: {
-#ifndef SQLITE_OMIT_WAL
+#ifndef SQLITE_OMIT_SHARED_MEM
       return unixFcntlExternalReader((unixFile*)id, (int*)pArg);
 #else
       *(int*)pArg = 0;
@@ -4257,7 +4257,7 @@ static int unixDeviceCharacteristics(sqlite3_file *id){
   return pFd->deviceCharacteristics;
 }
 
-#if !defined(SQLITE_OMIT_WAL) || SQLITE_MAX_MMAP_SIZE>0
+#if !defined(SQLITE_OMIT_SHARED_MEM) || SQLITE_MAX_MMAP_SIZE>0
 
 /*
 ** Return the system page size.
@@ -4275,9 +4275,9 @@ static int unixGetpagesize(void){
 #endif
 }
 
-#endif /* !defined(SQLITE_OMIT_WAL) || SQLITE_MAX_MMAP_SIZE>0 */
+#endif /* !defined(SQLITE_OMIT_SHARED_MEM) || SQLITE_MAX_MMAP_SIZE>0 */
 
-#ifndef SQLITE_OMIT_WAL
+#ifndef SQLITE_OMIT_SHARED_MEM
 
 /*
 ** Object used to represent an shared memory buffer.
@@ -5143,7 +5143,7 @@ static int unixShmUnmap(
 # define unixShmLock    0
 # define unixShmBarrier 0
 # define unixShmUnmap   0
-#endif /* #ifndef SQLITE_OMIT_WAL */
+#endif /* #ifndef SQLITE_OMIT_SHARED_MEM */
 
 #if SQLITE_MAX_MMAP_SIZE>0
 /*
@@ -8105,7 +8105,7 @@ int sqlite3_os_init(void){
 #endif
   unixBigLock = sqlite3MutexAlloc(SQLITE_MUTEX_STATIC_VFS1);
 
-#ifndef SQLITE_OMIT_WAL
+#ifndef SQLITE_OMIT_SHARED_MEM
   /* Validate lock assumptions */
   assert( SQLITE_SHM_NLOCK==8 );  /* Number of available locks */
   assert( UNIX_SHM_BASE==120  );  /* Start of locking area */

--- a/libsql-sqlite3/src/sqlite.h.in
+++ b/libsql-sqlite3/src/sqlite.h.in
@@ -10855,8 +10855,9 @@ int sqlite3_deserialize(
 #if defined(__wasi__)
 # undef SQLITE_WASI
 # define SQLITE_WASI 1
-# undef SQLITE_OMIT_WAL
-# define SQLITE_OMIT_WAL 1/* because it requires shared memory APIs */
+// NOTICE: we do support WAL mode, we just don't support shared memory
+//# undef SQLITE_OMIT_WAL
+//# define SQLITE_OMIT_WAL 1/* because it requires shared memory APIs */
 # ifndef SQLITE_OMIT_LOAD_EXTENSION
 #  define SQLITE_OMIT_LOAD_EXTENSION
 # endif

--- a/libsql-sqlite3/src/sqliteInt.h
+++ b/libsql-sqlite3/src/sqliteInt.h
@@ -50,6 +50,12 @@
 #  define SQLITE_TCLAPI
 #endif
 
+// NOTICE: libSQL extension: disabled WAL also implies we don't want shared memory via mmap
+#ifdef SQLITE_OMIT_WAL
+# undef SQLITE_OMIT_SHARED_MEM
+# define SQLITE_OMIT_SHARED_MEM 1
+#endif
+
 /*
 ** Include the header file used to customize the compiler options for MSVC.
 ** This should be done first so that it can successfully prevent spurious


### PR DESCRIPTION
It is not directly tested or usable yet, and depends on having wasi-libc library available at /usr/share/wasi-sysroot.

Still, it compiled, so it's a nice start.

`make wasi` produces `libsql.wasm` module.
Future work includes using this module to run a WebAssembly app in a runtime that supports WASI, using `libsql.wasm` as the database implementation.

The patch is based on splitting SQLITE_OMIT_WAL into SQLITE_OMIT_SHARED_MEM, so that we can still compile WAL mode, just without shared memory, so still usable with exclusive mode or via libSQL's virtual WAL.