### PR TITLE
fix embedded replication

### DIFF
--- a/libsql-replication/src/replicator.rs
+++ b/libsql-replication/src/replicator.rs
@@ -77,6 +77,8 @@ pub trait ReplicatorClient {
     async fn commit_frame_no(&mut self, frame_no: FrameNo) -> Result<(), Error>;
     /// Returns the currently committed replication index
     fn committed_frame_no(&self) -> Option<FrameNo>;
+    /// rollback the client to previously commited index.
+    fn rollback(&mut self);
 }
 
 #[async_trait::async_trait]
@@ -120,6 +122,13 @@ where
         match self {
             Either::Left(a) => a.committed_frame_no(),
             Either::Right(b) => b.committed_frame_no(),
+        }
+    }
+
+    fn rollback(&mut self) {
+        match self {
+            Either::Left(a) => a.rollback(),
+            Either::Right(b) => b.rollback(),
         }
     }
 }
@@ -342,6 +351,8 @@ mod test {
             fn committed_frame_no(&self) -> Option<FrameNo> {
                 unreachable!()
             }
+
+            fn rollback(&mut self) {}
         }
 
         let mut replicator = Replicator::new(Client, tmp.path().to_path_buf(), 10000)
@@ -384,6 +395,7 @@ mod test {
             fn committed_frame_no(&self) -> Option<FrameNo> {
                 unreachable!()
             }
+            fn rollback(&mut self) {}
         }
 
         let mut replicator = Replicator::new(Client, tmp.path().to_path_buf(), 10000)
@@ -427,6 +439,7 @@ mod test {
             fn committed_frame_no(&self) -> Option<FrameNo> {
                 unreachable!()
             }
+            fn rollback(&mut self) {}
         }
 
         let mut replicator = Replicator::new(Client, tmp.path().to_path_buf(), 10000)
@@ -470,6 +483,7 @@ mod test {
             fn committed_frame_no(&self) -> Option<FrameNo> {
                 unreachable!()
             }
+            fn rollback(&mut self) {}
         }
 
         let mut replicator = Replicator::new(Client, tmp.path().to_path_buf(), 10000)
@@ -511,6 +525,7 @@ mod test {
             fn committed_frame_no(&self) -> Option<FrameNo> {
                 unreachable!()
             }
+            fn rollback(&mut self) {}
         }
 
         let mut replicator = Replicator::new(Client, tmp.path().to_path_buf(), 10000)
@@ -552,6 +567,7 @@ mod test {
             fn committed_frame_no(&self) -> Option<FrameNo> {
                 unreachable!()
             }
+            fn rollback(&mut self) {}
         }
 
         let mut replicator = Replicator::new(Client, tmp.path().to_path_buf(), 10000)
@@ -594,6 +610,7 @@ mod test {
             fn committed_frame_no(&self) -> Option<FrameNo> {
                 unreachable!()
             }
+            fn rollback(&mut self) {}
         }
 
         let mut replicator = Replicator::new(Client, tmp.path().to_path_buf(), 10000)
@@ -636,6 +653,7 @@ mod test {
             fn committed_frame_no(&self) -> Option<FrameNo> {
                 unreachable!()
             }
+            fn rollback(&mut self) {}
         }
 
         let mut replicator = Replicator::new(Client, tmp.path().to_path_buf(), 10000)
@@ -717,6 +735,7 @@ mod test {
             fn committed_frame_no(&self) -> Option<FrameNo> {
                 unimplemented!()
             }
+            fn rollback(&mut self) {}
         }
 
         let client = Client {

--- a/libsql-replication/src/replicator.rs
+++ b/libsql-replication/src/replicator.rs
@@ -169,6 +169,11 @@ impl<C: ReplicatorClient> Replicator<C> {
         })
     }
 
+    /// for a handshake on next call to replicate.
+    pub fn force_handshake(&mut self) {
+        self.state = ReplicatorState::NeedHandshake;
+    }
+
     pub fn client_mut(&mut self) -> &mut C {
         &mut self.client
     }
@@ -225,6 +230,7 @@ impl<C: ReplicatorClient> Replicator<C> {
 
         // in case of error we rollback the current injector transaction, and start over.
         if ret.is_err() {
+            self.client.rollback();
             self.injector.lock().rollback();
         }
 

--- a/libsql-server/src/replication/replicator_client.rs
+++ b/libsql-server/src/replication/replicator_client.rs
@@ -138,5 +138,5 @@ impl ReplicatorClient for Client {
         self.meta.current_frame_no()
     }
 
-    fn rollback(&mut self) { }
+    fn rollback(&mut self) {}
 }

--- a/libsql-server/src/replication/replicator_client.rs
+++ b/libsql-server/src/replication/replicator_client.rs
@@ -137,4 +137,6 @@ impl ReplicatorClient for Client {
     fn committed_frame_no(&self) -> Option<FrameNo> {
         self.meta.current_frame_no()
     }
+
+    fn rollback(&mut self) { }
 }

--- a/libsql-server/tests/embedded_replica/mod.rs
+++ b/libsql-server/tests/embedded_replica/mod.rs
@@ -112,7 +112,7 @@ fn embedded_replica() {
             if key.kind() == metrics_util::MetricKind::Counter
                 && key.key().name() == "libsql_client_version"
             {
-                assert_eq!(val, &metrics_util::debugging::DebugValue::Counter(6));
+                assert_eq!(val, &metrics_util::debugging::DebugValue::Counter(8));
                 let label = key.key().labels().next().unwrap();
                 assert!(label.value().starts_with("libsql-rpc-"));
             }

--- a/libsql/src/replication/local_client.rs
+++ b/libsql/src/replication/local_client.rs
@@ -74,4 +74,6 @@ impl ReplicatorClient for LocalClient {
     fn committed_frame_no(&self) -> Option<FrameNo> {
         self.meta.current_frame_no()
     }
+
+    fn rollback(&mut self) {}
 }

--- a/libsql/src/replication/remote_client.rs
+++ b/libsql/src/replication/remote_client.rs
@@ -150,4 +150,8 @@ impl ReplicatorClient for RemoteClient {
     fn committed_frame_no(&self) -> Option<FrameNo> {
         self.meta.current_frame_no()
     }
+
+    fn rollback(&mut self) {
+        self.last_received = self.committed_frame_no()
+    }
 }

--- a/libsql/src/replication/remote_client.rs
+++ b/libsql/src/replication/remote_client.rs
@@ -19,6 +19,7 @@ pub struct RemoteClient {
     meta: WalIndexMeta,
     last_received: Option<FrameNo>,
     session_token: Option<Bytes>,
+    last_handshake_replication_index: Option<FrameNo>,
     // the replication log is dirty, reset the meta on next handshake
     dirty: bool,
 }
@@ -32,6 +33,7 @@ impl RemoteClient {
             last_received: None,
             session_token: None,
             dirty: false,
+            last_handshake_replication_index: None,
         })
     }
 
@@ -53,6 +55,10 @@ impl RemoteClient {
 
         req
     }
+
+    pub fn last_handshake_replication_index(&self) -> Option<u64> {
+        self.last_handshake_replication_index
+    }
 }
 
 #[async_trait::async_trait]
@@ -69,8 +75,10 @@ impl ReplicatorClient for RemoteClient {
         self.session_token = Some(hello.session_token.clone());
         if self.dirty {
             self.meta.reset();
+            self.last_received = None;
             self.dirty = false;
         }
+        let current_replication_index = hello.current_replication_index;
         if let Err(e) = self.meta.init_from_hello(hello) {
             // set the meta as dirty. The caller should catch the error and clean the db
             // file. On the next call to replicate, the db will be replicated from the new
@@ -81,6 +89,7 @@ impl ReplicatorClient for RemoteClient {
 
             Err(e)?;
         }
+        self.last_handshake_replication_index = current_replication_index;
         self.meta.flush().await?;
 
         Ok(())


### PR DESCRIPTION
Embedded replicas fetch frames in batches and need to resume replication at offset that are not necessarily on commit boundaries. When the replicator encounters an error and calls next_frames again, it expects the client to send frames from the previously known commit index. The embedded replica would instead try to fetch from the last received. This is fixed by adding a rollback method to the client to force fetch from previous commit index. Furthermore, the embedded replica now replicates to match the primary replication index on a call to `sync_oneshot`, and a handshake is forced on `sync_oneshot` to know the current primary index. That makes calling sync_oneshot more deterministic and prevent out-of-transaction boundaries syncs.