### PR TITLE
Support compiling libSQL to Wasm with virtual WAL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ members = [
   "xtask",
 ]
 
-exclude = [ "./libsql-sqlite3/ext/crr" ]
+exclude = [
+    "./libsql-sqlite3/ext/crr",
+    "./libsql-sqlite3/ext/libsql-wasi-demo",
+]
 
 [profile.release]
 codegen-units = 1

--- a/libsql-sqlite3/Makefile.in
+++ b/libsql-sqlite3/Makefile.in
@@ -1688,6 +1688,7 @@ fiddle: sqlite3.c shell.c
 #
 wasi: sqlite3.c sqlite3.h
 	clang --target=wasm32-unknown-wasi \
+		-I . \
 		-DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_OMIT_DEPRECATED -DSQLITE_OMIT_UTF16 \
 		-DSQLITE_OMIT_SHARED_CACHE -DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_SHARED_MEM=1 \
 		-DSQLITE_TEMP_STORE=2 \
@@ -1699,7 +1700,7 @@ wasi: sqlite3.c sqlite3.h
 		-Wl,--export-all \
 		-o libsql.wasm \
 		-v \
-		sqlite3.c
+		sqlite3.c ext/wasi/vfs.c
 
 
 #

--- a/libsql-sqlite3/ext/libsql-wasi-demo/.gitignore
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/libsql-sqlite3/ext/libsql-wasi-demo/Cargo.toml
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
+rand = "0.8.5"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 wasmtime = "15.0.0"

--- a/libsql-sqlite3/ext/libsql-wasi-demo/Cargo.toml
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "libsql-wasi-demo"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.75"
+wasmtime = "15.0.0"
+wasmtime-wasi = "15.0.0"

--- a/libsql-sqlite3/ext/libsql-wasi-demo/Cargo.toml
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 wasmtime = "15.0.0"
 wasmtime-wasi = "15.0.0"

--- a/libsql-sqlite3/ext/libsql-wasi-demo/src/main.rs
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/src/main.rs
@@ -1,0 +1,57 @@
+mod memory;
+mod vfs;
+
+// FIXME: add any state we need to pass - WasiCtx is here to get free println! and stuff
+type State = WasiCtx;
+
+use anyhow::Context;
+use wasmtime::{Caller, Engine, Linker, Module, Store};
+use wasmtime_wasi::{WasiCtx, WasiCtxBuilder};
+
+fn main() -> anyhow::Result<()> {
+    let engine = Engine::default();
+
+    let libsql_module = Module::from_file(&engine, "../../libsql.wasm")?;
+
+    let mut linker = Linker::new(&engine);
+    vfs::link(&mut linker)?;
+    wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
+
+    std::fs::create_dir("/tmp/wasm-demo").ok();
+    // FIXME: we might as well not need it with VFS and virtual WAL, it's here to make stuff easier for debugging
+    let wasi = WasiCtxBuilder::new()
+        .inherit_stdio()
+        .inherit_args()?
+        .build();
+
+    let mut store = Store::new(&engine, wasi);
+    let instance = linker.instantiate(&mut store, &libsql_module)?;
+
+    let malloc = instance.get_typed_func::<i32, i32>(&mut store, "malloc")?;
+    let free = instance.get_typed_func::<i32, ()>(&mut store, "free")?;
+
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .context("memory export not found")?;
+
+    let db_path = malloc.call(&mut store, 16)?;
+    memory.write(&mut store, db_path as usize, b"/tmp/wasm-demo.db\0")?;
+
+    let libsql_wasi_init = instance.get_typed_func::<(), ()>(&mut store, "libsql_wasi_init")?;
+    let open_func = instance.get_typed_func::<i32, i32>(&mut store, "libsql_wasi_open_db")?;
+    let exec_func = instance.get_typed_func::<(i32, i32), i32>(&mut store, "libsql_wasi_exec")?;
+    let close_func = instance.get_typed_func::<i32, i32>(&mut store, "sqlite3_close")?;
+
+    libsql_wasi_init.call(&mut store, ())?;
+    let db = open_func.call(&mut store, db_path)?;
+    let sql = malloc.call(&mut store, 64)?;
+    memory.write(&mut store, sql as usize, b"PRAGMA journal_mode=WAL;\0")?;
+    let rc = exec_func.call(&mut store, (db, sql))?;
+    let _ = free.call(&mut store, sql)?;
+    let _ = close_func.call(&mut store, db)?;
+    let _ = free.call(&mut store, db_path)?;
+
+    println!("rc: {rc}");
+
+    Ok(())
+}

--- a/libsql-sqlite3/ext/libsql-wasi-demo/src/main.rs
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/src/main.rs
@@ -45,9 +45,9 @@ fn main() -> anyhow::Result<()> {
     let sql = malloc.call(&mut store, 64)?;
     memory.write(&mut store, sql as usize, b"PRAGMA journal_mode=WAL;\0")?;
     let rc = exec_func.call(&mut store, (db, sql))?;
-    let _ = free.call(&mut store, sql)?;
+    free.call(&mut store, sql)?;
     let _ = close_func.call(&mut store, db)?;
-    let _ = free.call(&mut store, db_path)?;
+    free.call(&mut store, db_path)?;
 
     println!("rc: {rc}");
 

--- a/libsql-sqlite3/ext/libsql-wasi-demo/src/main.rs
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/src/main.rs
@@ -5,7 +5,7 @@ mod vfs;
 type State = WasiCtx;
 
 use anyhow::Context;
-use wasmtime::{Caller, Engine, Linker, Module, Store};
+use wasmtime::{Engine, Linker, Module, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder};
 
 fn main() -> anyhow::Result<()> {

--- a/libsql-sqlite3/ext/libsql-wasi-demo/src/main.rs
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/src/main.rs
@@ -1,4 +1,4 @@
-mod memory;
+pub mod memory;
 mod vfs;
 
 // FIXME: add any state we need to pass - WasiCtx is here to get free println! and stuff
@@ -17,7 +17,6 @@ fn main() -> anyhow::Result<()> {
     vfs::link(&mut linker)?;
     wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
 
-    std::fs::create_dir("/tmp/wasm-demo").ok();
     // FIXME: we might as well not need it with VFS and virtual WAL, it's here to make stuff easier for debugging
     let wasi = WasiCtxBuilder::new()
         .inherit_stdio()

--- a/libsql-sqlite3/ext/libsql-wasi-demo/src/main.rs
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/src/main.rs
@@ -1,7 +1,6 @@
 pub mod memory;
 mod vfs;
 
-// FIXME: add any state we need to pass - WasiCtx is here to get free println! and stuff
 type State = WasiCtx;
 
 use anyhow::Context;
@@ -9,6 +8,7 @@ use wasmtime::{Engine, Linker, Module, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder};
 
 fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::try_init().ok();
     let engine = Engine::default();
 
     let libsql_module = Module::from_file(&engine, "../../libsql.wasm")?;
@@ -17,7 +17,6 @@ fn main() -> anyhow::Result<()> {
     vfs::link(&mut linker)?;
     wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
 
-    // FIXME: we might as well not need it with VFS and virtual WAL, it's here to make stuff easier for debugging
     let wasi = WasiCtxBuilder::new()
         .inherit_stdio()
         .inherit_args()?

--- a/libsql-sqlite3/ext/libsql-wasi-demo/src/memory.rs
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/src/memory.rs
@@ -1,0 +1,67 @@
+// Shamelessly stolen from Honza - thx man!!!
+
+use anyhow::{bail, ensure, Context as _, Result};
+
+pub type Ptr = i32;
+
+pub fn slice(memory: &[u8], ptr: Ptr, len: usize) -> Result<&[u8]> {
+    let ptr = ptr as usize;
+    ensure!(ptr != 0 && ptr <= memory.len(), "Invalid pointer");
+    ensure!(ptr + len <= memory.len(), "Invalid pointer and length");
+    Ok(&memory[ptr..][..len])
+}
+
+pub fn slice_mut(memory: &mut [u8], ptr: Ptr, len: usize) -> Result<&mut [u8]> {
+    let ptr = ptr as usize;
+    ensure!(ptr != 0 && ptr <= memory.len(), "Invalid pointer");
+    ensure!(ptr + len <= memory.len(), "Invalid pointer and length");
+    Ok(&mut memory[ptr..][..len])
+}
+
+pub fn read_vec(memory: &[u8], ptr: Ptr, len: usize) -> Result<Vec<u8>> {
+    slice(memory, ptr, len).map(|slice| slice.to_vec())
+}
+
+pub fn read_cstr(memory: &[u8], cstr_ptr: Ptr) -> Result<String> {
+    let Some(data) = read_cstr_bytes(memory, cstr_ptr) else {
+        bail!("Invalid pointer to C string")
+    };
+    String::from_utf8(data).context("Invalid data in C string")
+}
+
+pub fn read_cstr_or_null(memory: &[u8], cstr_ptr: Ptr) -> Result<Option<String>> {
+    if cstr_ptr != 0 {
+        read_cstr(memory, cstr_ptr).map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn read_cstr_lossy(memory: &[u8], cstr_ptr: Ptr) -> String {
+    match read_cstr_bytes(memory, cstr_ptr) {
+        Some(data) => match String::from_utf8(data) {
+            Ok(string) => string,
+            Err(err) => String::from_utf8_lossy(err.as_bytes()).into_owned(),
+        },
+        None => String::new(),
+    }
+}
+
+pub fn read_cstr_bytes(memory: &[u8], cstr_ptr: Ptr) -> Option<Vec<u8>> {
+    let cstr_ptr = cstr_ptr as usize;
+    if cstr_ptr == 0 || cstr_ptr >= memory.len() {
+        return None;
+    }
+
+    let data = &memory[cstr_ptr..];
+    let mut strlen = 0;
+    loop {
+        match data.get(strlen) {
+            None => return None,
+            Some(0) => break,
+            Some(_) => strlen += 1,
+        }
+    }
+
+    Some(data[..strlen].to_vec())
+}

--- a/libsql-sqlite3/ext/libsql-wasi-demo/src/vfs.rs
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/src/vfs.rs
@@ -1,6 +1,14 @@
 use super::{memory, State};
 use wasmtime::{Caller, Linker, Memory};
 
+const SQLITE_DATAONLY: i32 = 0x00010;
+const SQLITE_IOERR_READ: i32 = 266;
+const SQLITE_IOERR_SHORT_READ: i32 = 522;
+const SQLITE_IOERR_WRITE: i32 = 778;
+
+const SQLITE_ACCESS_EXISTS: i32 = 0;
+const SQLITE_ACCESS_READWRITE: i32 = 1;
+
 /* Reference from C:
 typedef struct libsql_wasi_file {
     const struct sqlite3_io_methods* pMethods;
@@ -24,7 +32,7 @@ fn get_file(memory: &[u8], file_ptr: i32) -> &'static mut std::fs::File {
             .try_into()
             .unwrap(),
     );
-    let mut file: &'static mut std::fs::File = unsafe { &mut *(file_fd as *mut std::fs::File) };
+    let file: &'static mut std::fs::File = unsafe { &mut *(file_fd as *mut std::fs::File) };
 
     tracing::debug!("Metadata: {:?}", file.metadata());
     file
@@ -32,7 +40,7 @@ fn get_file(memory: &[u8], file_ptr: i32) -> &'static mut std::fs::File {
 
 fn open_fd(mut caller: Caller<'_, State>, name: i32, flags: i32) -> anyhow::Result<i64> {
     let memory = get_memory(&mut caller);
-    let (memory, _state) = memory.data_and_store_mut(&mut caller);
+    let memory = memory.data_mut(&mut caller);
 
     let name = memory::read_cstr(memory, name)?;
 
@@ -50,40 +58,67 @@ fn open_fd(mut caller: Caller<'_, State>, name: i32, flags: i32) -> anyhow::Resu
 
 fn delete(
     mut caller: Caller<'_, State>,
-    vfs: i32,
+    _vfs: i32,
     name: i32,
     sync_dir: i32,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
+    let memory = memory.data_mut(&mut caller);
 
-    tracing::debug!("HOST DELETE CALLED");
+    let name = memory::read_cstr(memory, name)?;
+    tracing::debug!("HOST DELETE: {name:?}, sync_dir={sync_dir}");
+
+    let _ = std::fs::remove_file(&name);
     Ok(0)
 }
 
 fn access(
     mut caller: Caller<'_, State>,
-    vfs: i32,
+    _vfs: i32,
     name: i32,
     flags: i32,
     res_out: i32,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
+    let memory = memory.data_mut(&mut caller);
 
-    tracing::debug!("HOST ACCESS CALLED");
+    let name = memory::read_cstr(memory, name)?;
+    tracing::debug!("HOST ACCESS: {name:?} {flags:x}");
+
+    let res_out = memory::slice_mut(memory, res_out, 4)?;
+    if flags == SQLITE_ACCESS_EXISTS {
+        if std::fs::metadata(&name).is_ok() {
+            res_out[0] = 1;
+        } else {
+            res_out[0] = 0;
+        }
+    } else if flags == SQLITE_ACCESS_READWRITE {
+        if std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&name)
+            .is_ok()
+        {
+            res_out[0] = 1;
+        } else {
+            res_out[0] = 0;
+        }
+    } else {
+        res_out[0] = 0;
+    }
+
     Ok(0)
 }
 
 fn full_pathname(
     mut caller: Caller<'_, State>,
-    vfs: i32,
+    _vfs: i32,
     name: i32,
     n_out: i32,
     out: i32,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, _state) = memory.data_and_store_mut(&mut caller);
+    let memory = memory.data_mut(&mut caller);
 
     let name = memory::read_cstr(memory, name)?;
     let out = memory::slice_mut(memory, out, n_out as usize)?;
@@ -94,64 +129,91 @@ fn full_pathname(
 
 fn randomness(
     mut caller: Caller<'_, State>,
-    vfs: i32,
+    _vfs: i32,
     n_byte: i32,
     out: i32,
 ) -> anyhow::Result<i32> {
-    let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
+    use rand::Rng;
 
-    tracing::debug!("HOST RANDOMNESS CALLED");
+    let memory = get_memory(&mut caller);
+    let memory = memory.data_mut(&mut caller);
+
+    let out = memory::slice_mut(memory, out, n_byte as usize)?;
+    let mut rng = rand::thread_rng();
+    rng.fill(out);
+
+    tracing::debug!("HOST RANDOMNESS: {n_byte} {out:0x?}");
     Ok(0)
 }
 
-fn sleep(mut caller: Caller<'_, State>, vfs: i32, microseconds: i32) -> anyhow::Result<i32> {
+fn sleep(mut caller: Caller<'_, State>, _vfs: i32, microseconds: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
     let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
-    tracing::debug!("HOST SLEEP CALLED");
+    tracing::debug!("HOST SLEEP: {microseconds}ms");
+    std::thread::sleep(std::time::Duration::from_micros(microseconds as u64));
     Ok(0)
 }
 
-fn current_time(mut caller: Caller<'_, State>, vfs: i32, out: i32) -> anyhow::Result<i32> {
+fn current_time(mut caller: Caller<'_, State>, _vfs: i32, out: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
+    let memory = memory.data_mut(&mut caller);
 
-    tracing::debug!("HOST CURRENT TIME CALLED");
+    tracing::debug!("HOST CURRENT TIME");
+
+    let out = memory::slice_mut(memory, out, 8)?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as f64;
+
+    out[0..8].copy_from_slice(&now.to_le_bytes());
     Ok(0)
 }
 
 fn get_last_error(
     mut caller: Caller<'_, State>,
-    vfs: i32,
+    _vfs: i32,
     i: i32,
     out: i32,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
+    let memory = memory.data_mut(&mut caller);
 
-    tracing::debug!("HOST GET LAST ERROR CALLED");
+    tracing::debug!("HOST GET LAST ERROR: STUB");
+
+    let out = memory::slice_mut(memory, out, i as usize)?;
+    out[0] = 0;
     Ok(0)
 }
 
-fn current_time_64(mut caller: Caller<'_, State>, vfs: i32, out: i32) -> anyhow::Result<i32> {
+fn current_time_64(mut caller: Caller<'_, State>, _vfs: i32, out: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
+    let memory = memory.data_mut(&mut caller);
 
-    tracing::debug!("HOST CURRENT TIME 64 CALLED");
+    tracing::debug!("HOST CURRENT TIME 64");
+
+    let out = memory::slice_mut(memory, out, 8)?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+
+    out[0..8].copy_from_slice(&now.to_le_bytes());
+
     Ok(0)
 }
 
 fn close(mut caller: Caller<'_, State>, file: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, _state) = memory.data_and_store_mut(&mut caller);
+    let memory = memory.data_mut(&mut caller);
 
     let file_fd = i64::from_le_bytes(
         memory[file as usize + 8..file as usize + 8 + 8]
             .try_into()
             .unwrap(),
     );
-    let file = unsafe { Box::from_raw(file_fd as *mut std::fs::File) };
+    let _file = unsafe { Box::from_raw(file_fd as *mut std::fs::File) };
 
     Ok(0)
 }
@@ -166,7 +228,7 @@ fn read(
     use std::io::{Read, Seek};
 
     let memory = get_memory(&mut caller);
-    let (memory, _state) = memory.data_and_store_mut(&mut caller);
+    let memory = memory.data_mut(&mut caller);
 
     tracing::debug!("HOST READ CALLED: {amt} bytes starting at {offset}");
 
@@ -176,12 +238,15 @@ fn read(
     let buf = memory::slice_mut(memory, buf, amt as usize)?;
     match file.read_exact(buf) {
         Ok(_) => Ok(0),
-        Err(e) => {
-            let errno = e.raw_os_error().unwrap_or(0);
-            tracing::debug!("Assuming short read, got: {e}");
-            // 522 == SQLITE_IOERR_SHORT_READ
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+            tracing::debug!("(short read)");
+            // VFS layer expects filling the buffer with zeros on short reads
             buf.fill(0);
-            Ok(522)
+            Ok(SQLITE_IOERR_SHORT_READ)
+        }
+        Err(e) => {
+            tracing::error!("read error: {e}");
+            Ok(SQLITE_IOERR_READ)
         }
     }
 }
@@ -196,9 +261,9 @@ fn write(
     use std::io::{Seek, Write};
 
     let memory = get_memory(&mut caller);
-    let (memory, _state) = memory.data_and_store_mut(&mut caller);
+    let memory = memory.data_mut(&mut caller);
 
-    tracing::debug!("HOST WRITE CALLED");
+    tracing::debug!("HOST WRITE CALLED: {amt} bytes starting at {offset}");
 
     let file = get_file(memory, file);
     file.seek(std::io::SeekFrom::Start(offset as u64))?;
@@ -207,103 +272,53 @@ fn write(
     match file.write_all(buf) {
         Ok(_) => Ok(0),
         Err(e) => {
-            let errno = e.raw_os_error().unwrap_or(0);
-            tracing::debug!("Assuming short write, got: {e}");
-            // 778 == SQLITE_IOERR_WRITE
-            Ok(778)
+            tracing::error!("write error: {e}");
+            Ok(SQLITE_IOERR_WRITE)
         }
     }
 }
 
 fn truncate(mut caller: Caller<'_, State>, file: i32, size: i64) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
-    tracing::debug!("HOST TRUNCATE CALLED");
+    let memory = memory.data_mut(&mut caller);
+
+    let file = get_file(memory, file);
+    file.set_len(size as u64)?;
+
+    tracing::debug!("HOST TRUNCATE: {size} bytes");
     Ok(0)
 }
 
 fn sync(mut caller: Caller<'_, State>, file: i32, flags: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
-    tracing::debug!("HOST SYNC CALLED");
+    let memory = memory.data_mut(&mut caller);
+
+    tracing::debug!("HOST SYNC: flags={flags:x}");
+
+    let file = get_file(memory, file);
+    if flags & SQLITE_DATAONLY != 0 {
+        file.sync_data()?;
+    } else {
+        file.sync_all()?;
+    }
+
     Ok(0)
 }
 
-fn file_size(mut caller: Caller<'_, State>, file: i32, size: i32) -> anyhow::Result<i32> {
+fn file_size(mut caller: Caller<'_, State>, file: i32, size_ptr: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
-    tracing::debug!("HOST FILE SIZE CALLED");
+    let memory = memory.data_mut(&mut caller);
+    tracing::debug!("HOST FILE SIZE");
+
+    let file = get_file(memory, file);
+    let file_size = file.metadata()?.len() as i64;
+    memory[size_ptr as usize..size_ptr as usize + 8].copy_from_slice(&file_size.to_le_bytes());
+
     Ok(0)
-}
-
-fn lock(mut caller: Caller<'_, State>, file: i32, lock: i32) -> anyhow::Result<i32> {
-    let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
-    tracing::debug!("HOST LOCK CALLED");
-    Ok(0)
-}
-
-fn unlock(mut caller: Caller<'_, State>, file: i32, lock: i32) -> anyhow::Result<i32> {
-    let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
-    tracing::debug!("HOST UNLOCK CALLED");
-    Ok(0)
-}
-
-fn check_reserved_lock(
-    mut caller: Caller<'_, State>,
-    file: i32,
-    reserved_lock: i32,
-) -> anyhow::Result<i32> {
-    let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
-    tracing::debug!("HOST CHECK RESERVED LOCK CALLED");
-    Ok(0)
-}
-
-fn file_control(
-    mut caller: Caller<'_, State>,
-    file: i32,
-    op: i32,
-    arg: i32,
-) -> anyhow::Result<i32> {
-    let memory = get_memory(&mut caller);
-    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
-
-    tracing::debug!("HOST FILE CONTROL CALLED: op={op}, arg={arg}");
-    // 12 == SQLITE_NOTFOUND
-    Ok(12)
-}
-
-fn sector_size(mut caller: Caller<'_, State>, _file: i32) -> anyhow::Result<i32> {
-    tracing::debug!("HOST SECTOR SIZE CALLED");
-    Ok(512)
-}
-
-fn device_characteristics(mut caller: Caller<'_, State>, _file: i32) -> anyhow::Result<i32> {
-    /*
-       #define SQLITE_IOCAP_ATOMIC                 0x00000001
-       #define SQLITE_IOCAP_ATOMIC512              0x00000002
-       #define SQLITE_IOCAP_ATOMIC1K               0x00000004
-       #define SQLITE_IOCAP_ATOMIC2K               0x00000008
-       #define SQLITE_IOCAP_ATOMIC4K               0x00000010
-       #define SQLITE_IOCAP_ATOMIC8K               0x00000020
-       #define SQLITE_IOCAP_ATOMIC16K              0x00000040
-       #define SQLITE_IOCAP_ATOMIC32K              0x00000080
-       #define SQLITE_IOCAP_ATOMIC64K              0x00000100
-       #define SQLITE_IOCAP_SAFE_APPEND            0x00000200
-       #define SQLITE_IOCAP_SEQUENTIAL             0x00000400
-       #define SQLITE_IOCAP_UNDELETABLE_WHEN_OPEN  0x00000800
-       #define SQLITE_IOCAP_POWERSAFE_OVERWRITE    0x00001000
-       #define SQLITE_IOCAP_IMMUTABLE              0x00002000
-       #define SQLITE_IOCAP_BATCH_ATOMIC           0x00004000
-    */
-    // ATOMIC | SAFE_APPEND | SEQUENTIAL
-    tracing::debug!("dEVICE CHARACTERISTICS CALLED");
-    Ok(0x00000001 | 0x00000200 | 0x00000400)
 }
 
 pub fn link(linker: &mut Linker<State>) -> anyhow::Result<()> {
+    // VFS methods required by sqlite3_vfs
     linker.func_wrap("libsql_host", "open_fd", open_fd)?;
     linker.func_wrap("libsql_host", "delete", delete)?;
     linker.func_wrap("libsql_host", "access", access)?;
@@ -314,21 +329,16 @@ pub fn link(linker: &mut Linker<State>) -> anyhow::Result<()> {
     linker.func_wrap("libsql_host", "get_last_error", get_last_error)?;
     linker.func_wrap("libsql_host", "current_time_64", current_time_64)?;
 
+    // IO methods required by sqlite3_io_methods
     linker.func_wrap("libsql_host", "close", close)?;
     linker.func_wrap("libsql_host", "read", read)?;
     linker.func_wrap("libsql_host", "write", write)?;
     linker.func_wrap("libsql_host", "truncate", truncate)?;
     linker.func_wrap("libsql_host", "sync", sync)?;
     linker.func_wrap("libsql_host", "file_size", file_size)?;
-    linker.func_wrap("libsql_host", "lock", lock)?;
-    linker.func_wrap("libsql_host", "unlock", unlock)?;
-    linker.func_wrap("libsql_host", "check_reserved_lock", check_reserved_lock)?;
-    linker.func_wrap("libsql_host", "file_control", file_control)?;
-    linker.func_wrap("libsql_host", "sector_size", sector_size)?;
-    linker.func_wrap(
-        "libsql_host",
-        "device_characteristics",
-        device_characteristics,
-    )?;
+
+    // NOTICE: locking is handled as no-ops in the VFS layer,
+    // it is expected to be handled by the upper layers at the moment.
+
     Ok(())
 }

--- a/libsql-sqlite3/ext/libsql-wasi-demo/src/vfs.rs
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/src/vfs.rs
@@ -1,0 +1,260 @@
+use super::{memory, State};
+use wasmtime::{Caller, Linker, Memory};
+
+fn get_memory(caller: &mut Caller<'_, State>) -> Memory {
+    caller.get_export("memory").unwrap().into_memory().unwrap()
+}
+
+fn open_fd(mut caller: Caller<'_, State>, name: i32, flags: i32) -> anyhow::Result<i64> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    let name = memory::read_cstr(memory, name)?;
+
+    println!("HOST OPEN_FD CALLED: {name:?} {flags:0o}");
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(name)?;
+    let file = Box::new(file);
+
+    Ok(Box::into_raw(file) as i64)
+}
+
+fn delete(
+    mut caller: Caller<'_, State>,
+    vfs: i32,
+    name: i32,
+    sync_dir: i32,
+) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST DELETE CALLED");
+    Ok(0)
+}
+
+fn access(
+    mut caller: Caller<'_, State>,
+    vfs: i32,
+    name: i32,
+    flags: i32,
+    res_out: i32,
+) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST ACCESS CALLED");
+    Ok(0)
+}
+
+fn full_pathname(
+    mut caller: Caller<'_, State>,
+    vfs: i32,
+    name: i32,
+    n_out: i32,
+    out: i32,
+) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    let name = memory::read_cstr(memory, name)?;
+    let out = memory::slice_mut(memory, out, n_out as usize)?;
+
+    out[..name.len()].copy_from_slice(name.as_bytes());
+    Ok(0)
+}
+
+fn randomness(
+    mut caller: Caller<'_, State>,
+    vfs: i32,
+    n_byte: i32,
+    out: i32,
+) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST RANDOMNESS CALLED");
+    Ok(0)
+}
+
+fn sleep(mut caller: Caller<'_, State>, vfs: i32, microseconds: i32) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST SLEEP CALLED");
+    Ok(0)
+}
+
+fn current_time(mut caller: Caller<'_, State>, vfs: i32, out: i32) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST CURRENT TIME CALLED");
+    Ok(0)
+}
+
+fn get_last_error(
+    mut caller: Caller<'_, State>,
+    vfs: i32,
+    i: i32,
+    out: i32,
+) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST GET LAST ERROR CALLED");
+    Ok(0)
+}
+
+fn current_time_64(mut caller: Caller<'_, State>, vfs: i32, out: i32) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST CURRENT TIME 64 CALLED");
+    Ok(0)
+}
+
+fn close(mut caller: Caller<'_, State>, file: i32) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    // TODO: read the file pointer from guest memory and feed it to Box::from_raw
+    println!("HOST CLOSE CALLED");
+
+    Ok(0)
+}
+
+fn read(
+    mut caller: Caller<'_, State>,
+    file: i32,
+    buf: i32,
+    amt: i32,
+    offset: i64,
+) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST READ CALLED");
+    Ok(0)
+}
+
+fn write(
+    mut caller: Caller<'_, State>,
+    file: i32,
+    buf: i32,
+    amt: i32,
+    offset: i64,
+) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST WRITE CALLED");
+    Ok(0)
+}
+
+fn truncate(mut caller: Caller<'_, State>, file: i32, size: i64) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    println!("HOST TRUNCATE CALLED");
+    Ok(0)
+}
+
+fn sync(mut caller: Caller<'_, State>, file: i32, flags: i32) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    println!("HOST SYNC CALLED");
+    Ok(0)
+}
+
+fn file_size(mut caller: Caller<'_, State>, file: i32, size: i32) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    println!("HOST FILE SIZE CALLED");
+    Ok(0)
+}
+
+fn lock(mut caller: Caller<'_, State>, file: i32, lock: i32) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    println!("HOST LOCK CALLED");
+    Ok(0)
+}
+
+fn unlock(mut caller: Caller<'_, State>, file: i32, lock: i32) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    println!("HOST UNLOCK CALLED");
+    Ok(0)
+}
+
+fn check_reserved_lock(
+    mut caller: Caller<'_, State>,
+    file: i32,
+    reserved_lock: i32,
+) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    println!("HOST CHECK RESERVED LOCK CALLED");
+    Ok(0)
+}
+
+fn file_control(
+    mut caller: Caller<'_, State>,
+    file: i32,
+    op: i32,
+    arg: i32,
+) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST FILE CONTROL CALLED");
+    Ok(0)
+}
+
+fn sector_size(mut caller: Caller<'_, State>, file: i32) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST SECTOR SIZE CALLED");
+    Ok(0)
+}
+
+fn device_characteristics(mut caller: Caller<'_, State>, file: i32) -> anyhow::Result<i32> {
+    let memory = get_memory(&mut caller);
+    let (memory, state) = memory.data_and_store_mut(&mut caller);
+
+    println!("HOST DEVICE CHARACTERISTICS CALLED");
+    Ok(0)
+}
+
+pub fn link(linker: &mut Linker<State>) -> anyhow::Result<()> {
+    linker.func_wrap("libsql_host", "open_fd", open_fd)?;
+    linker.func_wrap("libsql_host", "delete", delete)?;
+    linker.func_wrap("libsql_host", "access", access)?;
+    linker.func_wrap("libsql_host", "full_pathname", full_pathname)?;
+    linker.func_wrap("libsql_host", "randomness", randomness)?;
+    linker.func_wrap("libsql_host", "sleep", sleep)?;
+    linker.func_wrap("libsql_host", "current_time", current_time)?;
+    linker.func_wrap("libsql_host", "get_last_error", get_last_error)?;
+    linker.func_wrap("libsql_host", "current_time_64", current_time_64)?;
+
+    linker.func_wrap("libsql_host", "close", close)?;
+    linker.func_wrap("libsql_host", "read", read)?;
+    linker.func_wrap("libsql_host", "write", write)?;
+    linker.func_wrap("libsql_host", "truncate", truncate)?;
+    linker.func_wrap("libsql_host", "sync", sync)?;
+    linker.func_wrap("libsql_host", "file_size", file_size)?;
+    linker.func_wrap("libsql_host", "lock", lock)?;
+    linker.func_wrap("libsql_host", "unlock", unlock)?;
+    linker.func_wrap("libsql_host", "check_reserved_lock", check_reserved_lock)?;
+    linker.func_wrap("libsql_host", "file_control", file_control)?;
+    linker.func_wrap("libsql_host", "sector_size", sector_size)?;
+    linker.func_wrap(
+        "libsql_host",
+        "device_characteristics",
+        device_characteristics,
+    )?;
+    Ok(())
+}

--- a/libsql-sqlite3/ext/libsql-wasi-demo/src/vfs.rs
+++ b/libsql-sqlite3/ext/libsql-wasi-demo/src/vfs.rs
@@ -7,7 +7,7 @@ fn get_memory(caller: &mut Caller<'_, State>) -> Memory {
 
 fn open_fd(mut caller: Caller<'_, State>, name: i32, flags: i32) -> anyhow::Result<i64> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (memory, _state) = memory.data_and_store_mut(&mut caller);
 
     let name = memory::read_cstr(memory, name)?;
 
@@ -30,7 +30,7 @@ fn delete(
     sync_dir: i32,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST DELETE CALLED");
     Ok(0)
@@ -44,7 +44,7 @@ fn access(
     res_out: i32,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST ACCESS CALLED");
     Ok(0)
@@ -58,7 +58,7 @@ fn full_pathname(
     out: i32,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (memory, _state) = memory.data_and_store_mut(&mut caller);
 
     let name = memory::read_cstr(memory, name)?;
     let out = memory::slice_mut(memory, out, n_out as usize)?;
@@ -74,7 +74,7 @@ fn randomness(
     out: i32,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST RANDOMNESS CALLED");
     Ok(0)
@@ -82,7 +82,7 @@ fn randomness(
 
 fn sleep(mut caller: Caller<'_, State>, vfs: i32, microseconds: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST SLEEP CALLED");
     Ok(0)
@@ -90,7 +90,7 @@ fn sleep(mut caller: Caller<'_, State>, vfs: i32, microseconds: i32) -> anyhow::
 
 fn current_time(mut caller: Caller<'_, State>, vfs: i32, out: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST CURRENT TIME CALLED");
     Ok(0)
@@ -103,7 +103,7 @@ fn get_last_error(
     out: i32,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST GET LAST ERROR CALLED");
     Ok(0)
@@ -111,7 +111,7 @@ fn get_last_error(
 
 fn current_time_64(mut caller: Caller<'_, State>, vfs: i32, out: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST CURRENT TIME 64 CALLED");
     Ok(0)
@@ -119,7 +119,7 @@ fn current_time_64(mut caller: Caller<'_, State>, vfs: i32, out: i32) -> anyhow:
 
 fn close(mut caller: Caller<'_, State>, file: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
     // TODO: read the file pointer from guest memory and feed it to Box::from_raw
     println!("HOST CLOSE CALLED");
 
@@ -134,7 +134,7 @@ fn read(
     offset: i64,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST READ CALLED");
     Ok(0)
@@ -148,7 +148,7 @@ fn write(
     offset: i64,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST WRITE CALLED");
     Ok(0)
@@ -156,35 +156,35 @@ fn write(
 
 fn truncate(mut caller: Caller<'_, State>, file: i32, size: i64) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
     println!("HOST TRUNCATE CALLED");
     Ok(0)
 }
 
 fn sync(mut caller: Caller<'_, State>, file: i32, flags: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
     println!("HOST SYNC CALLED");
     Ok(0)
 }
 
 fn file_size(mut caller: Caller<'_, State>, file: i32, size: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
     println!("HOST FILE SIZE CALLED");
     Ok(0)
 }
 
 fn lock(mut caller: Caller<'_, State>, file: i32, lock: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
     println!("HOST LOCK CALLED");
     Ok(0)
 }
 
 fn unlock(mut caller: Caller<'_, State>, file: i32, lock: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
     println!("HOST UNLOCK CALLED");
     Ok(0)
 }
@@ -195,7 +195,7 @@ fn check_reserved_lock(
     reserved_lock: i32,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
     println!("HOST CHECK RESERVED LOCK CALLED");
     Ok(0)
 }
@@ -207,7 +207,7 @@ fn file_control(
     arg: i32,
 ) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST FILE CONTROL CALLED");
     Ok(0)
@@ -215,7 +215,7 @@ fn file_control(
 
 fn sector_size(mut caller: Caller<'_, State>, file: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST SECTOR SIZE CALLED");
     Ok(0)
@@ -223,7 +223,7 @@ fn sector_size(mut caller: Caller<'_, State>, file: i32) -> anyhow::Result<i32> 
 
 fn device_characteristics(mut caller: Caller<'_, State>, file: i32) -> anyhow::Result<i32> {
     let memory = get_memory(&mut caller);
-    let (memory, state) = memory.data_and_store_mut(&mut caller);
+    let (_memory, _state) = memory.data_and_store_mut(&mut caller);
 
     println!("HOST DEVICE CHARACTERISTICS CALLED");
     Ok(0)

--- a/libsql-sqlite3/ext/wasi/vfs.c
+++ b/libsql-sqlite3/ext/wasi/vfs.c
@@ -1,0 +1,108 @@
+#include "sqlite3.h"
+#include <string.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define LIBSQL_IMPORT(name) extern __attribute__((import_module("libsql_host"), import_name(name)))
+
+LIBSQL_IMPORT("close") int libsql_wasi_close(sqlite3_file*);
+LIBSQL_IMPORT("read") int libsql_wasi_read(sqlite3_file*, void*, int iAmt, sqlite3_int64 iOfst);
+LIBSQL_IMPORT("write") int libsql_wasi_write(sqlite3_file*, const void*, int iAmt, sqlite3_int64 iOfst);
+LIBSQL_IMPORT("truncate") int libsql_wasi_truncate(sqlite3_file*, sqlite3_int64 size);
+LIBSQL_IMPORT("sync") int libsql_wasi_sync(sqlite3_file*, int flags);
+LIBSQL_IMPORT("file_size") int libsql_wasi_file_size(sqlite3_file*, sqlite3_int64 *pSize);
+LIBSQL_IMPORT("lock") int libsql_wasi_lock(sqlite3_file*, int);
+LIBSQL_IMPORT("unlock") int libsql_wasi_unlock(sqlite3_file*, int);
+LIBSQL_IMPORT("check_reserved_lock") int libsql_wasi_check_reserved_lock(sqlite3_file*, int *pResOut);
+LIBSQL_IMPORT("file_control") int libslq_wasi_file_control(sqlite3_file*, int op, void *pArg);
+LIBSQL_IMPORT("sector_size") int libsql_wasi_sector_size(sqlite3_file*);
+LIBSQL_IMPORT("device_characteristics") int libsql_wasi_device_characteristics(sqlite3_file*);
+
+typedef struct libsql_wasi_file {
+    const struct sqlite3_io_methods* pMethods;
+    int64_t fd;
+} libsql_wasi_file;
+
+static const sqlite3_io_methods wasi_io_methods = {
+    .iVersion = 1,
+    .xClose = &libsql_wasi_close,
+    .xRead = &libsql_wasi_read,
+    .xWrite = &libsql_wasi_write,
+    .xTruncate = &libsql_wasi_truncate,
+    .xSync = &libsql_wasi_sync,
+    .xFileSize = &libsql_wasi_file_size,
+    .xLock = &libsql_wasi_lock,
+    .xUnlock = &libsql_wasi_unlock,
+    .xCheckReservedLock = &libsql_wasi_check_reserved_lock,
+    .xFileControl = &libslq_wasi_file_control,
+    .xSectorSize = &libsql_wasi_sector_size,
+    .xDeviceCharacteristics = &libsql_wasi_device_characteristics,
+};
+
+LIBSQL_IMPORT("open_fd") int64_t libsql_wasi_open_fd(const char *zName, int flags);
+LIBSQL_IMPORT("delete") int libsql_wasi_delete(sqlite3_vfs*, const char *zName, int syncDir);
+LIBSQL_IMPORT("access") int libsql_wasi_access(sqlite3_vfs*, const char *zName, int flags, int *pResOut);
+LIBSQL_IMPORT("full_pathname") int libsql_wasi_full_pathname(sqlite3_vfs*, const char *zName, int nOut, char *zOut);
+LIBSQL_IMPORT("randomness") int libsql_wasi_randomness(sqlite3_vfs*, int nByte, char *zOut);
+LIBSQL_IMPORT("sleep") int libsql_wasi_sleep(sqlite3_vfs*, int microseconds);
+LIBSQL_IMPORT("current_time") int libsql_wasi_current_time(sqlite3_vfs*, double*);
+LIBSQL_IMPORT("get_last_error") int libsql_wasi_get_last_error(sqlite3_vfs*, int, char*);
+LIBSQL_IMPORT("current_time_64") int libsql_wasi_current_time_64(sqlite3_vfs*, sqlite3_int64*);
+
+int libsql_wasi_vfs_open(sqlite3_vfs *vfs, const char *zName, sqlite3_file *file_, int flags, int *pOutFlags) {
+    libsql_wasi_file *file = (libsql_wasi_file*)file_;
+    file->fd = libsql_wasi_open_fd(zName, flags);
+    if (file->fd == 0) {
+        return SQLITE_CANTOPEN;
+    }
+    file->pMethods = &wasi_io_methods;
+    return SQLITE_OK;
+}
+
+sqlite3_vfs libsql_wasi_vfs = {
+    .iVersion = 2,
+    .szOsFile = sizeof(libsql_wasi_file),
+    .mxPathname = 100,
+    .zName = "libsql_wasi",
+
+    .xOpen = &libsql_wasi_vfs_open,
+    .xDelete = &libsql_wasi_delete,
+    .xAccess = &libsql_wasi_access,
+    .xFullPathname = &libsql_wasi_full_pathname,
+    .xRandomness = &libsql_wasi_randomness,
+    .xSleep = &libsql_wasi_sleep,
+    .xCurrentTime = &libsql_wasi_current_time,
+    .xGetLastError = &libsql_wasi_get_last_error,
+    .xCurrentTimeInt64 = &libsql_wasi_current_time_64,
+};
+
+void libsql_wasi_init() {
+    sqlite3_vfs_register(&libsql_wasi_vfs, 1);
+}
+
+sqlite3 *libsql_wasi_open_db(const char *filename) {
+    sqlite3 *db;
+    int rc = sqlite3_open_v2(filename, &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, "libsql_wasi");
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Failed to open database: %s\n", sqlite3_errmsg(db));
+        return NULL;
+    }
+    return db;
+}
+
+int libsql_wasi_exec(sqlite3 *db, const char *sql) {
+    sqlite3_stmt *stmt;
+    int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Failed to prepare statement: %s\n", sqlite3_errmsg(db));
+        return rc;
+    }
+    // Step in a loop until SQLITE_DONE or error
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {}
+    if (rc != SQLITE_DONE) {
+        fprintf(stderr, "Failed to execute statement: %s\n", sqlite3_errmsg(db));
+        return rc;
+    }
+    return SQLITE_OK;
+}


### PR DESCRIPTION
This PR contains a demo which uses Wasmtime runtime to run libSQL in a WebAssembly instance, compiled in WAL mode. Right now it's full of stubs, and a VFS that calls back to the host for each operation. Once these stubs are implemented **and** we also provide a virtual WAL implementation that calls back to the host, we'll have a solid foundation for running libSQL with replication as a Wasm instance.

Step 1: compile `libsql.wasm` (should be automated with build.rs, I'm just lazy)
```sh
cd libsql-sqlite3
make wasi
```
Step 2: run the demo
```sh
cd ext/libsql-wasi-demo
RUST_LOG=info,libsql_wasi_demo=trace cargo run
```
Step 3: profit
```sh
$ file /tmp/wasm-demo.db*
/tmp/wasm-demo.db:     SQLite 3.x database, last written using SQLite version 3044000, writer version 2, read version 2, file counter 1, database pages 1, cookie 0, schema 0, unknown 0 encoding, version-valid-for 1
/tmp/wasm-demo.db-wal: empty
$ sqlite3 /tmp/wasm-demo.db "pragma journal_mode"
wal
```

Virtual WAL is not implemented in this patch, **but** this demo already successfully used WAL mode from a WebAssembly instance and created a WAL.

Next steps (arbitrary order):
1. forge this demo into a library we can later use to run libsql Wasm instances for users
2. add virtual WAL support
