### PR TITLE
libsql: fix for rust-cache

### DIFF
--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -31,7 +31,7 @@ bytes = { version = "1.4.0", features = ["serde"], optional = true }
 uuid = { version = "1.4.0", features = ["v4", "serde"], optional = true }
 tokio-stream = { version = "0.1.14", optional = true }
 tonic = { version = "0.10.2", features = ["tls", "tls-roots", "tls-webpki-roots"], optional = true}
-tonic-web = { version = "0.10.2" , optional = true }
+tonic-web = { version = "0.10.2", optional = true }
 tower-http = { version = "0.4.4", features = ["trace", "set-header", "util"], optional = true }
 http = { version = "0.2", optional = true }
 


### PR DESCRIPTION
The rust-cache GitHub action uses a TOML parser which chokes on the extra space before the comma in one line of this `Cargo.toml`. While it's actually valid syntax, just removing the extra comma should fix running the job.