### PR TITLE
bottomless: wait for all background tasks to complete on graceful shutdown

### DIFF
--- a/libsql-server/src/database.rs
+++ b/libsql-server/src/database.rs
@@ -64,7 +64,7 @@ impl Database for PrimaryDatabase {
         if let Some(replicator) = &self.logger.bottomless_replicator {
             let replicator = replicator.lock().unwrap().take();
             if let Some(mut replicator) = replicator {
-                replicator.wait_until_snapshotted().await?;
+                replicator.shutdown_gracefully().await?;
             }
         }
         Ok(())


### PR DESCRIPTION
This PR adds a `graceful_shutdown` method to bottomless replicator, which will wait for all known committed frames to be uploaded to S3 and for all pending snapshots to be uploaded as well prior completion.

There's a matter when to call this method as `ReplicationLogger` doesn't seem to expose graceful shuttdown method on its own. @MarinPostma could maybe help here.