### PR TITLE
release libsql-sqlite3 on demand

### DIFF
--- a/.github/workflows/release-libsql.yml
+++ b/.github/workflows/release-libsql.yml
@@ -4,7 +4,7 @@ on:
   push:
     #branches: ['main']
     tags:
-      - libsql-v*.*.*
+      - libsql-sqlite3-v*.*.*
 
 jobs:
         


### PR DESCRIPTION
Only release a new version of libsql-sqlite3 on demand, by tagging `libsql-sqlite3-vx.x.x`