### PR TITLE
Build libsql-server images on PR

### DIFF
--- a/.github/workflows/server-pr-images.yml
+++ b/.github/workflows/server-pr-images.yml
@@ -1,0 +1,64 @@
+# This workflow builds and pushes the pull request Docker image. Note
+# that this workflow is only triggered for internal users and the pull
+# request body must contain the string `+build`.
+name: libsql server pull request Docker image
+
+on:
+  pull_request:
+    branches: ["main"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-server-devel
+
+jobs:
+  # docker image build and upload to ghcr
+  build-and-push-image:
+    # run this job only if the pull request is from the same repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.body && contains(github.event.pull_request.body, '+build')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Get short SHA
+        id: get-short-sha
+        run: |
+          SHA="$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-7)"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-${{ steps.get-short-sha.outputs.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Echo image name
+        run: |
+          echo "Pushed: ${{ steps.meta.outputs.tags }}-${{ steps.get-short-sha.outputs.sha }}"


### PR DESCRIPTION
This PR adds a workflow which builds and pushes the PR Docker image of sqld to `libsql-server-devel`. 

Note: This workflow is only triggered for internal users and the pull request body must contain a special string `+build`

+build

