### PR TITLE
sqld: add in process s3 for bottomless tests

### DIFF
--- a/.cargo/nextest.toml
+++ b/.cargo/nextest.toml
@@ -1,2 +1,9 @@
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 2, , grace-period = "30s" }
+
+[test-groups]
+serial-integration = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(test::bottomless)'
+test-group = 'serial-integration'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,18 +82,6 @@ jobs:
     name: Run Tests
     env:
       RUSTFLAGS: -D warnings
-    services:
-      minio:
-        image: lazybit/minio
-        ports:
-          - 9000:9000
-          - 9090:9090
-        env:
-          MINIO_ACCESS_KEY: minioadmin
-          MINIO_SECRET_KEY: minioadmin
-        volumes:
-          - /data
-        options: --name=minio --health-cmd "curl http://localhost:9000/minio/health/live"
     steps:
     - uses: hecrj/setup-rust-action@v1
 
@@ -134,12 +122,6 @@ jobs:
 
     - name: Run tests
       run: cargo nextest run
-      env:
-        LIBSQL_BOTTOMLESS_AWS_ACCESS_KEY_ID: minioadmin
-        LIBSQL_BOTTOMLESS_AWS_SECRET_ACCESS_KEY: minioadmin
-        LIBSQL_BOTTOMLESS_AWS_DEFAULT_REGION: eu-central-2
-        LIBSQL_BOTTOMLESS_BUCKET: bottomless
-        LIBSQL_BOTTOMLESS_ENDPOINT: http://localhost:9000
 
   # test-rust-wasm:
   #   runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +965,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d80203ea6b29df88012294f62733de21cfeab47f17b41af3a38bc30a03ee72"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -2149,6 +2167,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7685beb53fc20efc2605f32f5d51e9ba18b8ef237961d1760169d2290d3bee"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,7 +2409,7 @@ dependencies = [
  "log",
  "num-format",
  "once_cell",
- "quick-xml",
+ "quick-xml 0.26.0",
  "rgb",
  "str_stack",
 ]
@@ -2740,6 +2768,8 @@ dependencies = [
  "rusqlite",
  "rustls 0.21.9",
  "rustls-pemfile",
+ "s3s",
+ "s3s-fs",
  "semver",
  "serde",
  "serde_json",
@@ -3099,6 +3129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nugine-rust-utils"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04dcd9cfa92246a9c7ca0671e00733c4e9d77ee1fa0ae08c9a181b7c8802aea2"
+dependencies = [
+ "simdutf8",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3196,12 @@ checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "numeric_cast"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf70ee2d9b1737d1836c20d9f8f96ec3901b2bf92128439db13237ddce9173a5"
 
 [[package]]
 name = "object"
@@ -3272,6 +3317,24 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -3634,6 +3697,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -4076,6 +4149,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "s3s"
+version = "0.8.1-dev"
+source = "git+https://github.com/LucioFranco/s3s?rev=e2b4f44f711b527f6e18dc9ababd80ab050746a3#e2b4f44f711b527f6e18dc9ababd80ab050746a3"
+dependencies = [
+ "arrayvec",
+ "async-trait",
+ "atoi",
+ "base64-simd",
+ "bytes",
+ "bytestring",
+ "chrono",
+ "crc32fast",
+ "futures",
+ "hex-simd",
+ "hmac",
+ "http-body",
+ "httparse",
+ "hyper",
+ "itoa",
+ "memchr",
+ "mime",
+ "nom",
+ "nugine-rust-utils",
+ "pin-project-lite",
+ "quick-xml 0.31.0",
+ "serde",
+ "serde_urlencoded",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "time",
+ "tracing",
+ "transform-stream",
+ "urlencoding",
+ "zeroize",
+]
+
+[[package]]
+name = "s3s-fs"
+version = "0.8.1-dev"
+source = "git+https://github.com/LucioFranco/s3s?rev=e2b4f44f711b527f6e18dc9ababd80ab050746a3#e2b4f44f711b527f6e18dc9ababd80ab050746a3"
+dependencies = [
+ "async-trait",
+ "base64-simd",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "crc32fast",
+ "digest",
+ "futures",
+ "hex-simd",
+ "md-5",
+ "mime",
+ "nugine-rust-utils",
+ "numeric_cast",
+ "path-absolutize",
+ "s3s",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-error",
+ "transform-stream",
+ "uuid",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4276,6 +4421,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "similar"
@@ -4944,6 +5095,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4970,6 +5131,15 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "transform-stream"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05034de7a8fcb11796a36478a2a8b16dca6772644dec5f49f709d5c66a38d359"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,7 @@ allow-dirty = ["ci"] # we've edited the release yml to narrow the tag scope
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+[patch.crates-io]
+s3s-fs = { git = "https://github.com/LucioFranco/s3s", rev = "e2b4f44f711b527f6e18dc9ababd80ab050746a3" }
+s3s = { git = "https://github.com/LucioFranco/s3s", rev = "e2b4f44f711b527f6e18dc9ababd80ab050746a3" }

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -1022,7 +1022,7 @@ impl Replicator {
         timestamp: Option<NaiveDateTime>,
     ) -> Result<(RestoreAction, bool)> {
         tracing::debug!("restoring from");
-        if let Some(tombstone) = dbg!(self.get_tombstone().await)? {
+        if let Some(tombstone) = self.get_tombstone().await? {
             if let Some(timestamp) = Self::generation_to_timestamp(&generation) {
                 if tombstone.timestamp() as u64 >= timestamp.to_unix().0 {
                     bail!(
@@ -1423,7 +1423,7 @@ impl Replicator {
         generation: Option<Uuid>,
         timestamp: Option<NaiveDateTime>,
     ) -> Result<(RestoreAction, bool)> {
-        tracing::debug!("restoring with {:?} at {:?}", generation, timestamp);
+        tracing::debug!("restoring with {generation:?} at {timestamp:?}");
         let generation = match generation {
             Some(gen) => gen,
             None => match self.latest_generation_before(timestamp.as_ref()).await {
@@ -1457,7 +1457,7 @@ impl Replicator {
             marker = Self::try_get_last_frame_no(response, &mut last_frame);
             marker.is_some()
         } {}
-        Ok(dbg!(last_frame))
+        Ok(last_frame)
     }
 
     fn try_get_last_frame_no(response: ListObjectsOutput, frame_no: &mut u32) -> Option<String> {

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -92,6 +92,8 @@ tempfile = "3.7.0"
 turmoil = "0.5.6"
 url = "2.3"
 metrics-util = "0.15"
+s3s = "0.8.1-dev"
+s3s-fs = "0.8.1-dev"
 
 [build-dependencies]
 prost-build = "0.12.0"

--- a/libsql-server/README.md
+++ b/libsql-server/README.md
@@ -24,6 +24,14 @@ case.
 Follow the [instructions](../docs/BUILD-RUN.md) to build and run `sqld`
 using Homebrew, Docker, or your own Rust toolchain.
 
+## Tests
+
+Run the command below to run all tests for `libsql` and `libsql-server`.
+
+```
+cargo xtask test
+```
+
 ## Client libraries
 
 The following client libraries enable your app to query `sqld` programmatically:

--- a/libsql-server/src/test/bottomless.rs
+++ b/libsql-server/src/test/bottomless.rs
@@ -5,17 +5,58 @@ use aws_sdk_s3::Client;
 use futures_core::Future;
 use itertools::Itertools;
 use libsql_client::{Connection, QueryResult, Statement, Value};
+use s3s::auth::SimpleAuth;
+use s3s::service::S3ServiceBuilder;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
+use std::sync::Once;
 use tokio::time::sleep;
 use tokio::time::Duration;
 use url::Url;
+use uuid::Uuid;
 
 use crate::config::{DbConfig, UserApiConfig};
 use crate::net::AddrIncoming;
 use crate::Server;
 
 const S3_URL: &str = "http://localhost:9000/";
+
+const S3_SERVER: Once = Once::new();
+
+async fn start_s3_server() {
+    std::env::set_var("LIBSQL_BOTTOMLESS_ENDPOINT", "http://localhost:9000");
+    std::env::set_var("LIBSQL_BOTTOMLESS_AWS_SECRET_ACCESS_KEY", "foo");
+    std::env::set_var("LIBSQL_BOTTOMLESS_AWS_ACCESS_KEY_ID", "bar");
+    std::env::set_var("LIBSQL_BOTTOMLESS_AWS_DEFAULT_REGION", "us-east-1");
+    std::env::set_var("LIBSQL_BOTTOMLESS_BUCKET", "my-bucket");
+
+    S3_SERVER.call_once(|| {
+        let tmp = std::env::temp_dir().join(format!("s3s-{}", Uuid::new_v4().as_simple()));
+
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        tracing::info!("starting mock s3 server with path: {}", tmp.display());
+
+        let s3_impl = s3s_fs::FileSystem::new(tmp).unwrap();
+
+        let key = std::env::var("LIBSQL_BOTTOMLESS_AWS_ACCESS_KEY_ID").unwrap();
+        let secret = std::env::var("LIBSQL_BOTTOMLESS_AWS_SECRET_ACCESS_KEY").unwrap();
+
+        let auth = SimpleAuth::from_single(key, secret);
+
+        let mut s3 = S3ServiceBuilder::new(s3_impl);
+        s3.set_auth(auth);
+        let s3 = s3.build().into_shared().into_make_service();
+
+        tokio::spawn(async move {
+            let addr = ([127, 0, 0, 1], 9000).into();
+
+            hyper::Server::bind(&addr).serve(s3).await.unwrap();
+        });
+    });
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+}
 
 /// returns a future that once polled will shutdown the server and wait for cleanup
 fn start_db(step: u32, server: Server) -> impl Future<Output = ()> {
@@ -75,7 +116,10 @@ async fn configure_server(
 
 #[tokio::test]
 async fn backup_restore() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = tracing_subscriber::fmt::try_init();
+
+    start_s3_server().await;
+
     const DB_ID: &str = "testbackuprestore";
     const BUCKET: &str = "testbackuprestore";
     const PATH: &str = "backup_restore.sqld";
@@ -122,6 +166,8 @@ async fn backup_restore() {
         .unwrap();
 
         perform_updates(&connection_addr, ROWS, OPS, "A").await;
+
+        assert_updates(&connection_addr, ROWS, OPS, "A").await;
 
         sleep(Duration::from_secs(2)).await;
 
@@ -203,7 +249,10 @@ async fn backup_restore() {
 
 #[tokio::test]
 async fn rollback_restore() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = tracing_subscriber::fmt::try_init();
+
+    start_s3_server().await;
+
     const DB_ID: &str = "testrollbackrestore";
     const BUCKET: &str = "testrollbackrestore";
     const PATH: &str = "rollback_restore.sqld";


### PR DESCRIPTION
This adds in process mock s3 backend via the `s3s` crate. This allows us to run tests without requiring a user run `minio` or hook up their real aws account.