### PR TITLE
libsql-server: use LRU cache to store active namespaces

### DIFF
--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -76,6 +76,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 http-body = "0.4"
 url = { version = "2.3", features = ["serde"] }
 uuid = { version = "1.3", features = ["v4", "serde"] }
+moka = { version = "0.12.1", features = ["future"] }
 
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive_arbitrary"] }


### PR DESCRIPTION
This is a port of Marin's https://github.com/libsql/sqld/pull/689/

This PR replaces the namespace store dumb hashmap with an LRU cache to bound the maximum number of namespaces loaded into memory while unbounding the number of namespaces allocated on a sqld instance.  Additionally, this enables fully concurrent access to namespaces by removing the global lock on the namespace store.