### PR TITLE
libsql-server: use LRU cache to store active namespaces

### DIFF
--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -41,6 +41,7 @@ metrics = "0.21.1"
 metrics-util = "0.15"
 metrics-exporter-prometheus = "0.12.2"
 mimalloc = { version = "0.1.36", default-features = false }
+moka = { version = "0.12.1", features = ["future"] }
 nix = { version = "0.26.2", features = ["fs"] }
 once_cell = "1.17.0"
 parking_lot = "0.12.1"

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -531,7 +531,8 @@ where
             self.db_config.snapshot_at_shutdown,
             meta_store_path,
             self.max_active_namespaces,
-        );
+        )
+        .await?;
 
         // eagerly load the default namespace when namespaces are disabled
         if self.disable_namespaces {
@@ -638,7 +639,8 @@ impl<C: Connector> Replica<C> {
             false,
             meta_store_path,
             self.max_active_namespaces,
-        );
+        )
+        .await?;
         let replication_service = ReplicationLogProxyService::new(channel.clone(), uri.clone());
         let proxy_service = ReplicaProxyService::new(channel, uri, self.auth.clone());
 

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -100,6 +100,7 @@ pub struct Server<C = HttpConnector, A = AddrIncoming, D = HttpsConnector<HttpCo
     pub heartbeat_config: Option<HeartbeatConfig>,
     pub disable_namespaces: bool,
     pub shutdown: Arc<Notify>,
+    pub max_active_namespaces: usize,
 }
 
 impl<C, A, D> Default for Server<C, A, D> {
@@ -117,6 +118,7 @@ impl<C, A, D> Default for Server<C, A, D> {
             heartbeat_config: Default::default(),
             disable_namespaces: true,
             shutdown: Default::default(),
+            max_active_namespaces: 100,
         }
     }
 }
@@ -384,6 +386,7 @@ where
                     db_config: self.db_config.clone(),
                     base_path: self.path.clone(),
                     auth: auth.clone(),
+                    max_active_namespaces: self.max_active_namespaces,
                 };
                 let (namespaces, proxy_service, replication_service) = replica.configure().await?;
                 self.rpc_client_config = None;
@@ -422,6 +425,7 @@ where
                     extensions,
                     base_path: self.path.clone(),
                     disable_namespaces: self.disable_namespaces,
+                    max_active_namespaces: self.max_active_namespaces,
                     join_set: &mut join_set,
                     auth: auth.clone(),
                 };
@@ -487,6 +491,7 @@ struct Primary<'a, A> {
     extensions: Arc<[PathBuf]>,
     base_path: Arc<Path>,
     disable_namespaces: bool,
+    max_active_namespaces: usize,
     auth: Arc<Auth>,
     join_set: &'a mut JoinSet<anyhow::Result<()>>,
 }
@@ -520,14 +525,13 @@ where
         let meta_store_path = conf.base_path.join("metastore");
 
         let factory = PrimaryNamespaceMaker::new(conf);
-
         let namespaces = NamespaceStore::new(
             factory,
             false,
             self.db_config.snapshot_at_shutdown,
             meta_store_path,
-        )
-        .await?;
+            self.max_active_namespaces,
+        );
 
         // eagerly load the default namespace when namespaces are disabled
         if self.disable_namespaces {
@@ -602,6 +606,7 @@ struct Replica<C> {
     db_config: DbConfig,
     base_path: Arc<Path>,
     auth: Arc<Auth>,
+    max_active_namespaces: usize,
 }
 
 impl<C: Connector> Replica<C> {
@@ -627,7 +632,13 @@ impl<C: Connector> Replica<C> {
         let meta_store_path = conf.base_path.join("metastore");
 
         let factory = ReplicaNamespaceMaker::new(conf);
-        let namespaces = NamespaceStore::new(factory, true, false, meta_store_path).await?;
+        let namespaces = NamespaceStore::new(
+            factory,
+            true,
+            false,
+            meta_store_path,
+            self.max_active_namespaces,
+        );
         let replication_service = ReplicationLogProxyService::new(channel.clone(), uri.clone());
         let proxy_service = ReplicaProxyService::new(channel, uri, self.auth.clone());
 

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -195,6 +195,10 @@ struct Cli {
     /// Enable snapshot at shutdown
     #[clap(long)]
     snapshot_at_shutdown: bool,
+
+    /// Max active namespaces kept in-memory
+    #[clap(long, env = "SQLD_MAX_ACTIVE_NAMESPACES", default_value = "100")]
+    max_active_namespaces: usize,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -506,6 +510,7 @@ async fn build_server(config: &Cli) -> anyhow::Result<Server> {
         disable_default_namespace: config.disable_default_namespace,
         disable_namespaces: !config.enable_namespaces,
         shutdown,
+        max_active_namespaces: config.max_active_namespaces,
     })
 }
 

--- a/libsql-server/src/namespace/fork.rs
+++ b/libsql-server/src/namespace/fork.rs
@@ -109,7 +109,6 @@ impl ForkTask<'_> {
                 self.dest_namespace.clone(),
                 RestoreOption::Latest,
                 self.bottomless_db_id,
-                true,
                 // Forking works only on primary and
                 // PrimaryNamespaceMaker::create ignores
                 // reset_cb param

--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -177,6 +177,13 @@ impl MetaStore {
             inner: HandleState::External(change_tx, rx),
         }
     }
+
+    // TODO: we need to either make sure that the metastore is restored
+    // before we start accepting connections or we need to contact bottomless
+    // here to check if a namespace exists. Preferably the former.
+    pub fn exists(&self, namespace: &NamespaceName) -> bool {
+        self.inner.lock().configs.contains_key(namespace)
+    }
 }
 
 impl MetaStoreHandle {

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -634,6 +634,13 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         let init = {
             let namespace = namespace.clone();
             async move {
+                if !self.inner.make_namespace.exists(&namespace) {
+                    if self.inner.allow_lazy_creation {
+                        return Ok(None);
+                    } else {
+                        return Err(Error::NamespaceDoesntExist(namespace.to_string()));
+                    }
+                }
                 let ns = self
                     .inner
                     .make_namespace

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -10,16 +10,18 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 
 use anyhow::Context as _;
-use async_lock::{RwLock, RwLockUpgradableReadGuard};
+use async_lock::RwLock;
 use bottomless::bottomless_wal::CreateBottomlessWal;
 use bottomless::replicator::Options;
 use bytes::Bytes;
 use chrono::NaiveDateTime;
 use enclose::enclose;
-use futures_core::Stream;
+use futures::TryFutureExt;
+use futures_core::{Future, Stream};
 use hyper::Uri;
 use libsql_replication::rpc::replication::replication_log_client::ReplicationLogClient;
 use libsql_sys::wal::{Sqlite3WalManager, WalManager};
+use moka::future::Cache;
 use parking_lot::Mutex;
 use rusqlite::ErrorCode;
 use serde::de::Visitor;
@@ -30,7 +32,6 @@ use tokio::task::JoinSet;
 use tokio::time::{Duration, Instant};
 use tokio_util::io::StreamReader;
 use tonic::transport::Channel;
-use tracing::trace;
 use uuid::Uuid;
 
 use crate::auth::Authenticated;
@@ -379,6 +380,8 @@ impl MakeNamespace for ReplicaNamespaceMaker {
     }
 }
 
+type NamespaceEntry<T> = Arc<RwLock<Option<Namespace<T>>>>;
+
 /// Stores and manage a set of namespaces.
 pub struct NamespaceStore<M: MakeNamespace> {
     inner: Arc<NamespaceStoreInner<M>>,
@@ -393,7 +396,7 @@ impl<M: MakeNamespace> Clone for NamespaceStore<M> {
 }
 
 struct NamespaceStoreInner<M: MakeNamespace> {
-    store: RwLock<HashMap<NamespaceName, Namespace<M::Database>>>,
+    store: Cache<NamespaceName, NamespaceEntry<M::Database>>,
     metadata: MetaStore,
     /// The namespace factory, to create new namespaces.
     make_namespace: M,
@@ -411,9 +414,25 @@ impl<M: MakeNamespace> NamespaceStore<M> {
     ) -> crate::Result<Self> {
         let metadata = MetaStore::new(meta_store_path).await?;
 
+        let store = Cache::<NamespaceName, NamespaceEntry<M::Database>>::builder()
+        .async_eviction_listener(|name, ns, _| {
+            Box::pin(async move {
+                tracing::info!("namespace `{name}` deallocated");
+                // shutdown namespace
+                if let Some(ns) = ns.write().await.take() {
+                    if let Err(e) = ns.destroy().await {
+                        tracing::error!("error deallocating `{name}`: {e}")
+                    }
+                }
+            })
+        })
+        // TODO(marin): configurable capacity
+        .max_capacity(25)
+        .build();
+
         Ok(Self {
             inner: Arc::new(NamespaceStoreInner {
-                store: Default::default(),
+                store,
                 metadata,
                 make_namespace,
                 allow_lazy_creation,
@@ -427,18 +446,19 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         if self.inner.has_shutdown.load(Ordering::Relaxed) {
             return Err(Error::NamespaceStoreShutdown);
         }
-        let mut lock = self.inner.store.write().await;
         let mut bottomless_db_id_init = NamespaceBottomlessDbIdInit::FetchFromConfig;
-        if let Some(ns) = lock.remove(&namespace) {
-            bottomless_db_id_init = NamespaceBottomlessDbIdInit::Provided(
-                NamespaceBottomlessDbId::from_config(&ns.db_config_store.get()),
-            );
+        if let Some(ns) = self.inner.store.remove(&namespace).await {
             // FIXME: when destroying, we are waiting for all the tasks associated with the
-            // allocation to finnish, which create a lot of contention on the lock. Need to use a
+            // allocation to finish, which create a lot of contention on the lock. Need to use a
             // conccurent hashmap to deal with this issue.
 
             // deallocate in-memory resources
-            ns.destroy().await?;
+            if let Some(ns) = ns.write().await.take() {
+                bottomless_db_id_init = NamespaceBottomlessDbIdInit::Provided(
+                    NamespaceBottomlessDbId::from_config(&ns.db_config_store.get()),
+                );
+                ns.destroy().await?;
+            }
         }
 
         // destroy on-disk database and backups
@@ -457,24 +477,29 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         Ok(())
     }
 
-    async fn reset(
+    pub async fn reset(
         &self,
         namespace: NamespaceName,
         restore_option: RestoreOption,
-    ) -> crate::Result<()> {
-        if self.inner.has_shutdown.load(Ordering::Relaxed) {
-            return Err(Error::NamespaceStoreShutdown);
-        }
-        let mut lock = self.inner.store.write().await;
-        if let Some(ns) = lock.remove(&namespace) {
+    ) -> anyhow::Result<()> {
+        // The process for reseting is as follow:
+        // - get a lock on the namespace entry, if the entry exists, then it's a lock on the entry,
+        // if it doesn't exist, insert an empty entry and take a lock on it
+        // - destroy the old namespace
+        // - create a new namespace and insert it in the held lock
+        let entry = self
+            .inner
+            .store
+            .get_with(namespace.clone(), async { Default::default() })
+            .await;
+        let mut lock = entry.write().await;
+        if let Some(ns) = lock.take() {
             // FIXME: when destroying, we are waiting for all the tasks associated with the
             // allocation to finnish, which create a lot of contention on the lock. Need to use a
             // conccurent hashmap to deal with this issue.
-
             // deallocate in-memory resources
             ns.destroy().await?;
         }
-
         // destroy on-disk database
         self.inner
             .make_namespace
@@ -497,7 +522,8 @@ impl<M: MakeNamespace> NamespaceStore<M> {
                 &self.inner.metadata,
             )
             .await?;
-        lock.insert(namespace, ns);
+
+        lock.replace(ns);
 
         Ok(())
     }
@@ -534,18 +560,22 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         if self.inner.has_shutdown.load(Ordering::Relaxed) {
             return Err(Error::NamespaceStoreShutdown);
         }
-        let mut lock = self.inner.store.write().await;
-        if lock.contains_key(&to) {
-            return Err(crate::error::Error::NamespaceAlreadyExist(
-                to.as_str().to_string(),
-            ));
+
+        let to_entry = self
+            .inner
+            .store
+            .get_with(to.clone(), async { Default::default() })
+            .await;
+        let mut to_lock = to_entry.write().await;
+        if to_lock.is_some() {
+            return Err(crate::error::Error::NamespaceAlreadyExist(to.to_string()));
         }
 
         // check that the source namespace exists
-        let from_ns = match lock.entry(from.clone()) {
-            Entry::Occupied(e) => e.into_mut(),
-            Entry::Vacant(e) => {
-                // we just want to load the namespace into memory, so we refuse creation.
+        let from_entry = self
+            .inner
+            .store
+            .try_get_with(from.clone(), async {
                 let ns = self
                     .inner
                     .make_namespace
@@ -558,16 +588,25 @@ impl<M: MakeNamespace> NamespaceStore<M> {
                         &self.inner.metadata,
                     )
                     .await?;
-                e.insert(ns)
-            }
+                tracing::info!("loaded namespace: `{to}`");
+                Ok::<_, crate::error::Error>(Arc::new(RwLock::new(Some(ns))))
+            })
+            .await
+            // FIXME: find how to deal with Arc<Error>
+            .unwrap();
+
+        let from_lock = from_entry.read().await;
+        let Some(from_ns) = &*from_lock else {
+            return Err(crate::error::Error::NamespaceDoesntExist(to.to_string()));
         };
 
-        let forked = self
+        let to_ns = self
             .inner
             .make_namespace
             .fork(from_ns, to.clone(), timestamp, &self.inner.metadata)
             .await?;
-        lock.insert(to.clone(), forked);
+
+        to_lock.replace(to_ns);
 
         Ok(())
     }
@@ -579,7 +618,7 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         f: Fun,
     ) -> crate::Result<R>
     where
-        Fun: FnOnce(&Namespace<M::Database>) -> R,
+        Fun: FnOnce(&Namespace<M::Database>) -> R + 'static,
     {
         if self.inner.has_shutdown.load(Ordering::Relaxed) {
             return Err(Error::NamespaceStoreShutdown);
@@ -593,37 +632,65 @@ impl<M: MakeNamespace> NamespaceStore<M> {
 
     pub async fn with<Fun, R>(&self, namespace: NamespaceName, f: Fun) -> crate::Result<R>
     where
-        Fun: FnOnce(&Namespace<M::Database>) -> R,
+        Fun: FnOnce(&Namespace<M::Database>) -> R + 'static,
     {
-        if self.inner.has_shutdown.load(Ordering::Relaxed) {
-            return Err(Error::NamespaceStoreShutdown);
-        }
+        let init = {
+            let namespace = namespace.clone();
+            async move {
+                let ns = self
+                    .inner
+                    .make_namespace
+                    .create(
+                        namespace.clone(),
+                        RestoreOption::Latest,
+                        NamespaceBottomlessDbId::NotProvided,
+                        self.inner.allow_lazy_creation,
+                        self.make_reset_cb(),
+                    )
+                    .await?;
+                tracing::info!("loaded namespace: `{namespace}`");
+
+                Ok(Some(ns))
+            }
+        };
+
+        let f = {
+            let name = namespace.clone();
+            move |ns: NamespaceEntry<M::Database>| async move {
+                let lock = ns.read().await;
+                match &*lock {
+                    Some(ns) => Ok(f(ns)),
+                    // the namespace was taken out of the entry
+                    None => Err(Error::NamespaceDoesntExist(name.to_string())),
+                }
+            }
+        };
+
+        self.with_lock_or_init(namespace, f, init).await?
+    }
+
+    async fn with_lock_or_init<Fun, R, Init, Fut>(
+        &self,
+        namespace: NamespaceName,
+        f: Fun,
+        init: Init,
+    ) -> crate::Result<R>
+    where
+        Fun: FnOnce(NamespaceEntry<M::Database>) -> Fut,
+        Fut: Future<Output = R>,
+        Init: Future<Output = crate::Result<Option<Namespace<M::Database>>>>,
+    {
         let before_load = Instant::now();
-        let lock = self.inner.store.upgradable_read().await;
-        if let Some(ns) = lock.get(&namespace) {
-            Ok(f(ns))
-        } else {
-            let mut lock = RwLockUpgradableReadGuard::upgrade(lock).await;
-            let ns = self
-                .inner
-                .make_namespace
-                .create(
-                    namespace.clone(),
-                    RestoreOption::Latest,
-                    NamespaceBottomlessDbId::NotProvided,
-                    self.inner.allow_lazy_creation,
-                    self.make_reset_cb(),
-                    &self.inner.metadata,
-                )
-                .await?;
-            let ret = f(&ns);
-            tracing::info!("loaded namespace: `{namespace}`");
-            lock.insert(namespace, ns);
-
-            NAMESPACE_LOAD_LATENCY.record(before_load.elapsed());
-
-            Ok(ret)
-        }
+        let ns = self
+            .inner
+            .store
+            .try_get_with(
+                namespace.clone(),
+                init.map_ok(|ns| Arc::new(RwLock::new(ns))),
+            )
+            .await?;
+        NAMESPACE_LOAD_LATENCY.record(before_load.elapsed());
+        Ok(f(ns).await)
     }
 
     pub async fn create(
@@ -632,43 +699,77 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         restore_option: RestoreOption,
         bottomless_db_id: NamespaceBottomlessDbId,
     ) -> crate::Result<()> {
-        if self.inner.has_shutdown.load(Ordering::Relaxed) {
-            return Err(Error::NamespaceStoreShutdown);
-        }
-        let lock = self.inner.store.upgradable_read().await;
-        if lock.contains_key(&namespace) {
-            return Err(crate::error::Error::NamespaceAlreadyExist(
-                namespace.as_str().to_owned(),
-            ));
-        }
+        let name = namespace.clone();
+        let bottomless_db_id_for_init = bottomless_db_id.clone();
+        let init = async {
+            let ns = self
+                .inner
+                .make_namespace
+                .create(
+                    name.clone(),
+                    RestoreOption::Latest,
+                    bottomless_db_id_for_init,
+                    false,
+                    self.make_reset_cb(),
+                )
+                .await;
+            match ns {
+                // the namespace already exist, load it, and let the `f` function fail
+                Ok(ns) => {
+                    tracing::info!("loaded namespace: `{name}`");
+                    Ok(Some(ns))
+                }
+                // return an empty slot to put the new namespace in
+                Err(Error::NamespaceDoesntExist(_)) => Ok(None),
+                Err(e) => Err(e),
+            }
+        };
 
-        let ns = self
-            .inner
-            .make_namespace
-            .create(
-                namespace.clone(),
-                restore_option,
-                bottomless_db_id,
-                true,
-                self.make_reset_cb(),
-                &self.inner.metadata,
-            )
-            .await?;
+        let f = {
+            let name = namespace.clone();
+            move |ns: NamespaceEntry<M::Database>| {
+                let ns = ns.clone();
+                let name = name.clone();
+                async move {
+                    let mut lock = ns.write().await;
+                    if lock.is_some() {
+                        return Err(Error::NamespaceAlreadyExist(name.to_string()));
+                    }
+                    let ns = self
+                        .inner
+                        .make_namespace
+                        .create(
+                            name.clone(),
+                            restore_option,
+                            bottomless_db_id,
+                            true,
+                            self.make_reset_cb(),
+                            &self.inner.metadata
+                        )
+                        .await?;
 
-        let mut lock = RwLockUpgradableReadGuard::upgrade(lock).await;
-        tracing::info!("loaded namespace: `{namespace}`");
-        lock.insert(namespace, ns);
+                    tracing::info!("loaded namespace: `{name}`");
 
-        Ok(())
+                    lock.replace(ns);
+
+                    Ok(())
+                }
+            }
+        };
+
+        self.with_lock_or_init(namespace, f, init).await?
     }
 
     pub async fn shutdown(self) -> crate::Result<()> {
         self.inner.has_shutdown.store(true, Ordering::Relaxed);
-        let mut lock = self.inner.store.write().await;
-        for (name, ns) in lock.drain() {
-            ns.shutdown(self.inner.snapshot_at_shutdown).await?;
-            trace!("shutdown namespace: `{}`", name);
+        for (_name, entry) in self.inner.store.iter() {
+            let mut lock = entry.write().await;
+            if let Some(ns) = lock.take() {
+                ns.shutdown(self.inner.snapshot_at_shutdown).await?;
+            }
         }
+        self.inner.store.invalidate_all();
+        self.inner.store.run_pending_tasks().await;
         Ok(())
     }
 

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -719,7 +719,7 @@ impl<M: MakeNamespace> NamespaceStore<M> {
                     name.clone(),
                     restore_option,
                     bottomless_db_id_for_init,
-                    false,
+                    true,
                     self.make_reset_cb(),
                 )
                 .await;

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -433,7 +433,7 @@ impl<M: MakeNamespace> NamespaceStore<M> {
                 })
             })
             .max_capacity(max_active_namespaces as u64)
-            .time_to_idle(Duration::from_secs(300))
+            .time_to_idle(Duration::from_secs(86400))
             .build();
         Self {
             inner: Arc::new(NamespaceStoreInner {

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -414,9 +414,10 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         meta_store_path: impl AsRef<Path>,
         max_active_namespaces: usize,
     ) -> Self {
+        tracing::trace!("Max active namespaces: {max_active_namespaces}");
         let store = Cache::<NamespaceName, NamespaceEntry<M::Database>>::builder()
-            .async_eviction_listener(move |name, ns, _| {
-                tracing::info!("evicting namespace `{name}` asynchronously");
+            .async_eviction_listener(move |name, ns, cause| {
+                tracing::debug!("evicting namespace `{name}` asynchronously: {cause:?}");
                 // TODO(sarna): not clear if we should snapshot-on-evict...
                 // On the one hand, better to do so, because we have no idea
                 // for how long we're evicting a namespace.

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -634,12 +634,9 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         let init = {
             let namespace = namespace.clone();
             async move {
-                if !self.inner.make_namespace.exists(&namespace) {
-                    if self.inner.allow_lazy_creation {
-                        return Ok(None);
-                    } else {
-                        return Err(Error::NamespaceDoesntExist(namespace.to_string()));
-                    }
+                if !self.inner.make_namespace.exists(&namespace) && !self.inner.allow_lazy_creation
+                {
+                    return Err(Error::NamespaceDoesntExist(namespace.to_string()));
                 }
                 let ns = self
                     .inner

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -634,7 +634,9 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         let init = {
             let namespace = namespace.clone();
             async move {
-                if !self.inner.make_namespace.exists(&namespace) && !self.inner.allow_lazy_creation
+                if namespace != NamespaceName::default()
+                    && !self.inner.make_namespace.exists(&namespace)
+                    && !self.inner.allow_lazy_creation
                 {
                     return Err(Error::NamespaceDoesntExist(namespace.to_string()));
                 }
@@ -701,8 +703,8 @@ impl<M: MakeNamespace> NamespaceStore<M> {
     ) -> crate::Result<()> {
         // With namespaces disabled, the default namespace can be auto-created,
         // otherwise it's an error.
-        if self.inner.allow_lazy_creation && namespace == NamespaceName::default() {
-            tracing::trace!("auto-creating default namespace");
+        if self.inner.allow_lazy_creation || namespace == NamespaceName::default() {
+            tracing::trace!("auto-creating the namespace");
         } else if self.inner.make_namespace.exists(&namespace) {
             return Err(Error::NamespaceAlreadyExist(namespace.to_string()));
         }

--- a/libsql-server/src/test/bottomless.rs
+++ b/libsql-server/src/test/bottomless.rs
@@ -105,6 +105,7 @@ async fn configure_server(
         },
         path: path.into().into(),
         disable_default_namespace: false,
+        max_active_namespaces: 100,
         heartbeat_config: None,
         idle_shutdown_timeout: None,
         initial_idle_shutdown_timeout: None,


### PR DESCRIPTION
This is a port of Marin's https://github.com/libsql/sqld/pull/689

This PR replaces the namespace store dumb hashmap with an LRU cache to bound the maximum number of namespaces loaded into memory while unbounding the number of namespaces allocated on a sqld instance. Additionally, this enables fully concurrent access to namespaces by removing the global lock on the namespace store.