### PR TITLE
Store replication index in Page 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ dependencies = [
  "url",
  "uuid",
  "vergen",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2819,6 +2820,7 @@ dependencies = [
  "once_cell",
  "rusqlite",
  "tracing",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6280,18 +6282,19 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -76,6 +76,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 http-body = "0.4"
 url = { version = "2.3", features = ["serde"] }
 uuid = { version = "1.3", features = ["v4", "serde"] }
+zerocopy = "0.7.28"
 
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive_arbitrary"] }

--- a/libsql-sys/Cargo.toml
+++ b/libsql-sys/Cargo.toml
@@ -15,6 +15,7 @@ libsql-ffi = { path = "../libsql-ffi/" }
 once_cell = "1.18.0"
 rusqlite = { workspace = true, features = ["trace"], optional = true }
 tracing = "0.1.37"
+zerocopy = { version = "0.7.28", features = ["derive"] }
 
 [features]
 default = ["api"]

--- a/libsql-sys/src/lib.rs
+++ b/libsql-sys/src/lib.rs
@@ -1,4 +1,61 @@
-pub use libsql_ffi as ffi;
+pub mod ffi {
+    pub use libsql_ffi::*;
+    use zerocopy::byteorder::big_endian::{U16 as bu16, U32 as bu32, U64 as bu64};
+
+    /// Patched database header file, in use by libsql
+    #[repr(C)]
+    #[derive(Clone, Copy, zerocopy::FromBytes, zerocopy::FromZeroes, zerocopy::AsBytes)]
+    pub struct Sqlite3DbHeader {
+        /// The header string: "SQLite format 3\000"
+        pub header_str: [u8; 16],
+        /// The database page size in bytes. Must be a power of two between 512 and 32768 inclusive, or the value 1 representing a page size of 65536.
+        pub page_size: bu16,
+        /// File format write version. 1 for legacy; 2 for WAL.
+        pub write_version: u8,
+        /// File format write version. 1 for legacy; 2 for WAL.
+        pub read_version: u8,
+        /// Bytes of unused "reserved" space at the end of each page. Usually 0.
+        pub reserved_in_page: u8,
+        /// Maximum embedded payload fraction. Must be 64.
+        pub max_payload: u8,
+        /// Minimum embedded payload fraction. Must be 32.
+        pub min_payload: u8,
+        /// Leaf payload fraction. Must be 32.
+        pub leaf_payload: u8,
+        /// File change counter.
+        pub change_count: bu32,
+        /// Size of the database file in pages. The "in-header database size".
+        pub db_size: bu32,
+        /// Page number of the first freelist trunk page.
+        pub freelist_pno: bu32,
+        /// Total number of freelist pages.
+        pub freelist_len: bu32,
+        /// The schema cookie.
+        pub schema_cookie: bu32,
+        /// The schema format number. Supported schema formats are 1, 2, 3, and 4.
+        pub schema_format_number: bu32,
+        /// Default page cache size.
+        pub default_cache_size: bu32,
+        /// The page number of the largest root b-tree page when in auto-vacuum or incremental-vacuum modes, or zero otherwise.
+        pub largest_root: bu32,
+        /// The database text encoding. A value of 1 means UTF-8. A value of 2 means UTF-16le. A value of 3 means UTF-16be.
+        pub text_encoding: bu32,
+        /// The "user version" as read and set by the user_version pragma.
+        pub user_version: bu32,
+        /// True (non-zero) for incremental-vacuum mode. False (zero) otherwise.
+        pub incremental_vacuum: bu32,
+        /// The "Application ID" set by PRAGMA application_id.
+        pub app_id: bu32,
+        /// Reserved for expansion. Must be zero.
+        _reserved: [u8; 12],
+        /// The replication index of this database, this is a libsql extension, ignored by sqlite3.
+        pub replication_index: bu64,
+        /// The version-valid-for number.
+        pub version_valid_for: bu32,
+        /// SQLITE_VERSION_NUMBER
+        pub sqlite_version: bu32,
+    }
+}
 
 #[cfg(feature = "api")]
 pub mod connection;

--- a/libsql-sys/src/wal/sqlite3_wal.rs
+++ b/libsql-sys/src/wal/sqlite3_wal.rs
@@ -143,6 +143,15 @@ pub struct Sqlite3Wal {
     inner: libsql_wal,
 }
 
+impl Sqlite3Wal {
+    pub fn db_file(&mut self) -> &mut Sqlite3File {
+        unsafe {
+            let ptr = &mut (*(self.inner.pData as *mut sqlite3_wal)).pDbFd;
+            std::mem::transmute(ptr)
+        }
+    }
+}
+
 impl Wal for Sqlite3Wal {
     fn limit(&mut self, size: i64) {
         unsafe {
@@ -281,7 +290,7 @@ impl Wal for Sqlite3Wal {
             (self.inner.methods.xFrames.unwrap())(
                 self.inner.pData,
                 page_size,
-                page_headers.as_ptr(),
+                page_headers.as_mut_ptr(),
                 size_after,
                 is_commit as _,
                 sync_flags,


### PR DESCRIPTION
Until this PR, the replication index was stored in two places:
- In the shadow wal header on a primary
- In the `client_wal_meta` on a replication

Thsi was problematic because, on the replica it forces us to inject a transaction at a time and sync the meta file on each injection, and on the primary, it forces us to recover the database from scratch when we loose the shadow wal.

To fix that, we we now store the replication index in the sqlite file header, in the top 8 bytes of the reserved bytes available in the header. On checkpoint, the most recent version of page 1 is patched with the new replication index, before being re-injected in the wal, and then checkpointed.
