### PR TITLE
Libsql cursor

### DIFF
--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -14,7 +14,7 @@ futures = { version = "0.3.28", optional = true }
 libsql-sys = { version = "0.2.13", path = "../libsql-sys", optional = true }
 tokio = { version = "1.29.1", features = ["fs", "sync"], optional = true }
 parking_lot = { version = "0.12.1", optional = true }
-hyper = { version = "0.14", features = ["client"], optional = true }
+hyper = { version = "0.14", features = ["client", "stream"], optional = true }
 hyper-rustls = { version = "0.24", features = ["webpki-roots"], optional = true }
 base64 = { version = "0.21", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -90,7 +90,8 @@ hrana = [
   "serde",
   "dep:base64",
   "dep:serde_json",
-  "dep:futures"
+  "dep:futures",
+  "dep:bytes"
 ]
 serde = ["dep:serde"]
 remote = [

--- a/libsql/src/hrana/connection.rs
+++ b/libsql/src/hrana/connection.rs
@@ -82,6 +82,7 @@ where
         HranaStream::open(
             client.inner.clone(),
             client.pipeline_url.clone(),
+            client.cursor_url.clone(),
             client.auth.clone(),
         )
     }

--- a/libsql/src/hrana/connection.rs
+++ b/libsql/src/hrana/connection.rs
@@ -32,7 +32,7 @@ where
     pub fn new(url: String, token: String, inner: T) -> Self {
         // The `libsql://` protocol is an alias for `https://`.
         let base_url = coerce_url_scheme(&url);
-        let pipeline_url = Arc::from(format!("{base_url}/v2/pipeline"));
+        let pipeline_url = Arc::from(format!("{base_url}/v3/pipeline"));
         let cursor_url = Arc::from(format!("{base_url}/v3/cursor"));
         HttpConnection(Arc::new(InnerClient {
             inner,

--- a/libsql/src/hrana/connection.rs
+++ b/libsql/src/hrana/connection.rs
@@ -9,12 +9,12 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct HttpConnection<T>(Arc<InnerClient<T>>)
 where
-    T: for<'a> HttpSend<'a>;
+    T: HttpSend;
 
 #[derive(Debug)]
 struct InnerClient<T>
 where
-    T: for<'a> HttpSend<'a>,
+    T: HttpSend,
 {
     inner: T,
     pipeline_url: Arc<str>,
@@ -27,7 +27,7 @@ where
 
 impl<T> HttpConnection<T>
 where
-    T: for<'a> HttpSend<'a>,
+    T: HttpSend,
 {
     pub fn new(url: String, token: String, inner: T) -> Self {
         // The `libsql://` protocol is an alias for `https://`.
@@ -128,7 +128,7 @@ where
 
 impl<T> Clone for HttpConnection<T>
 where
-    T: for<'a> HttpSend<'a>,
+    T: HttpSend,
 {
     fn clone(&self) -> Self {
         HttpConnection(self.0.clone())

--- a/libsql/src/hrana/connection.rs
+++ b/libsql/src/hrana/connection.rs
@@ -1,5 +1,5 @@
 use crate::hrana::pipeline::{BatchStreamReq, ExecuteStreamReq, StreamRequest, StreamResponse};
-use crate::hrana::proto::{Batch, BatchCond, BatchResult, Stmt, StmtResult};
+use crate::hrana::proto::{Batch, BatchResult, Stmt, StmtResult};
 use crate::hrana::stream::HranaStream;
 use crate::hrana::{HranaError, HttpSend, Result, Statement};
 use crate::util::coerce_url_scheme;
@@ -90,7 +90,7 @@ where
         &self,
         stmts: impl IntoIterator<Item = Stmt>,
     ) -> Result<BatchResult> {
-        let batch = stmts_to_batch(false, stmts);
+        let batch = Batch::from_iter(stmts, false);
         let (resp, is_autocommit) = self
             .open_stream()
             .finalize(StreamRequest::Batch(BatchStreamReq { batch }))
@@ -137,25 +137,4 @@ where
 pub(crate) enum CommitBehavior {
     Commit,
     Rollback,
-}
-
-pub(super) fn stmts_to_batch(protocol_v3: bool, stmts: impl IntoIterator<Item = Stmt>) -> Batch {
-    let mut batch = Batch::new();
-    let mut step = -1;
-    for stmt in stmts.into_iter() {
-        let cond = if step >= 0 {
-            let mut cond = BatchCond::Ok { step };
-            if protocol_v3 {
-                cond = BatchCond::And {
-                    conds: vec![cond, BatchCond::IsAutocommit],
-                };
-            }
-            Some(cond)
-        } else {
-            None
-        };
-        batch.step(cond, stmt);
-        step += 1;
-    }
-    batch
 }

--- a/libsql/src/hrana/connection.rs
+++ b/libsql/src/hrana/connection.rs
@@ -74,9 +74,9 @@ where
         &self.0
     }
 
-    pub(crate) fn open_stream(&self) -> HttpStream<T> {
+    pub(crate) fn open_stream(&self) -> HranaStream<T> {
         let client = self.client();
-        HttpStream::open(
+        HranaStream::open(
             client.inner.clone(),
             client.url_for_queries.clone(),
             client.auth.clone(),

--- a/libsql/src/hrana/cursor.rs
+++ b/libsql/src/hrana/cursor.rs
@@ -1,0 +1,87 @@
+// https://github.com/tursodatabase/libsql/blob/main/docs/HRANA_3_SPEC.md#cursor-entries
+
+use crate::hrana::proto::{Batch, Col, Value};
+use crate::hrana::{HttpSend, Result};
+use futures::lock::Mutex;
+use serde::{Deserialize, Serialize};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+#[derive(Serialize, Debug)]
+pub struct CursorReq {
+    pub baton: Option<String>,
+    pub batch: Batch,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct CursorResp {
+    pub baton: Option<String>,
+    pub base_url: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CursorEntry {
+    StepBegin(StepBeginEntry),
+    StepEnd(StepEndEntry),
+    StepError(StepErrorEntry),
+    Row(RowEntry),
+    Error(ErrorEntry),
+}
+
+#[derive(Deserialize, Debug)]
+pub struct StepBeginEntry {
+    pub step: u32,
+    pub cols: Vec<Col>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct StepEndEntry {
+    pub affected_row_count: u32,
+    pub last_inserted_rowid: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct RowEntry {
+    pub row: Vec<Value>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct StepErrorEntry {
+    pub step: u32,
+    pub error: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ErrorEntry {
+    pub error: String,
+}
+
+#[derive(Debug)]
+pub struct Cursor<T>
+where
+    T: for<'a> HttpSend<'a>,
+{
+    stream: T,
+}
+
+impl<T> Cursor<T>
+where
+    T: for<'a> HttpSend<'a>,
+{
+    pub async fn open(stream: T, url: String, auth_token: String, body: Batch) -> Result<T> {
+        todo!()
+    }
+}
+
+impl<T> futures::Stream for Cursor<T>
+where
+    T: for<'a> HttpSend<'a>,
+{
+    type Item = Result<CursorEntry>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        todo!()
+    }
+}

--- a/libsql/src/hrana/cursor.rs
+++ b/libsql/src/hrana/cursor.rs
@@ -2,10 +2,8 @@
 
 use crate::hrana::proto::{Batch, Col, Value};
 use crate::hrana::{HttpSend, Result};
-use futures::lock::Mutex;
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 
 #[derive(Serialize, Debug)]

--- a/libsql/src/hrana/cursor.rs
+++ b/libsql/src/hrana/cursor.rs
@@ -211,9 +211,11 @@ where
                     begin = Some(entry);
                     break;
                 }
-                CursorEntry::Row(_) | CursorEntry::StepEnd(_) => {
-                    // skipping over entries: Cursor::next_step might
-                    // have been called before previous step ended
+                CursorEntry::Row(_) => {
+                    tracing::trace!("skipping over row message for previous cursor step")
+                }
+                CursorEntry::StepEnd(_) => {
+                    tracing::debug!("skipping over StepEnd message for previous cursor step")
                 }
                 CursorEntry::StepError(e) => {
                     return Err(HranaError::CursorError(CursorResponseError::StepError {

--- a/libsql/src/hrana/cursor.rs
+++ b/libsql/src/hrana/cursor.rs
@@ -1,7 +1,7 @@
 // https://github.com/tursodatabase/libsql/blob/main/docs/HRANA_3_SPEC.md#cursor-entries
 
 use crate::hrana::proto::{Batch, Col, Value};
-use crate::hrana::{HttpSend, Result};
+use crate::hrana::{ByteStream, HttpBody, HttpSend, Result};
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -56,27 +56,13 @@ pub struct ErrorEntry {
     pub error: String,
 }
 
-#[derive(Debug)]
-pub struct Cursor<T>
-where
-    T: for<'a> HttpSend<'a>,
-{
-    stream: T,
+pub struct Cursor {
+    response_stream: ByteStream,
 }
 
-impl<T> Cursor<T>
-where
-    T: for<'a> HttpSend<'a>,
-{
-    pub async fn open(stream: T, url: String, auth_token: String, body: Batch) -> Result<T> {
-        todo!()
-    }
-}
+impl Cursor {}
 
-impl<T> futures::Stream for Cursor<T>
-where
-    T: for<'a> HttpSend<'a>,
-{
+impl futures::Stream for Cursor {
     type Item = Result<CursorEntry>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/libsql/src/hrana/cursor.rs
+++ b/libsql/src/hrana/cursor.rs
@@ -1,9 +1,12 @@
 // https://github.com/tursodatabase/libsql/blob/main/docs/HRANA_3_SPEC.md#cursor-entries
 
 use crate::hrana::proto::{Batch, Col, Value};
-use crate::hrana::{ByteStream, HttpBody, HttpSend, Result};
+use crate::hrana::{ByteStream, CursorResponseError, HranaError, Result, Row};
+use futures::{ready, Future, Stream, StreamExt};
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 #[derive(Serialize, Debug)]
@@ -57,15 +60,248 @@ pub struct ErrorEntry {
 }
 
 pub struct Cursor {
-    response_stream: ByteStream,
+    stream: ByteStream,
+    buf: VecDeque<u8>,
 }
 
-impl Cursor {}
+impl Cursor {
+    pub(super) async fn open(stream: ByteStream) -> Result<(Self, CursorResp)> {
+        let mut cursor = Cursor {
+            stream,
+            buf: VecDeque::new(),
+        };
+        if let Some(line) = cursor.next_line().await {
+            let response: CursorResp = serde_json::from_str(&line?)?;
+            Ok((cursor, response))
+        } else {
+            Err(HranaError::CursorError(CursorResponseError::CursorClosed))
+        }
+    }
 
-impl futures::Stream for Cursor {
+    pub async fn next_step(&mut self) -> Result<CursorStep> {
+        CursorStep::new(self).await
+    }
+
+    pub async fn next_line(&mut self) -> Option<Result<String>> {
+        //TODO: this could be optimized into dedicated async STM
+        const NEW_LINE: u8 = '\n' as u8;
+        let mut len = self.buf.len();
+        let mut index = self.buf.iter().position(|b| *b == NEW_LINE);
+        while index.is_none() {
+            match self.stream.next().await {
+                Some(Err(e)) => return Some(Err(e.into())),
+                Some(Ok(bytes)) if !bytes.is_empty() => {
+                    index = bytes.iter().position(|b| *b == NEW_LINE).map(|i| i + len);
+                    self.buf.extend(bytes);
+                    len = self.buf.len();
+                }
+                _ => break,
+            };
+        }
+
+        let line: Vec<_> = if let Some(index) = index {
+            let line = self.buf.drain(..index).collect();
+            self.buf.pop_front(); // remove new line character from the buffer
+            line
+        } else {
+            self.buf.drain(..).collect()
+        };
+        if line.is_empty() {
+            None
+        } else {
+            let result = String::from_utf8(line).map_err(|_| {
+                HranaError::UnexpectedResponse("Response is not a valid UTF-8 string".to_string())
+            });
+            Some(result)
+        }
+    }
+}
+
+impl Stream for Cursor {
     type Item = Result<CursorEntry>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        todo!()
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut fut = Box::pin(self.next_line());
+        let res = ready!(Pin::new(&mut fut).poll(cx));
+        match res {
+            None => Poll::Ready(None),
+            Some(Err(e)) => Poll::Ready(Some(Err(e))),
+            Some(Ok(line)) => {
+                let entry: CursorEntry = match serde_json::from_str(line.as_str()) {
+                    Ok(entry) => entry,
+                    Err(e) => return Poll::Ready(Some(Err(e.into()))),
+                };
+                Poll::Ready(Some(Ok(entry)))
+            }
+        }
+    }
+}
+
+pub struct CursorStep<'a> {
+    cursor: Option<&'a mut Cursor>,
+    cols: Arc<Vec<Col>>,
+    step_no: u32,
+    affected_rows: u32,
+    last_inserted_rowid: Option<String>,
+}
+
+impl<'a> CursorStep<'a> {
+    async fn new(cursor: &'a mut Cursor) -> Result<CursorStep<'a>> {
+        let mut begin = None;
+        while let Some(res) = cursor.next().await {
+            match res? {
+                CursorEntry::StepBegin(entry) => {
+                    begin = Some(entry);
+                    break;
+                }
+                CursorEntry::Row(_) | CursorEntry::StepEnd(_) => {
+                    // skipping over entries: Cursor::next_step might
+                    // have been called before previous step ended
+                }
+                CursorEntry::StepError(e) => {
+                    return Err(HranaError::CursorError(CursorResponseError::StepError {
+                        step: e.step,
+                        error: e.error,
+                    }))
+                }
+                CursorEntry::Error(e) => {
+                    return Err(HranaError::CursorError(CursorResponseError::Other(e.error)))
+                }
+            }
+        }
+        if let Some(begin) = begin {
+            Ok(CursorStep {
+                cursor: Some(cursor),
+                cols: Arc::new(begin.cols),
+                step_no: begin.step,
+                affected_rows: 0,
+                last_inserted_rowid: None,
+            })
+        } else {
+            Err(HranaError::CursorError(CursorResponseError::CursorClosed))
+        }
+    }
+
+    pub fn cols(&self) -> &[Col] {
+        &self.cols
+    }
+
+    pub fn step_no(&self) -> u32 {
+        self.step_no
+    }
+
+    pub fn affected_rows(&self) -> u32 {
+        self.affected_rows
+    }
+
+    pub fn last_inserted_rowid(&self) -> Option<&str> {
+        self.last_inserted_rowid.as_deref()
+    }
+}
+
+impl<'a> Stream for CursorStep<'a> {
+    type Item = Result<Row>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let cursor = if let Some(cursor) = &mut self.cursor {
+            Pin::new(cursor)
+        } else {
+            return Poll::Ready(None);
+        };
+        match ready!(cursor.poll_next(cx)) {
+            None => {
+                self.cursor = None;
+                Poll::Ready(None)
+            }
+            Some(Err(e)) => Poll::Ready(Some(Err(e))),
+            Some(Ok(entry)) => match entry {
+                CursorEntry::Row(row) => {
+                    let row = Row::new(self.cols.clone(), row.row);
+                    Poll::Ready(Some(Ok(row)))
+                }
+                CursorEntry::StepEnd(end) => {
+                    self.affected_rows = end.affected_row_count;
+                    self.last_inserted_rowid = end.last_inserted_rowid;
+                    self.cursor = None;
+                    Poll::Ready(None)
+                }
+                CursorEntry::StepBegin(begin) => Poll::Ready(Some(Err(HranaError::CursorError(
+                    CursorResponseError::NotClosed {
+                        expected: self.step_no,
+                        actual: begin.step,
+                    },
+                )))),
+                CursorEntry::StepError(e) => Poll::Ready(Some(Err(HranaError::CursorError(
+                    CursorResponseError::StepError {
+                        step: e.step,
+                        error: e.error,
+                    },
+                )))),
+                CursorEntry::Error(e) => Poll::Ready(Some(Err(HranaError::CursorError(
+                    CursorResponseError::Other(e.error),
+                )))),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::hrana::cursor::Cursor;
+    use crate::hrana::ByteStream;
+    use crate::rows::RowInner;
+    use crate::Value;
+    use bytes::Bytes;
+    use futures::StreamExt;
+    use serde_json::json;
+
+    fn byte_stream(entries: impl IntoIterator<Item = serde_json::Value>) -> ByteStream {
+        let mut payload = Vec::new();
+        const NEW_LINE: &[u8] = "\n".as_bytes();
+        for v in entries.into_iter() {
+            serde_json::to_writer(&mut payload, &v).unwrap();
+            payload.extend_from_slice(NEW_LINE);
+        }
+        let chunks: Vec<_> = Bytes::from(payload)
+            .chunks(23)
+            .map(|chunk| Ok(Bytes::copy_from_slice(chunk)))
+            .collect();
+        let stream = futures::stream::iter(chunks);
+        Box::new(stream)
+    }
+    #[tokio::test]
+    async fn cursor_streaming() {
+        let byte_stream = byte_stream(vec![
+            json!({"baton": null, "base_url": null}),
+            json!({"type": "step_begin", "step": 0, "cols": [{"name": "id"}, {"name": "email"}]}),
+            json!({"type": "row", "row": [{"type": "integer", "value": "1"}, {"type": "text", "value": "alice@test.com"}]}),
+            json!({"type": "row", "row": [{"type": "integer", "value": "2"}, {"type": "text", "value": "bob@test.com"}]}),
+            json!({"type": "step_end", "affected_row_count": 0, "last_insert_rowid": null}),
+        ]);
+        let (mut cursor, resp) = Cursor::open(byte_stream).await.unwrap();
+        assert_eq!(resp.baton, None);
+        assert_eq!(resp.base_url, None);
+
+        let mut step = cursor.next_step().await.unwrap();
+        assert_eq!(step.step_no(), 0);
+        {
+            let cols: Vec<_> = step
+                .cols
+                .iter()
+                .map(|col| col.name.as_deref().unwrap_or(""))
+                .collect();
+            assert_eq!(cols, vec!["id", "email"]);
+        }
+
+        let row = step.next().await.unwrap().unwrap();
+        assert_eq!(row.column_value(0).unwrap(), Value::from(1));
+        assert_eq!(row.column_value(1).unwrap(), Value::from("alice@test.com"));
+
+        let row = step.next().await.unwrap().unwrap();
+        assert_eq!(row.column_value(0).unwrap(), Value::from(2));
+        assert_eq!(row.column_value(1).unwrap(), Value::from("bob@test.com"));
+
+        let row = step.next().await;
+        assert!(row.is_none(), "last row should be None: {:?}", row);
     }
 }

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -218,13 +218,13 @@ impl Conn for HranaStream<HttpSender> {
     }
 
     async fn execute_batch(&self, sql: &str) -> crate::Result<()> {
-        let mut batch = Batch::new();
-        let stmts = crate::parser::Statement::parse(sql);
-        for s in stmts {
+        let mut stmts = Vec::new();
+        let parse = crate::parser::Statement::parse(sql);
+        for s in parse {
             let s = s?;
-            batch.step(None, Stmt::new(s.stmt, false));
+            stmts.push(Stmt::new(s.stmt, false));
         }
-        self.batch(batch)
+        self.batch(Batch::from_iter(stmts, false))
             .await
             .map_err(|e| crate::Error::Hrana(e.into()))?;
         Ok(())

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -33,7 +33,7 @@ impl HttpSender {
         Self { inner, version }
     }
 
-    async fn send(&self, url: String, auth: String, body: String) -> Result<super::HttpBody> {
+    async fn send(&self, url: &str, auth: &str, body: String) -> Result<super::HttpBody> {
         let req = hyper::Request::post(url)
             .header(AUTHORIZATION, auth)
             .header("x-libsql-client-version", self.version.clone())
@@ -70,7 +70,7 @@ impl HttpSender {
 impl<'a> HttpSend<'a> for HttpSender {
     type Result = BoxFuture<'a, Result<super::HttpBody>>;
 
-    fn http_send(&'a self, url: String, auth: String, body: String) -> Self::Result {
+    fn http_send(&'a self, url: &'a str, auth: &'a str, body: String) -> Self::Result {
         let fut = self.send(url, auth, body);
         Box::pin(fut)
     }

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -2,13 +2,14 @@ use crate::connection::Conn;
 use crate::hrana::connection::HttpConnection;
 use crate::hrana::pipeline::ServerMsg;
 use crate::hrana::proto::{Batch, Stmt};
-use crate::hrana::stream::HttpStream;
+use crate::hrana::stream::HranaStream;
 use crate::hrana::transaction::HttpTransaction;
 use crate::hrana::{bind_params, HranaError, HttpSend, Result};
 use crate::params::Params;
 use crate::transaction::Tx;
 use crate::util::ConnectorService;
 use crate::{Rows, Statement};
+use bytes::Bytes;
 use futures::future::BoxFuture;
 use http::header::AUTHORIZATION;
 use http::{HeaderValue, StatusCode};
@@ -31,7 +32,7 @@ impl HttpSender {
         Self { inner, version }
     }
 
-    async fn send(&self, url: String, auth: String, body: String) -> Result<ServerMsg> {
+    async fn send(&self, url: String, auth: String, body: String) -> Result<Bytes> {
         let req = hyper::Request::post(url)
             .header(AUTHORIZATION, auth)
             .header("x-libsql-client-version", self.version.clone())
@@ -48,15 +49,12 @@ impl HttpSender {
         }
 
         let body = hyper::body::to_bytes(res.into_body()).await?;
-
-        let msg = serde_json::from_slice::<ServerMsg>(&body[..])?;
-
-        Ok(msg)
+        Ok(body)
     }
 }
 
 impl<'a> HttpSend<'a> for HttpSender {
-    type Result = BoxFuture<'a, Result<ServerMsg>>;
+    type Result = BoxFuture<'a, Result<Bytes>>;
 
     fn http_send(&'a self, url: String, auth: String, body: String) -> Self::Result {
         let fut = self.send(url, auth, body);
@@ -194,7 +192,7 @@ impl Tx for HttpTransaction<HttpSender> {
 }
 
 #[async_trait::async_trait]
-impl Conn for HttpStream<HttpSender> {
+impl Conn for HranaStream<HttpSender> {
     async fn execute(&self, sql: &str, params: Params) -> crate::Result<u64> {
         let mut stmt = Stmt::new(sql, false);
         bind_params(params, &mut stmt);

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -1,6 +1,5 @@
 use crate::connection::Conn;
 use crate::hrana::connection::HttpConnection;
-use crate::hrana::pipeline::ServerMsg;
 use crate::hrana::proto::{Batch, Stmt};
 use crate::hrana::stream::HranaStream;
 use crate::hrana::transaction::HttpTransaction;
@@ -9,10 +8,12 @@ use crate::params::Params;
 use crate::transaction::Tx;
 use crate::util::ConnectorService;
 use crate::{Rows, Statement};
-use bytes::Bytes;
 use futures::future::BoxFuture;
+use futures::TryStreamExt;
 use http::header::AUTHORIZATION;
 use http::{HeaderValue, StatusCode};
+use hyper::body::HttpBody;
+use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
@@ -32,29 +33,42 @@ impl HttpSender {
         Self { inner, version }
     }
 
-    async fn send(&self, url: String, auth: String, body: String) -> Result<Bytes> {
+    async fn send(&self, url: String, auth: String, body: String) -> Result<super::HttpBody> {
         let req = hyper::Request::post(url)
             .header(AUTHORIZATION, auth)
             .header("x-libsql-client-version", self.version.clone())
             .body(hyper::Body::from(body))
             .map_err(|err| HranaError::Http(format!("{:?}", err)))?;
 
-        let res = self.inner.request(req).await?;
+        let resp = self.inner.request(req).await.map_err(HranaError::from)?;
 
-        if res.status() != StatusCode::OK {
-            let body = hyper::body::to_bytes(res.into_body()).await?;
-            let msg = String::from_utf8(body.into())
-                .unwrap_or_else(|err| format!("Invalid payload: {}", err));
-            return Err(HranaError::Api(msg));
+        if resp.status() != StatusCode::OK {
+            let body = hyper::body::to_bytes(resp.into_body())
+                .await
+                .map_err(HranaError::from)?;
+            let body = String::from_utf8(body.into()).unwrap();
+            return Err(HranaError::Api(body));
         }
 
-        let body = hyper::body::to_bytes(res.into_body()).await?;
+        let body = if resp.is_end_stream() {
+            let body = hyper::body::to_bytes(resp.into_body())
+                .await
+                .map_err(HranaError::from)?;
+            super::HttpBody::Body(body)
+        } else {
+            let stream = resp
+                .into_body()
+                .into_stream()
+                .map_err(|e| HranaError::Http(e.to_string()));
+            super::HttpBody::Stream(Box::new(stream))
+        };
+
         Ok(body)
     }
 }
 
 impl<'a> HttpSend<'a> for HttpSender {
-    type Result = BoxFuture<'a, Result<Bytes>>;
+    type Result = BoxFuture<'a, Result<super::HttpBody>>;
 
     fn http_send(&'a self, url: String, auth: String, body: String) -> Self::Result {
         let fut = self.send(url, auth, body);

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -24,7 +24,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tokio_stream::StreamExt;
 
 use super::rows::{RowInner, RowsInner};
 
@@ -88,6 +87,8 @@ impl Stream for SimpleStream {
 }
 
 async fn stream_to_bytes(mut stream: ByteStream) -> Result<Bytes> {
+    use futures::StreamExt;
+
     let mut buf = BytesMut::new();
     while let Some(chunk) = stream.next().await {
         buf.extend_from_slice(&chunk?);

--- a/libsql/src/hrana/stream.rs
+++ b/libsql/src/hrana/stream.rs
@@ -214,10 +214,10 @@ where
     client: T,
     baton: Option<String>,
     pipeline_url: Arc<str>,
+    cursor_url: Arc<str>,
     auth_token: Arc<str>,
     status: StreamStatus,
     sql_id_generator: SqlId,
-    cursor_url: Arc<str>,
 }
 
 impl<T> RawStream<T>
@@ -246,7 +246,8 @@ where
             .await?;
         let (cursor, mut response) = Cursor::open(stream).await?;
         if let Some(base_url) = response.base_url.take() {
-            self.cursor_url = Arc::from(base_url);
+            self.pipeline_url = Arc::from(format!("{base_url}/v3/pipeline"));
+            self.cursor_url = Arc::from(format!("{base_url}/v3/cursor"));
         }
         match response.baton.take() {
             None => {

--- a/libsql/src/hrana/stream.rs
+++ b/libsql/src/hrana/stream.rs
@@ -236,6 +236,8 @@ where
         let body = self
             .client
             .http_send(self.base_url.clone(), self.auth_token.clone(), body)
+            .await?
+            .bytes()
             .await?;
         let mut response: ServerMsg = serde_json::from_slice(&body)?;
         if let Some(base_url) = response.base_url.take() {

--- a/libsql/src/hrana/transaction.rs
+++ b/libsql/src/hrana/transaction.rs
@@ -1,7 +1,7 @@
 use crate::hrana::connection::stmts_to_batch;
 use crate::hrana::pipeline::{ExecuteStreamReq, StreamRequest};
-use crate::hrana::proto::{BatchResult, Stmt, StmtResult};
-use crate::hrana::stream::HttpStream;
+use crate::hrana::proto::{Batch, BatchResult, Stmt, StmtResult};
+use crate::hrana::stream::HranaStream;
 use crate::hrana::{HttpSend, Result};
 use crate::TransactionBehavior;
 
@@ -10,18 +10,18 @@ pub(crate) struct HttpTransaction<T>
 where
     T: for<'a> HttpSend<'a>,
 {
-    stream: HttpStream<T>,
+    stream: HranaStream<T>,
 }
 
 impl<T> HttpTransaction<T>
 where
     T: for<'a> HttpSend<'a>,
 {
-    pub fn stream(&self) -> &HttpStream<T> {
+    pub fn stream(&self) -> &HranaStream<T> {
         &self.stream
     }
 
-    pub async fn open(stream: HttpStream<T>, tx_behavior: TransactionBehavior) -> Result<Self> {
+    pub async fn open(stream: HranaStream<T>, tx_behavior: TransactionBehavior) -> Result<Self> {
         let begin_stmt = match tx_behavior {
             TransactionBehavior::Deferred => "BEGIN DEFERRED",
             TransactionBehavior::Immediate => "BEGIN IMMEDIATE",

--- a/libsql/src/hrana/transaction.rs
+++ b/libsql/src/hrana/transaction.rs
@@ -1,6 +1,6 @@
 use crate::hrana::connection::stmts_to_batch;
 use crate::hrana::pipeline::{ExecuteStreamReq, StreamRequest};
-use crate::hrana::proto::{Batch, BatchResult, Stmt, StmtResult};
+use crate::hrana::proto::{BatchResult, Stmt, StmtResult};
 use crate::hrana::stream::HranaStream;
 use crate::hrana::{HttpSend, Result};
 use crate::TransactionBehavior;

--- a/libsql/src/hrana/transaction.rs
+++ b/libsql/src/hrana/transaction.rs
@@ -1,6 +1,5 @@
-use crate::hrana::connection::stmts_to_batch;
 use crate::hrana::pipeline::{ExecuteStreamReq, StreamRequest};
-use crate::hrana::proto::{BatchResult, Stmt, StmtResult};
+use crate::hrana::proto::{Batch, BatchResult, Stmt, StmtResult};
 use crate::hrana::stream::HranaStream;
 use crate::hrana::{HttpSend, Result};
 use crate::TransactionBehavior;
@@ -40,7 +39,7 @@ where
         &self,
         stmts: impl IntoIterator<Item = Stmt>,
     ) -> Result<BatchResult> {
-        let batch = stmts_to_batch(false, stmts);
+        let batch = Batch::from_iter(stmts, false);
         self.stream.batch(batch).await
     }
 

--- a/libsql/src/hrana/transaction.rs
+++ b/libsql/src/hrana/transaction.rs
@@ -7,14 +7,14 @@ use crate::TransactionBehavior;
 #[derive(Debug, Clone)]
 pub(crate) struct HttpTransaction<T>
 where
-    T: for<'a> HttpSend<'a>,
+    T: HttpSend,
 {
     stream: HranaStream<T>,
 }
 
 impl<T> HttpTransaction<T>
 where
-    T: for<'a> HttpSend<'a>,
+    T: HttpSend,
 {
     pub fn stream(&self) -> &HranaStream<T> {
         &self.stream

--- a/libsql/src/value.rs
+++ b/libsql/src/value.rs
@@ -2,8 +2,7 @@ use std::str::FromStr;
 
 use crate::{Error, Result};
 
-/// An enum representing the types in libsql.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum Value {
     Null,

--- a/libsql/src/wasm/cloudflare.rs
+++ b/libsql/src/wasm/cloudflare.rs
@@ -13,16 +13,16 @@ impl CloudflareSender {
         CloudflareSender(())
     }
 
-    async fn send(url: String, auth: String, body: String) -> Result<Bytes> {
+    async fn send(url: &str, auth: &str, body: String) -> Result<Bytes> {
         use worker::*;
 
         let mut response = Fetch::Request(Request::new_with_init(
-            &url,
+            url,
             &RequestInit {
                 body: Some(JsValue::from(body)),
                 headers: {
                     let mut headers = Headers::new();
-                    headers.append("Authorization", &auth)?;
+                    headers.append("Authorization", auth)?;
                     headers
                 },
                 cf: CfProperties::new(),
@@ -45,7 +45,7 @@ impl CloudflareSender {
 impl<'a> HttpSend<'a> for CloudflareSender {
     type Result = Pin<Box<dyn Future<Output = Result<Bytes>> + 'a>>;
 
-    fn http_send(&self, url: String, auth: String, body: String) -> Self::Result {
+    fn http_send(&'a self, url: &'a str, auth: &'a str, body: String) -> Self::Result {
         let fut = Self::send(url, auth, body);
         Box::pin(fut)
     }

--- a/libsql/src/wasm/cloudflare.rs
+++ b/libsql/src/wasm/cloudflare.rs
@@ -1,8 +1,9 @@
-use crate::hrana::pipeline::ServerMsg;
-use crate::hrana::{HranaError, HttpSend, Result};
+use crate::hrana::{HranaError, HttpBody, HttpSend, Result};
 use bytes::Bytes;
+use futures::{ready, Stream};
 use std::future::Future;
 use std::pin::Pin;
+use std::task::{Context, Poll};
 use worker::wasm_bindgen::JsValue;
 
 #[derive(Debug, Copy, Clone)]
@@ -13,7 +14,7 @@ impl CloudflareSender {
         CloudflareSender(())
     }
 
-    async fn send(url: &str, auth: &str, body: String) -> Result<Bytes> {
+    async fn send(url: &str, auth: &str, body: String) -> Result<HttpBody> {
         use worker::*;
 
         let mut response = Fetch::Request(Request::new_with_init(
@@ -36,14 +37,18 @@ impl CloudflareSender {
             let body = response.text().await?;
             Err(HranaError::Api(body))
         } else {
-            let body = response.bytes().await?;
-            Ok(Bytes::from(body))
+            let body = match response.body() {
+                ResponseBody::Empty => HttpBody::Body(Bytes::new()),
+                ResponseBody::Body(body) => HttpBody::Body(Bytes::from(body.clone())),
+                _ => HttpBody::Stream(Box::new(HttpStream(response.stream()?))),
+            };
+            Ok(body)
         }
     }
 }
 
 impl<'a> HttpSend<'a> for CloudflareSender {
-    type Result = Pin<Box<dyn Future<Output = Result<Bytes>> + 'a>>;
+    type Result = Pin<Box<dyn Future<Output = Result<HttpBody>> + 'a>>;
 
     fn http_send(&'a self, url: &'a str, auth: &'a str, body: String) -> Self::Result {
         let fut = Self::send(url, auth, body);
@@ -56,5 +61,24 @@ impl From<worker::Error> for HranaError {
         // This converts it to a string due to the error type being !Send/!Sync which will break
         // a lot of stuff.
         HranaError::Http(value.to_string())
+    }
+}
+
+struct HttpStream(worker::ByteStream);
+
+impl Stream for HttpStream {
+    type Item = Result<Bytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let pin = Pin::new(&mut self.0);
+        let res = ready!(pin.poll_next(cx));
+        match res {
+            None => Poll::Ready(None),
+            Some(Ok(data)) => Poll::Ready(Some(Ok(Bytes::from(data)))),
+            Some(Err(e)) => Poll::Ready(Some(Err(HranaError::Http(format!(
+                "cloudflare HTTP stream error: {}",
+                e
+            ))))),
+        }
     }
 }

--- a/libsql/src/wasm/mod.rs
+++ b/libsql/src/wasm/mod.rs
@@ -42,7 +42,7 @@ cfg_cloudflare! {
 #[derive(Debug, Clone)]
 pub struct Connection<T>
 where
-    T: for<'a> HttpSend<'a>,
+    T: HttpSend,
 {
     conn: HttpConnection<T>,
 }
@@ -59,7 +59,7 @@ cfg_cloudflare! {
 
 impl<T> Connection<T>
 where
-    T: for<'a> HttpSend<'a>,
+    T: HttpSend,
 {
     pub async fn execute(&self, sql: &str, params: impl IntoParams) -> crate::Result<u64> {
         tracing::trace!("executing `{}`", sql);
@@ -105,14 +105,14 @@ where
 #[derive(Debug, Clone)]
 pub struct Transaction<T>
 where
-    T: for<'a> HttpSend<'a>,
+    T: HttpSend,
 {
     inner: HttpTransaction<T>,
 }
 
 impl<T> Transaction<T>
 where
-    T: for<'a> HttpSend<'a>,
+    T: HttpSend,
 {
     pub async fn query(&self, sql: &str, params: impl IntoParams) -> crate::Result<Rows> {
         tracing::trace!("querying `{}`", sql);


### PR DESCRIPTION
WIP

This PR adds a support for cursors in Hrana HTTP client. Cursors enable to fetch rows and batch results on demand, without requiring to prefetch (potentially large) result sets in memory. This is done by:
1. Splitting `HttpSend` trait response into buffered and streamed one.
2. Introducing cursor data structure capable of patching streamed response into series of protocol messages:
    - These messages are then organised into streams of cursor steps (each step matches an input batch request result set).
    - Further cursor steps organise streams of subsequent entries into start/end step metadata and stream of rows.

PS: atm. cursor API is replacing existing execute/execute_batch statement in HranaStream without any profound changes in the upper libsql client API. It does so by calling a cursor API and then buffering it into memory and converting it into `BatchResult` which is a well-understood libsql client structure. Therefore event though it's used underneath and tested, the advantages of using it are none, as currently the upper layer of libsql client API - which is shared between local SQLite, embedded replicas and Hrana - has no means to represent a streamed content.