### PR TITLE
Add path based routing

### DIFF
--- a/libsql-server/src/error.rs
+++ b/libsql-server/src/error.rs
@@ -56,6 +56,8 @@ pub enum Error {
     Anyhow(#[from] anyhow::Error),
     #[error("Invalid host header: `{0}`")]
     InvalidHost(String),
+    #[error("Invalid path in URI: `{0}`")]
+    InvalidPath(String),
     #[error("Namespace `{0}` doesn't exist")]
     NamespaceDoesntExist(String),
     #[error("Namespace `{0}` already exists")]
@@ -132,6 +134,7 @@ impl IntoResponse for Error {
             TooManyRequests => self.format_err(StatusCode::TOO_MANY_REQUESTS),
             QueryError(_) => self.format_err(StatusCode::BAD_REQUEST),
             InvalidHost(_) => self.format_err(StatusCode::BAD_REQUEST),
+            InvalidPath(_) => self.format_err(StatusCode::BAD_REQUEST),
             NamespaceDoesntExist(_) => self.format_err(StatusCode::BAD_REQUEST),
             PrimaryConnectionTimeout => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             NamespaceAlreadyExist(_) => self.format_err(StatusCode::BAD_REQUEST),

--- a/libsql-server/src/http/user/db_factory.rs
+++ b/libsql-server/src/http/user/db_factory.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use axum::extract::FromRequestParts;
+use axum::extract::{FromRequestParts, Path};
 use hyper::http::request::Parts;
 use hyper::HeaderMap;
 
@@ -78,13 +78,13 @@ where
         state: &AppState<F>,
     ) -> Result<Self, Self::Rejection> {
         let auth = Authenticated::from_request_parts(parts, state).await?;
-        let ns = axum::extract::Path::<NamespaceName>::from_request_parts(parts, state)
+        let Path((ns, _)) = Path::<(NamespaceName, String)>::from_request_parts(parts, state)
             .await
             .map_err(|e| Error::InvalidPath(e.to_string()))?;
         Ok(Self(
             state
                 .namespaces
-                .with_authenticated(ns.to_owned(), auth, |ns| ns.db.connection_maker())
+                .with_authenticated(ns, auth, |ns| ns.db.connection_maker())
                 .await?,
         ))
     }


### PR DESCRIPTION
This PR adds a way to extract namespace from the path. This is done so that users can have smooth experience in `turso dev` and they can connect to multiple namespaces without editing `/etc/hosts` file. This patch does not require any changes in shell or libraries.

1. The expected path format is `/dev/<namespace>` I am not sure if we want to enable to this feature on the platform. So for now, I kept it behind the `/dev` sub path
2. Similarly, I have enabled only `/dev/:namespace/v2/pipeline` and `/dev/:namespace/v3/pipeline` paths.

I have tested this with turso shell and go sdk.