### PR TITLE
fix libsql Value deserialization

### DIFF
--- a/libsql/src/de.rs
+++ b/libsql/src/de.rs
@@ -1,8 +1,5 @@
 use crate::{Row, Value};
-use serde::de::{
-    value::{Error as DeError, SeqDeserializer},
-    Error, IntoDeserializer, MapAccess, Visitor,
-};
+use serde::de::{value::Error as DeError, Error, IntoDeserializer, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 
 struct RowDeserializer<'de> {
@@ -66,16 +63,7 @@ impl<'de> Deserializer<'de> for RowDeserializer<'de> {
                     .take()
                     .ok_or(DeError::custom("Expects a value but row is exhausted"))?;
 
-                match value {
-                    Value::Text(value) => seed.deserialize(value.into_deserializer()),
-                    Value::Null => seed.deserialize(().into_deserializer()),
-                    Value::Integer(value) => seed.deserialize(value.into_deserializer()),
-                    Value::Real(value) => seed.deserialize(value.into_deserializer()),
-                    Value::Blob(value) => {
-                        let seq = SeqDeserializer::new(value.iter().cloned());
-                        seed.deserialize(seq)
-                    }
-                }
+                seed.deserialize(value.into_deserializer())
             }
         }
 

--- a/libsql/tests/integration_tests.rs
+++ b/libsql/tests/integration_tests.rs
@@ -384,7 +384,7 @@ async fn deserialize_row() {
         name: String,
         score: f64,
         data: Vec<u8>,
-        age: (),
+        age: Option<i64>,
     }
 
     let row = conn
@@ -399,5 +399,5 @@ async fn deserialize_row() {
     assert_eq!(data.name, "potato".to_string());
     assert_eq!(data.score, 3.14);
     assert_eq!(data.data, vec![0xde, 0xad, 0xbe, 0xef]);
-    assert_eq!(data.age, ());
+    assert_eq!(data.age, None);
 }


### PR DESCRIPTION
I noticed that the row deserialization was not implemented correctly, because `Value::Null` was deserialized with the unit deserializer, which is incorrect. Instead, I implemented a `ValueDeserializer` that handles deserializing values correctly.
