### PR TITLE
Use NonZeroU32 for frame_no and page_no

### DIFF
--- a/bottomless/src/bottomless_wal.rs
+++ b/bottomless/src/bottomless_wal.rs
@@ -1,4 +1,5 @@
 use std::ffi::{c_int, CStr};
+use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex};
 
 use libsql_sys::ffi::{SQLITE_BUSY, SQLITE_IOERR_WRITE};
@@ -110,11 +111,11 @@ impl<T: Wal> Wal for BottomlessWal<T> {
         self.inner.end_read_txn()
     }
 
-    fn find_frame(&mut self, page_no: u32) -> Result<u32> {
+    fn find_frame(&mut self, page_no: NonZeroU32) -> Result<Option<NonZeroU32>> {
         self.inner.find_frame(page_no)
     }
 
-    fn read_frame(&mut self, frame_no: u32, buffer: &mut [u8]) -> Result<()> {
+    fn read_frame(&mut self, frame_no: NonZeroU32, buffer: &mut [u8]) -> Result<()> {
         self.inner.read_frame(frame_no, buffer)
     }
 

--- a/libsql-replication/src/injector/injector_wal.rs
+++ b/libsql-replication/src/injector/injector_wal.rs
@@ -1,4 +1,5 @@
 use std::ffi::{c_int, CStr};
+use std::num::NonZeroU32;
 
 use libsql_sys::ffi::PgHdr;
 use libsql_sys::wal::{
@@ -101,11 +102,11 @@ impl Wal for InjectorWal {
         self.inner.end_read_txn()
     }
 
-    fn find_frame(&mut self, page_no: u32) -> Result<u32> {
+    fn find_frame(&mut self, page_no: NonZeroU32) -> Result<Option<NonZeroU32>> {
         self.inner.find_frame(page_no)
     }
 
-    fn read_frame(&mut self, frame_no: u32, buffer: &mut [u8]) -> Result<()> {
+    fn read_frame(&mut self, frame_no: NonZeroU32, buffer: &mut [u8]) -> Result<()> {
         self.inner.read_frame(frame_no, buffer)
     }
 

--- a/libsql-server/src/namespace/replication_wal.rs
+++ b/libsql-server/src/namespace/replication_wal.rs
@@ -1,7 +1,6 @@
-use std::{
-    ffi::{c_int, CStr},
-    sync::Arc,
-};
+use std::ffi::{c_int, CStr};
+use std::num::NonZeroU32;
+use std::sync::Arc;
 
 use bottomless::{
     bottomless_wal::{BottomlessWal, CreateBottomlessWal},
@@ -139,14 +138,14 @@ impl Wal for ReplicationWal {
         }
     }
 
-    fn find_frame(&mut self, page_no: u32) -> Result<u32> {
+    fn find_frame(&mut self, page_no: NonZeroU32) -> Result<Option<NonZeroU32>> {
         match self {
             ReplicationWal::Bottomless(inner) => inner.find_frame(page_no),
             ReplicationWal::Logger(inner) => inner.find_frame(page_no),
         }
     }
 
-    fn read_frame(&mut self, frame_no: u32, buffer: &mut [u8]) -> Result<()> {
+    fn read_frame(&mut self, frame_no: NonZeroU32, buffer: &mut [u8]) -> Result<()> {
         match self {
             ReplicationWal::Bottomless(inner) => inner.read_frame(frame_no, buffer),
             ReplicationWal::Logger(inner) => inner.read_frame(frame_no, buffer),

--- a/libsql-server/src/replication/primary/replication_logger_wal.rs
+++ b/libsql-server/src/replication/primary/replication_logger_wal.rs
@@ -1,4 +1,5 @@
 use std::ffi::{c_int, CStr};
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -139,11 +140,11 @@ impl libsql_sys::wal::Wal for ReplicationLoggerWal {
         self.inner.end_read_txn()
     }
 
-    fn find_frame(&mut self, page_no: u32) -> Result<u32> {
+    fn find_frame(&mut self, page_no: NonZeroU32) -> Result<Option<NonZeroU32>> {
         self.inner.find_frame(page_no)
     }
 
-    fn read_frame(&mut self, frame_no: u32, buffer: &mut [u8]) -> Result<()> {
+    fn read_frame(&mut self, frame_no: NonZeroU32, buffer: &mut [u8]) -> Result<()> {
         self.inner.read_frame(frame_no, buffer)
     }
 

--- a/libsql-sqlite3/test/rust_suite/src/virtual_wal.rs
+++ b/libsql-sqlite3/test/rust_suite/src/virtual_wal.rs
@@ -1,6 +1,8 @@
 #![allow(improper_ctypes)]
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use libsql_sys::wal::{WalManager, Sqlite3WalManager, Sqlite3Wal, Wal, make_wal_manager};
     use libsql_sys::rusqlite::{Connection, OpenFlags};
 
@@ -67,11 +69,11 @@ mod tests {
             self.0.end_read_txn()
         }
 
-        fn find_frame(&mut self, page_no: u32) -> libsql_sys::wal::Result<u32> {
+        fn find_frame(&mut self, page_no: NonZeroU32) -> libsql_sys::wal::Result<Option<NonZeroU32>> {
             self.0.find_frame(page_no)
         }
 
-        fn read_frame(&mut self, frame_no: u32, buffer: &mut [u8]) -> libsql_sys::wal::Result<()> {
+        fn read_frame(&mut self, frame_no: NonZeroU32, buffer: &mut [u8]) -> libsql_sys::wal::Result<()> {
             self.0.read_frame(frame_no, buffer)
         }
 

--- a/libsql-sys/src/wal/mod.rs
+++ b/libsql-sys/src/wal/mod.rs
@@ -1,4 +1,5 @@
 use std::ffi::{c_int, CStr};
+use std::num::NonZeroU32;
 
 pub use crate::ffi::Error;
 use crate::ffi::*;
@@ -122,9 +123,9 @@ pub trait Wal {
     fn end_read_txn(&mut self);
 
     /// locate the frame containing page `page_no`
-    fn find_frame(&mut self, page_no: u32) -> Result<u32>;
+    fn find_frame(&mut self, page_no: NonZeroU32) -> Result<Option<NonZeroU32>>;
     /// reads frame `frame_no` into buffer.
-    fn read_frame(&mut self, frame_no: u32, buffer: &mut [u8]) -> Result<()>;
+    fn read_frame(&mut self, frame_no: NonZeroU32, buffer: &mut [u8]) -> Result<()>;
 
     fn db_size(&self) -> u32;
 


### PR DESCRIPTION
Use `NonZeroU32` to represent page_no and frame_no coming from sqlite, since a valid frame/page_no can't be 0. Also, find_frame returns 0, when a frame can't be found, instead, we return `Option<NonZeroU32>`
