### PR TITLE
Migrate from bytemuck to zerocopy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,20 +918,6 @@ name = "bytemuck"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
-]
 
 [[package]]
 name = "byteorder"
@@ -2627,7 +2613,6 @@ dependencies = [
  "base64 0.21.5",
  "bincode",
  "bitflags 2.4.1",
- "bytemuck",
  "bytes",
  "criterion",
  "fallible-iterator 0.3.0",
@@ -2655,6 +2640,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "worker",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2689,7 +2675,6 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bincode",
- "bytemuck",
  "bytes",
  "libsql-sys",
  "parking_lot",
@@ -2706,6 +2691,7 @@ dependencies = [
  "tonic-build",
  "tracing",
  "uuid",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2725,7 +2711,6 @@ dependencies = [
  "base64 0.21.5",
  "bincode",
  "bottomless",
- "bytemuck",
  "bytes",
  "bytesize",
  "chrono",

--- a/libsql-replication/Cargo.toml
+++ b/libsql-replication/Cargo.toml
@@ -11,7 +11,6 @@ prost = "0.12"
 libsql-sys = { path = "../libsql-sys", default-features = false, features = ["wal", "rusqlite"] }
 rusqlite = { workspace = true }
 parking_lot = "0.12.1"
-bytemuck = { version = "1.13.0", features = ["derive"] }
 bytes = { version = "1.5.0", features = ["serde"] } 
 serde = { version = "1.0.189", features = ["derive"] }
 thiserror = "1.0.49"
@@ -22,6 +21,7 @@ async-trait = "0.1.74"
 uuid = { version = "1.5.0", features = ["v4"] }
 tokio-util = "0.7.9"
 async-stream = "0.3.5"
+zerocopy = { version = "0.7.28", features = ["derive"] }
  
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive_arbitrary"] }

--- a/libsql-replication/src/injector/injector_wal.rs
+++ b/libsql-replication/src/injector/injector_wal.rs
@@ -224,7 +224,7 @@ fn make_page_header<'a>(frames: impl Iterator<Item = &'a FrameBorrowed>) -> (Hea
     while let Some(frame) = frames.next() {
         // the last frame in a batch marks the end of the txn
         if frames.peek().is_none() {
-            size_after = frame.header().size_after;
+            size_after = frame.header().size_after.get();
         }
 
         let page = PgHdr {
@@ -234,7 +234,7 @@ fn make_page_header<'a>(frames: impl Iterator<Item = &'a FrameBorrowed>) -> (Hea
             pCache: std::ptr::null_mut(),
             pDirty: std::ptr::null_mut(),
             pPager: std::ptr::null_mut(),
-            pgno: frame.header().page_no,
+            pgno: frame.header().page_no.get(),
             pageHash: 0,
             flags: 0x02, // PGHDR_DIRTY - it works without the flag, but why risk it
             nRef: 0,

--- a/libsql-replication/src/injector/mod.rs
+++ b/libsql-replication/src/injector/mod.rs
@@ -69,7 +69,7 @@ impl Injector {
 
     /// Inject a frame into the log. If this was a commit frame, returns Ok(Some(FrameNo)).
     pub fn inject_frame(&mut self, frame: Frame) -> Result<Option<FrameNo>, Error> {
-        let frame_close_txn = frame.header().size_after != 0;
+        let frame_close_txn = frame.header().size_after.get() != 0;
         self.buffer.lock().push_back(frame);
         if frame_close_txn || self.buffer.lock().len() >= self.capacity {
             return self.flush();
@@ -111,7 +111,7 @@ impl Injector {
         // (snapshot). Either way, we want to find the biggest frameno we're about to commit, and
         // that is either the front or the back of the buffer
         let last_frame_no = match lock.back().zip(lock.front()) {
-            Some((b, f)) => f.header().frame_no.max(b.header().frame_no),
+            Some((b, f)) => f.header().frame_no.get().max(b.header().frame_no.get()),
             None => {
                 tracing::trace!("nothing to inject");
                 return Ok(None);

--- a/libsql-replication/src/replicator.rs
+++ b/libsql-replication/src/replicator.rs
@@ -683,13 +683,13 @@ mod test {
                 .chunks(size_of::<FrameBorrowed>())
                 .map(|b| FrameMut::try_from(b).unwrap())
                 .map(|mut f| {
-                    f.header_mut().size_after = 0;
+                    f.header_mut().size_after.set(0);
                     f
                 })
                 .collect::<Vec<_>>();
 
             let size_after = frames.len();
-            frames.last_mut().unwrap().header_mut().size_after = size_after as _;
+            frames.last_mut().unwrap().header_mut().size_after = (size_after as u32).into();
 
             frames.into_iter().map(Into::into).collect()
         }

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -19,7 +19,6 @@ axum-extra = "0.7"
 base64 = "0.21.0"
 bincode = "1.3.3"
 bottomless = { version = "0", path = "../bottomless", features = ["libsql_linked_statically"] }
-bytemuck = { version = "1.13.0", features = ["derive"] }
 bytes = { version = "1.2.1", features = ["serde"] }
 bytesize = { version = "1.2.0", features = ["serde"] }
 chrono = { version = "0.4.26", features = ["serde"] }
@@ -76,7 +75,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 http-body = "0.4"
 url = { version = "2.3", features = ["serde"] }
 uuid = { version = "1.3", features = ["v4", "serde"] }
-zerocopy = "0.7.28"
+zerocopy = { version = "0.7.28", features = ["derive"] }
 
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive_arbitrary"] }

--- a/libsql-server/src/replication/primary/frame_stream.rs
+++ b/libsql-server/src/replication/primary/frame_stream.rs
@@ -126,7 +126,7 @@ impl Stream for FrameStream {
                 Ok(frame) => {
                     self.current_frame_no += 1;
                     self.produced_frames += 1;
-                    self.transaction_boundary = frame.header().size_after != 0;
+                    self.transaction_boundary = frame.header().size_after.get() != 0;
                     self.transition_state_next_frame();
                     tracing::trace!("sending frame_no {}", frame.header().frame_no);
                     Poll::Ready(Some(Ok(frame)))

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -26,7 +26,6 @@ worker = { version = "0.0.18", optional = true }
 
 bincode = { version = "1", optional = true }
 anyhow = { version = "1.0.71", optional = true }
-bytemuck = { version = "1.13.1", features = ["derive"], optional = true }
 bytes = { version = "1.4.0", features = ["serde"], optional = true }
 uuid = { version = "1.4.0", features = ["v4", "serde"], optional = true }
 tokio-stream = { version = "0.1.14", optional = true }
@@ -34,6 +33,7 @@ tonic = { version = "0.10.2", features = ["tls", "tls-roots", "tls-webpki-roots"
 tonic-web = { version = "0.10.2", optional = true }
 tower-http = { version = "0.4.4", features = ["trace", "set-header", "util"], optional = true }
 http = { version = "0.2", optional = true }
+zerocopy = { version = "0.7.28", optional = true }
 
 sqlite3-parser = { path = "../vendored/sqlite3-parser", version = "0.11", optional = true }
 fallible-iterator = { version = "0.3", optional = true }
@@ -69,7 +69,7 @@ replication = [
   "dep:tokio",
   "dep:anyhow",
   "dep:bincode",
-  "dep:bytemuck",
+  "dep:zerocopy",
   "dep:bytes",
   "dep:uuid",
   "dep:tokio-stream",

--- a/libsql/tests/replication.rs
+++ b/libsql/tests/replication.rs
@@ -18,16 +18,16 @@ async fn inject_frames() {
         .enumerate()
         .map(|(i, data)| {
             let header = FrameHeader {
-                frame_no: i as _,
-                checksum: 0,
-                page_no: i as u32 + 1,
-                size_after: 0,
+                frame_no: (i as u64).into(),
+                checksum: 0.into(),
+                page_no: (i as u32 + 1).into(),
+                size_after: 0.into(),
             };
             FrameBorrowed::from_parts(&header, data).into()
         })
         .collect();
 
-    frames.last_mut().unwrap().header_mut().size_after = frames.len() as _;
+    frames.last_mut().unwrap().header_mut().size_after = (frames.len() as u32).into();
 
     let frames = frames.into_iter().map(Into::into).collect();
 
@@ -59,16 +59,16 @@ async fn inject_frames() {
         .enumerate()
         .map(|(i, data)| {
             let header = FrameHeader {
-                frame_no: i as u64 + 3,
-                checksum: 0,
-                page_no: i as u32 + 1,
-                size_after: 0,
+                frame_no: (i as u64 + 3).into(),
+                checksum: 0.into(),
+                page_no: (i as u32 + 1).into(),
+                size_after: 0.into(),
             };
             FrameBorrowed::from_parts(&header, data).into()
         })
         .collect();
 
-    frames.last_mut().unwrap().header_mut().size_after = frames.len() as _;
+    frames.last_mut().unwrap().header_mut().size_after = (frames.len() as u32).into();
 
     let frames = frames.into_iter().map(Into::into).collect();
 
@@ -104,10 +104,10 @@ async fn inject_frames_split_txn() {
 
     let mut frames = DB.chunks(LIBSQL_PAGE_SIZE).enumerate().map(|(i, data)| {
         let header = FrameHeader {
-            frame_no: i as _,
-            checksum: 0,
-            page_no: i as u32 + 1,
-            size_after: 0,
+            frame_no: (i as u64).into(),
+            checksum: 0.into(),
+            page_no: (i as u32 + 1).into(),
+            size_after: 0.into(),
         };
         FrameBorrowed::from_parts(&header, data)
     });
@@ -136,7 +136,7 @@ async fn inject_frames_split_txn() {
         db.sync_frames(Frames::Vec(vec![frames
             .next()
             .map(|mut f| {
-                f.header_mut().size_after = 3;
+                f.header_mut().size_after = 3.into();
                 f
             })
             .unwrap()


### PR DESCRIPTION
zerocopy handles endianess, which was required for sqlite, and is overall more robust.
