### PR TITLE
prevent checkpoint on WAL close for InhibitCheckpointWal

### DIFF
--- a/bottomless/src/bottomless_wal.rs
+++ b/bottomless/src/bottomless_wal.rs
@@ -62,7 +62,7 @@ impl<T: WalManager> WalManager for CreateBottomlessWal<T> {
         wal: &mut Self::Wal,
         db: &mut Sqlite3Db,
         sync_flags: c_int,
-        scratch: &mut [u8],
+        scratch: Option<&mut [u8]>,
     ) -> Result<()> {
         self.inner.close(&mut wal.inner, db, sync_flags, scratch)
     }

--- a/libsql-replication/src/injector/injector_wal.rs
+++ b/libsql-replication/src/injector/injector_wal.rs
@@ -62,7 +62,7 @@ impl WalManager for InjectorWalManager {
         wal: &mut Self::Wal,
         db: &mut Sqlite3Db,
         sync_flags: c_int,
-        scratch: &mut [u8],
+        scratch: Option<&mut [u8]>,
     ) -> Result<()> {
         self.inner.close(&mut wal.inner, db, sync_flags, scratch)
     }

--- a/libsql-server/src/namespace/replication_wal.rs
+++ b/libsql-server/src/namespace/replication_wal.rs
@@ -73,7 +73,7 @@ impl WalManager for ReplicationWalManager {
         wal: &mut Self::Wal,
         db: &mut Sqlite3Db,
         sync_flags: c_int,
-        scratch: &mut [u8],
+        scratch: Option<&mut [u8]>,
     ) -> Result<()> {
         match (self, wal) {
             (ReplicationWalManager::Bottomless(inner), ReplicationWal::Bottomless(wal)) => {

--- a/libsql-server/src/replication/primary/replication_logger_wal.rs
+++ b/libsql-server/src/replication/primary/replication_logger_wal.rs
@@ -64,7 +64,7 @@ impl WalManager for ReplicationLoggerWalManager {
         wal: &mut Self::Wal,
         db: &mut Sqlite3Db,
         sync_flags: c_int,
-        scratch: &mut [u8],
+        scratch: Option<&mut [u8]>,
     ) -> Result<()> {
         self.sqlite_wal_manager
             .close(&mut wal.inner, db, sync_flags, scratch)

--- a/libsql-sys/src/wal/ffi.rs
+++ b/libsql-sys/src/wal/ffi.rs
@@ -103,7 +103,11 @@ pub unsafe extern "C" fn close<T: WalManager>(
 ) -> c_int {
     let this = &*(wal_manager as *mut T);
     let mut wal = Box::from_raw(wal as *mut T::Wal);
-    let scratch = std::slice::from_raw_parts_mut(z_buf, n_buf as usize);
+    let scratch = if z_buf.is_null() {
+        None
+    } else {
+        Some(std::slice::from_raw_parts_mut(z_buf, n_buf as usize))
+    };
     let mut db = Sqlite3Db { inner: db };
 
     match this.close(&mut wal, &mut db, sync_flags, scratch) {

--- a/libsql-sys/src/wal/mod.rs
+++ b/libsql-sys/src/wal/mod.rs
@@ -31,7 +31,7 @@ pub trait WalManager {
         wal: &mut Self::Wal,
         db: &mut Sqlite3Db,
         sync_flags: c_int,
-        scratch: &mut [u8],
+        scratch: Option<&mut [u8]>,
     ) -> Result<()>;
 
     fn destroy_log(&self, vfs: &mut Vfs, db_path: &CStr) -> Result<()>;


### PR DESCRIPTION
This fixes a mistake of mine. The `InhibitCheckpointWal` wal was not actually preventing checkpoint on close. This is solved by not providing a scratch buffer to the close method on close, and sqlite will simple skip checkpointing on close: https://github.com/tursodatabase/libsql/blob/main/libsql-sqlite3/src/wal.c#L2144
