### PR TITLE
.gitignore: add Cargo.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 .idea/
 *.sqld
+/Cargo.lock


### PR DESCRIPTION
According to https://doc.rust-lang.org/cargo/faq.html#why-have-cargolock-in-version-control, library code is better off ignoring Cargo.lock. Our gigarepo contains binaries too, but for the sake of dev speed, let's just ignore it. The only effect of keeping Cargo.lock around I'm aware of is to annoy people who often check out different git commits and branches.