### PR TITLE
Libsql: method to return currently commited index

### DIFF
--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -178,7 +178,7 @@ cfg_replication! {
         }
 
 
-        /// Sync database from remote, and returns the commited frame_no after syncing, if
+        /// Sync database from remote, and returns the committed frame_no after syncing, if
         /// applicable.
         pub async fn sync(&self) -> Result<Option<FrameNo>> {
             if let DbType::Sync { db } = &self.db_type {
@@ -188,7 +188,7 @@ cfg_replication! {
             }
         }
 
-        /// Apply a set of frames to the database and returns the commited frame_no after syncing, if
+        /// Apply a set of frames to the database and returns the committed frame_no after syncing, if
         /// applicable.
         pub async fn sync_frames(&self, frames: crate::replication::Frames) -> Result<Option<FrameNo>> {
             if let DbType::Sync { db } = &self.db_type {
@@ -203,6 +203,15 @@ cfg_replication! {
         pub async fn flush_replicator(&self) -> Result<Option<FrameNo>> {
             if let DbType::Sync { db } = &self.db_type {
                 db.flush_replicator().await
+            } else {
+                Err(Error::SyncNotSupported(format!("{:?}", self.db_type)))
+            }
+        }
+
+        /// Returns the database currently committed replication index
+        pub async fn replication_index(&self) -> Result<Option<FrameNo>> {
+            if let DbType::Sync { db } = &self.db_type {
+                db.replication_index().await
             } else {
                 Err(Error::SyncNotSupported(format!("{:?}", self.db_type)))
             }

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -311,4 +311,18 @@ if let Some(ReplicationContext {
             ))
         }
     }
+
+    #[cfg(feature = "replication")]
+    pub async fn replication_index(&self) -> Result<Option<FrameNo>> {
+        use libsql_replication::replicator::ReplicatorClient;
+
+        if let Some(ref ctx) = self.replication_ctx {
+            Ok(ctx.replicator.lock().await.client_mut().committed_frame_no())
+        } else {
+            Err(crate::errors::Error::Misuse(
+                "No replicator available. Use Database::with_replicator() to enable replication"
+                    .to_string(),
+            ))
+        }
+    }
 }


### PR DESCRIPTION
Add `Database::replication_index` that returns the currently committed replication index for the database.
