### PR TITLE
Libsql client: introduce async row fetcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2662,6 +2662,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
+ "tokio-util",
  "tonic",
  "tonic-web",
  "tower",

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -353,8 +353,9 @@ pub unsafe extern "C" fn libsql_next_row(
         *out_row = libsql_row_t::null();
         return 0;
     }
-    let res = res.get_ref_mut();
-    match res.next() {
+    let rows = res.get_ref_mut();
+    let res = tokio::runtime::Handle::current().block_on(rows.next());
+    match res {
         Ok(Some(row)) => {
             let row = Box::leak(Box::new(libsql_row { result: row }));
             *out_row = libsql_row_t::from(row);

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -354,7 +354,7 @@ pub unsafe extern "C" fn libsql_next_row(
         return 0;
     }
     let rows = res.get_ref_mut();
-    let res = tokio::runtime::Handle::current().block_on(rows.next());
+    let res = RT.block_on(rows.next());
     match res {
         Ok(Some(row)) => {
             let row = Box::leak(Box::new(libsql_row { result: row }));

--- a/libsql-server/tests/cluster/mod.rs
+++ b/libsql-server/tests/cluster/mod.rs
@@ -100,7 +100,7 @@ fn proxy_write() {
         let mut rows = conn.query("select count(*) from test", ()).await?;
 
         assert!(matches!(
-            rows.next().unwrap().unwrap().get_value(0).unwrap(),
+            rows.next().await.unwrap().unwrap().get_value(0).unwrap(),
             Value::Integer(1)
         ));
 
@@ -128,7 +128,7 @@ fn replica_read_write() {
         let mut rows = conn.query("select count(*) from test", ()).await?;
 
         assert!(matches!(
-            rows.next().unwrap().unwrap().get_value(0).unwrap(),
+            rows.next().await.unwrap().unwrap().get_value(0).unwrap(),
             Value::Integer(1)
         ));
 
@@ -200,7 +200,7 @@ fn sync_many_replica() {
             let conn = db.connect()?;
             let mut rows = conn.query("select count(*) from test", ()).await?;
             assert!(matches!(
-                rows.next().unwrap().unwrap().get_value(0).unwrap(),
+                rows.next().await.unwrap().unwrap().get_value(0).unwrap(),
                 Value::Integer(1)
             ));
         }
@@ -239,7 +239,7 @@ fn create_namespace() {
         conn.execute("create table test (x)", ()).await.unwrap();
         let mut rows = conn.query("select count(*) from test", ()).await.unwrap();
         assert!(matches!(
-            rows.next().unwrap().unwrap().get_value(0).unwrap(),
+            rows.next().await.unwrap().unwrap().get_value(0).unwrap(),
             Value::Integer(0)
         ));
 

--- a/libsql-server/tests/embedded_replica/mod.rs
+++ b/libsql-server/tests/embedded_replica/mod.rs
@@ -499,7 +499,7 @@ fn replicate_with_snapshots() {
         let conn = db.connect().unwrap();
         conn.execute("create table test (x)", ()).await.unwrap();
         // insert enough to trigger snapshot creation.
-        for _ in 0..200 {
+        for _ in 0..ROW_COUNT {
             conn.execute("INSERT INTO test values (randomblob(6000))", ())
                 .await
                 .unwrap();
@@ -530,7 +530,7 @@ fn replicate_with_snapshots() {
                 .unwrap()
                 .as_integer()
                 .unwrap(),
-            200
+            ROW_COUNT
         );
 
         Ok(())

--- a/libsql-server/tests/embedded_replica/mod.rs
+++ b/libsql-server/tests/embedded_replica/mod.rs
@@ -283,6 +283,7 @@ fn replica_primary_reset() {
             .await
             .unwrap()
             .next()
+            .await
             .unwrap()
             .unwrap()
             .get_value(0)
@@ -296,6 +297,7 @@ fn replica_primary_reset() {
             .await
             .unwrap()
             .next()
+            .await
             .unwrap()
             .unwrap()
             .get_value(0)
@@ -339,6 +341,7 @@ fn replica_primary_reset() {
             .await
             .unwrap()
             .next()
+            .await
             .unwrap()
             .unwrap()
             .get_value(0)
@@ -352,6 +355,7 @@ fn replica_primary_reset() {
             .await
             .unwrap()
             .next()
+            .await
             .unwrap()
             .unwrap()
             .get_value(0)
@@ -519,6 +523,7 @@ fn replicate_with_snapshots() {
         let mut res = conn.query("select count(*) from test", ()).await.unwrap();
         assert_eq!(
             *res.next()
+                .await
                 .unwrap()
                 .unwrap()
                 .get_value(0)

--- a/libsql-server/tests/embedded_replica/mod.rs
+++ b/libsql-server/tests/embedded_replica/mod.rs
@@ -461,6 +461,7 @@ fn replicate_with_snapshots() {
         .tcp_capacity(200)
         .build();
 
+    const ROW_COUNT: i64 = 200;
     let tmp = tempdir().unwrap();
 
     init_tracing();
@@ -617,7 +618,7 @@ fn proxy_write_returning_row() {
             .await
             .unwrap();
 
-        rows.next().unwrap().unwrap();
+        rows.next().await.unwrap().unwrap();
 
         Ok(())
     });

--- a/libsql-server/tests/hrana/batch.rs
+++ b/libsql-server/tests/hrana/batch.rs
@@ -54,8 +54,8 @@ fn execute_individual_statements() {
 
         assert_eq!(rows.column_count(), 1);
         assert_eq!(rows.column_name(0), Some("x"));
-        assert_eq!(rows.next()?.unwrap().get::<String>(0)?, "hello");
-        assert!(rows.next()?.is_none());
+        assert_eq!(rows.next().await?.unwrap().get::<String>(0)?, "hello");
+        assert!(rows.next().await?.is_none());
 
         Ok(())
     });
@@ -85,8 +85,11 @@ fn execute_batch() {
 
         assert_eq!(rows.column_count(), 1);
         assert_eq!(rows.column_name(0), Some("x"));
-        assert_eq!(rows.next()?.unwrap().get::<String>(0)?, "hello; world");
-        assert!(rows.next()?.is_none());
+        assert_eq!(
+            rows.next().await?.unwrap().get::<String>(0)?,
+            "hello; world"
+        );
+        assert!(rows.next().await?.is_none());
 
         Ok(())
     });

--- a/libsql-server/tests/hrana/transaction.rs
+++ b/libsql-server/tests/hrana/transaction.rs
@@ -118,6 +118,16 @@ fn transaction_timeout() {
 
         // transaction with temporary data
         let tx = conn.transaction().await?;
+        tx.execute("insert into t(x) values('hello');", ()).await?;
+
+        let mut rows = tx
+            .query("select * from t where x = ?", params!["hello"])
+            .await?;
+
+        assert_eq!(rows.column_count(), 1);
+        assert_eq!(rows.column_name(0), Some("x"));
+        assert_eq!(rows.next().await?.unwrap().get::<String>(0)?, "hello");
+        assert!(rows.next().await?.is_none());
 
         // Sleep to trigger stream expiration
         tokio::time::sleep(Duration::from_secs(300)).await;

--- a/libsql-server/tests/hrana/transaction.rs
+++ b/libsql-server/tests/hrana/transaction.rs
@@ -26,8 +26,8 @@ fn transaction_commit_and_rollback() {
 
         assert_eq!(rows.column_count(), 1);
         assert_eq!(rows.column_name(0), Some("x"));
-        assert_eq!(rows.next()?.unwrap().get::<String>(0)?, "hello");
-        assert!(rows.next()?.is_none());
+        assert_eq!(rows.next().await?.unwrap().get::<String>(0)?, "hello");
+        assert!(rows.next().await?.is_none());
         tx.rollback().await?;
 
         // confirm that temporary that was not committed
@@ -37,7 +37,7 @@ fn transaction_commit_and_rollback() {
 
         assert_eq!(rows.column_count(), 1);
         assert_eq!(rows.column_name(0), Some("x"));
-        assert!(rows.next()?.is_none());
+        assert!(rows.next().await?.is_none());
 
         Ok(())
     });
@@ -69,7 +69,7 @@ fn multiple_concurrent_transactions() {
             .await?;
         assert_eq!(rows.column_count(), 1);
         assert_eq!(rows.column_name(0), Some("x"));
-        assert!(rows.next()?.is_none());
+        assert!(rows.next().await?.is_none());
 
         // commit first transaction - T2 should still read old data
         tx1.commit().await?;
@@ -79,7 +79,7 @@ fn multiple_concurrent_transactions() {
             .await?;
         assert_eq!(rows.column_count(), 1);
         assert_eq!(rows.column_name(0), Some("x"));
-        assert!(rows.next()?.is_none());
+        assert!(rows.next().await?.is_none());
         tx2.commit().await?;
 
         // finally open new transaction - it now should read actual data
@@ -91,8 +91,8 @@ fn multiple_concurrent_transactions() {
             .await?;
         assert_eq!(rows.column_count(), 1);
         assert_eq!(rows.column_name(0), Some("x"));
-        assert_eq!(rows.next()?.unwrap().get::<String>(0)?, "hello");
-        assert!(rows.next()?.is_none());
+        assert_eq!(rows.next().await?.unwrap().get::<String>(0)?, "hello");
+        assert!(rows.next().await?.is_none());
 
         Ok(())
     });

--- a/libsql-server/tests/namespaces/dumps.rs
+++ b/libsql-server/tests/namespaces/dumps.rs
@@ -56,7 +56,7 @@ fn load_namespace_from_dump_from_url() {
         let foo_conn = foo.connect()?;
         let mut rows = foo_conn.query("select count(*) from test", ()).await?;
         assert!(matches!(
-            rows.next().unwrap().unwrap().get_value(0)?,
+            rows.next().await.unwrap().unwrap().get_value(0)?,
             Value::Integer(1)
         ));
 
@@ -125,7 +125,7 @@ fn load_namespace_from_dump_from_file() {
         let foo_conn = foo.connect()?;
         let mut rows = foo_conn.query("select count(*) from test", ()).await?;
         assert!(matches!(
-            rows.next().unwrap().unwrap().get_value(0)?,
+            rows.next().await.unwrap().unwrap().get_value(0)?,
             Value::Integer(1)
         ));
 

--- a/libsql-server/tests/namespaces/mod.rs
+++ b/libsql-server/tests/namespaces/mod.rs
@@ -72,7 +72,7 @@ fn fork_namespace() {
         // what's in foo is in bar as well
         let mut rows = bar_conn.query("select count(*) from test", ()).await?;
         assert!(matches!(
-            rows.next().unwrap().unwrap().get_value(0).unwrap(),
+            rows.next().await.unwrap().unwrap().get_value(0).unwrap(),
             Value::Integer(1)
         ));
 
@@ -81,14 +81,14 @@ fn fork_namespace() {
         // add something to bar
         let mut rows = bar_conn.query("select count(*) from test", ()).await?;
         assert!(matches!(
-            rows.next().unwrap().unwrap().get_value(0)?,
+            rows.next().await.unwrap().unwrap().get_value(0)?,
             Value::Integer(2)
         ));
 
         // ... and make sure it doesn't exist in foo
         let mut rows = foo_conn.query("select count(*) from test", ()).await?;
         assert!(matches!(
-            rows.next().unwrap().unwrap().get_value(0)?,
+            rows.next().await.unwrap().unwrap().get_value(0)?,
             Value::Integer(1)
         ));
 

--- a/libsql-server/tests/standalone/mod.rs
+++ b/libsql-server/tests/standalone/mod.rs
@@ -83,15 +83,16 @@ fn basic_metrics() {
 
         let snapshot = snapshot_metrics();
         snapshot.assert_counter("libsql_server_libsql_execute_program", 3);
-        snapshot.assert_counter("libsql_server_user_http_response", 3);
+        // cursor-based execution produces two responses per execution request
+        snapshot.assert_counter("libsql_server_user_http_response", 6);
 
         for (key, (_, _, val)) in snapshot.snapshot() {
             if key.kind() == metrics_util::MetricKind::Counter
                 && key.key().name() == "libsql_client_version"
             {
-                assert_eq!(val, &metrics_util::debugging::DebugValue::Counter(3));
                 let label = key.key().labels().next().unwrap();
                 assert!(label.value().starts_with("libsql-remote-"));
+                assert_eq!(val, &metrics_util::debugging::DebugValue::Counter(6));
             }
         }
 

--- a/libsql-server/tests/standalone/mod.rs
+++ b/libsql-server/tests/standalone/mod.rs
@@ -49,7 +49,7 @@ fn basic_query() {
         let mut rows = conn.query("select count(*) from test", ()).await?;
 
         assert!(matches!(
-            rows.next().unwrap().unwrap().get_value(0).unwrap(),
+            rows.next().await.unwrap().unwrap().get_value(0).unwrap(),
             libsql::Value::Integer(1)
         ));
 
@@ -75,7 +75,7 @@ fn basic_metrics() {
         let mut rows = conn.query("select count(*) from test", ()).await?;
 
         assert!(matches!(
-            rows.next().unwrap().unwrap().get_value(0).unwrap(),
+            rows.next().await.unwrap().unwrap().get_value(0).unwrap(),
             libsql::Value::Integer(1)
         ));
 
@@ -134,7 +134,7 @@ fn primary_serializability() {
             let mut rows = conn.query("select count(*) from test", ()).await?;
 
             assert!(matches!(
-                rows.next().unwrap().unwrap().get_value(0).unwrap(),
+                rows.next().await.unwrap().unwrap().get_value(0).unwrap(),
                 Value::Integer(1)
             ));
 
@@ -170,7 +170,7 @@ fn execute_transaction() {
             // we can read our write:
             let mut rows = txn.query("select count(*) from test", ()).await?;
             assert!(matches!(
-                rows.next().unwrap().unwrap().get_value(0).unwrap(),
+                rows.next().await.unwrap().unwrap().get_value(0).unwrap(),
                 Value::Integer(1)
             ));
             txn.commit().await?;
@@ -190,7 +190,7 @@ fn execute_transaction() {
             // at this point we should not see the written row.
             let mut rows = conn.query("select count(*) from test", ()).await?;
             assert!(matches!(
-                rows.next().unwrap().unwrap().get_value(0).unwrap(),
+                rows.next().await.unwrap().unwrap().get_value(0).unwrap(),
                 Value::Integer(0)
             ));
             notify.notify_waiters();
@@ -204,7 +204,7 @@ fn execute_transaction() {
             // now we can read the inserted row
             let mut rows = conn.query("select count(*) from test", ()).await?;
             assert!(matches!(
-                rows.next().unwrap().unwrap().get_value(0).unwrap(),
+                rows.next().await.unwrap().unwrap().get_value(0).unwrap(),
                 Value::Integer(1)
             ));
             notify.notify_waiters();

--- a/libsql-server/tests/standalone/snapshots/tests__standalone__basic_query_fail.snap
+++ b/libsql-server/tests/standalone/snapshots/tests__standalone__basic_query_fail.snap
@@ -3,10 +3,12 @@ source: libsql-server/tests/standalone/mod.rs
 expression: "conn.execute(\"insert into test values (12)\", ()).await.unwrap_err()"
 ---
 Hrana(
-    StreamError(
-        StreamResponseError {
+    CursorError(
+        StepError {
+            step: 0,
             error: Error {
                 message: "SQLite error: UNIQUE constraint failed: test.x",
+                code: "SQLITE_CONSTRAINT",
             },
         },
     ),

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -57,6 +57,10 @@ core = [
   "dep:bitflags",
   "dep:futures"
 ]
+stream = [
+  "dep:futures",
+  "dep:async-stream"
+]
 parser = [
   "dep:sqlite3-parser",
   "dep:fallible-iterator"
@@ -65,6 +69,7 @@ replication = [
   "core",
   "parser",
   "serde",
+  "stream",
   "dep:tower",
   "dep:hyper",
   "dep:http",
@@ -83,19 +88,18 @@ replication = [
   "dep:tower",
   "dep:hyper-rustls",
   "dep:futures",
-  "dep:libsql_replication",
-  "dep:async-stream",
+  "dep:libsql-replication",
 ]
 hrana = [
   "parser",
   "serde",
+  "stream",
   "dep:base64",
   "dep:serde_json",
   "dep:futures",
   "dep:tokio",
   "dep:tokio-util",
   "dep:bytes",
-  "dep:async-stream"
 ]
 serde = ["dep:serde"]
 remote = [

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -13,7 +13,7 @@ thiserror = "1.0.40"
 futures = { version = "0.3.28", optional = true }
 libsql-sys = { version = "0.3", path = "../libsql-sys", optional = true }
 tokio = { version = "1.29.1", features = ["fs", "sync"], optional = true }
-tokio-util = { version = "0.7", features = ["io-util","codec"], optional = true }
+tokio-util = { version = "0.7", features = ["io-util", "codec"], optional = true }
 parking_lot = { version = "0.12.1", optional = true }
 hyper = { version = "0.14", features = ["client", "stream"], optional = true }
 hyper-rustls = { version = "0.24", features = ["webpki-roots"], optional = true }
@@ -94,7 +94,8 @@ hrana = [
   "dep:futures",
   "dep:tokio",
   "dep:tokio-util",
-  "dep:bytes"
+  "dep:bytes",
+  "dep:async-stream"
 ]
 serde = ["dep:serde"]
 remote = [

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = "1.0.40"
 futures = { version = "0.3.28", optional = true }
 libsql-sys = { version = "0.3", path = "../libsql-sys", optional = true }
 tokio = { version = "1.29.1", features = ["fs", "sync"], optional = true }
+tokio-util = { version = "0.7", features = ["io-util","codec"], optional = true }
 parking_lot = { version = "0.12.1", optional = true }
 hyper = { version = "0.14", features = ["client", "stream"], optional = true }
 hyper-rustls = { version = "0.24", features = ["webpki-roots"], optional = true }
@@ -91,6 +92,8 @@ hrana = [
   "dep:base64",
   "dep:serde_json",
   "dep:futures",
+  "dep:tokio",
+  "dep:tokio-util",
   "dep:bytes"
 ]
 serde = ["dep:serde"]

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -88,7 +88,7 @@ replication = [
   "dep:tower",
   "dep:hyper-rustls",
   "dep:futures",
-  "dep:libsql-replication",
+  "dep:libsql_replication",
 ]
 hrana = [
   "parser",

--- a/libsql/benches/benchmark.rs
+++ b/libsql/benches/benchmark.rs
@@ -54,7 +54,7 @@ fn bench(c: &mut Criterion) {
     group.bench_function("in-memory-select-1-unprepared", |b| {
         b.to_async(&rt).iter(|| async {
             let mut rows = conn.query("SELECT 1", ()).await.unwrap();
-            let row = rows.next().unwrap().unwrap();
+            let row = rows.next().await.unwrap().unwrap();
             assert_eq!(row.get::<i32>(0).unwrap(), 1);
         });
     });
@@ -93,7 +93,7 @@ fn bench(c: &mut Criterion) {
             || block_on(conn.prepare("SELECT 1")).unwrap(),
             |mut stmt| async move {
                 let mut rows = stmt.query(()).await.unwrap();
-                let row = rows.next().unwrap().unwrap();
+                let row = rows.next().await.unwrap().unwrap();
                 assert_eq!(row.get::<i32>(0).unwrap(), 1);
                 stmt.reset();
             },
@@ -113,7 +113,7 @@ fn bench(c: &mut Criterion) {
             || block_on(conn.prepare("SELECT * FROM users LIMIT 1")).unwrap(),
             |mut stmt| async move {
                 let mut rows = stmt.query(()).await.unwrap();
-                let row = rows.next().unwrap().unwrap();
+                let row = rows.next().await.unwrap().unwrap();
                 assert_eq!(row.get::<i32>(0).unwrap(), 1);
                 stmt.reset();
             },
@@ -128,7 +128,7 @@ fn bench(c: &mut Criterion) {
                 || block_on(conn.prepare("SELECT * FROM users LIMIT 100")).unwrap(),
                 |mut stmt| async move {
                     let mut rows = stmt.query(()).await.unwrap();
-                    let row = rows.next().unwrap().unwrap();
+                    let row = rows.next().await.unwrap().unwrap();
                     assert_eq!(row.get::<i32>(0).unwrap(), 1);
                     stmt.reset();
                 },
@@ -146,7 +146,7 @@ fn bench(c: &mut Criterion) {
     group.bench_function("local-replica-select-1-unprepared", |b| {
         b.to_async(&rt).iter(|| async {
             let mut rows = conn.query("SELECT 1", ()).await.unwrap();
-            let row = rows.next().unwrap().unwrap();
+            let row = rows.next().await.unwrap().unwrap();
             assert_eq!(row.get::<i32>(0).unwrap(), 1);
         });
     });
@@ -156,7 +156,7 @@ fn bench(c: &mut Criterion) {
             || block_on(conn.prepare("SELECT 1")).unwrap(),
             |mut stmt| async move {
                 let mut rows = stmt.query(()).await.unwrap();
-                let row = rows.next().unwrap().unwrap();
+                let row = rows.next().await.unwrap().unwrap();
                 assert_eq!(row.get::<i32>(0).unwrap(), 1);
                 stmt.reset();
             },
@@ -188,7 +188,7 @@ fn bench(c: &mut Criterion) {
                 || block_on(conn.prepare("SELECT * FROM users LIMIT 1")).unwrap(),
                 |mut stmt| async move {
                     let mut rows = stmt.query(()).await.unwrap();
-                    let row = rows.next().unwrap().unwrap();
+                    let row = rows.next().await.unwrap().unwrap();
                     assert_eq!(row.get::<i32>(0).unwrap(), 1);
                     stmt.reset();
                 },
@@ -204,7 +204,7 @@ fn bench(c: &mut Criterion) {
                 || block_on(conn.prepare("SELECT * FROM users LIMIT 100")).unwrap(),
                 |mut stmt| async move {
                     let mut rows = stmt.query(()).await.unwrap();
-                    let row = rows.next().unwrap().unwrap();
+                    let row = rows.next().await.unwrap().unwrap();
                     assert_eq!(row.get::<i32>(0).unwrap(), 1);
                     stmt.reset();
                 },

--- a/libsql/examples/deserialization.rs
+++ b/libsql/examples/deserialization.rs
@@ -39,6 +39,7 @@ async fn main() {
         .await
         .unwrap()
         .next()
+        .await
         .unwrap()
         .unwrap();
 

--- a/libsql/examples/example.rs
+++ b/libsql/examples/example.rs
@@ -25,8 +25,38 @@ async fn main() {
         .prepare("INSERT INTO users (email) VALUES (?1)")
         .await
         .unwrap();
+    conn.execute(
+        "CREATE TABLE test1 (t TEXT, i INTEGER, f FLOAT, b BLOB)",
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "INSERT INTO test1 (t, i, f, b) VALUES (?, ?, ?, ?)",
+        ("a", 1, 1.0, vec![1, 2, 3]),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "INSERT INTO test1 (t, i, f, b) VALUES (?, ?, ?, ?)",
+        ("b", 2_u64, 2.0, vec![4, 5, 6]),
+    )
+    .await
+    .unwrap();
+    let mut rows = conn.query("SELECT * FROM test1", ()).await.unwrap();
+    while let Ok(Some(row)) = rows.next().await {
+        println!(
+            "{:?} {:?} {:?} {:?}",
+            row.get_value(0),
+            row.get_value(1),
+            row.get_value(2),
+            row.get_value(3)
+        );
+    }
 
-    stmt.execute(["foo@example.com"]).await.unwrap();
+    let mut rows = conn.query("SELECT * FROM test1", ()).await.unwrap();
+
+    let row = rows.next().await.unwrap().unwrap();
 
     let mut stmt = conn
         .prepare("SELECT * FROM users WHERE email = ?1")

--- a/libsql/examples/example.rs
+++ b/libsql/examples/example.rs
@@ -25,38 +25,8 @@ async fn main() {
         .prepare("INSERT INTO users (email) VALUES (?1)")
         .await
         .unwrap();
-    conn.execute(
-        "CREATE TABLE test1 (t TEXT, i INTEGER, f FLOAT, b BLOB)",
-        (),
-    )
-    .await
-    .unwrap();
-    conn.execute(
-        "INSERT INTO test1 (t, i, f, b) VALUES (?, ?, ?, ?)",
-        ("a", 1, 1.0, vec![1, 2, 3]),
-    )
-    .await
-    .unwrap();
-    conn.execute(
-        "INSERT INTO test1 (t, i, f, b) VALUES (?, ?, ?, ?)",
-        ("b", 2_u64, 2.0, vec![4, 5, 6]),
-    )
-    .await
-    .unwrap();
-    let mut rows = conn.query("SELECT * FROM test1", ()).await.unwrap();
-    while let Ok(Some(row)) = rows.next().await {
-        println!(
-            "{:?} {:?} {:?} {:?}",
-            row.get_value(0),
-            row.get_value(1),
-            row.get_value(2),
-            row.get_value(3)
-        );
-    }
 
-    let mut rows = conn.query("SELECT * FROM test1", ()).await.unwrap();
-
-    let row = rows.next().await.unwrap().unwrap();
+    stmt.execute(["foo@example.com"]).await.unwrap();
 
     let mut stmt = conn
         .prepare("SELECT * FROM users WHERE email = ?1")
@@ -65,7 +35,7 @@ async fn main() {
 
     let mut rows = stmt.query(["foo@example.com"]).await.unwrap();
 
-    let row = rows.next().unwrap().unwrap();
+    let row = rows.next().await.unwrap().unwrap();
 
     let value = row.get_value(0).unwrap();
 

--- a/libsql/examples/example_v2.rs
+++ b/libsql/examples/example_v2.rs
@@ -1,0 +1,43 @@
+use libsql::Database;
+
+#[tokio::main]
+async fn main() {
+    let db = if let Ok(url) = std::env::var("LIBSQL_HRANA_URL") {
+        let token = std::env::var("TURSO_AUTH_TOKEN").unwrap_or_else(|_| {
+            println!("TURSO_AUTH_TOKEN not set, using empty token...");
+            "".to_string()
+        });
+
+        Database::open_remote(url, token).unwrap()
+    } else {
+        Database::open_in_memory().unwrap()
+    };
+
+    let conn = db.connect().unwrap();
+
+    conn.query("select 1; select 1;", ()).await.unwrap();
+
+    conn.execute("CREATE TABLE IF NOT EXISTS users (email TEXT)", ())
+        .await
+        .unwrap();
+
+    let mut stmt = conn
+        .prepare("INSERT INTO users (email) VALUES (?1)")
+        .await
+        .unwrap();
+
+    stmt.execute(["foo@example.com"]).await.unwrap();
+
+    let mut stmt = conn
+        .prepare("SELECT * FROM users WHERE email = ?1")
+        .await
+        .unwrap();
+
+    let mut rows = stmt.query(["foo@example.com"]).await.unwrap();
+
+    let row = rows.next().await.unwrap().unwrap();
+
+    let value = row.get_value(0).unwrap();
+
+    println!("Row: {:?}", value);
+}

--- a/libsql/examples/flutter.rs
+++ b/libsql/examples/flutter.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     let mut rows = stmt.query(["foo@example.com"]).await.unwrap();
 
-    let row = rows.next().unwrap().unwrap();
+    let row = rows.next().await.unwrap().unwrap();
 
     let value = row.get_value(0).unwrap();
 

--- a/libsql/examples/local_sync.rs
+++ b/libsql/examples/local_sync.rs
@@ -39,7 +39,7 @@ async fn main() {
         }
 
         let mut rows = conn.query("SELECT * FROM sqlite_master", ()).await.unwrap();
-        while let Ok(Some(row)) = rows.next() {
+        while let Ok(Some(row)) = rows.next().await {
             println!(
                 "| {:024} | {:024} | {:024} | {:024} |",
                 row.get_str(0).unwrap(),

--- a/libsql/examples/remote_sync.rs
+++ b/libsql/examples/remote_sync.rs
@@ -74,7 +74,7 @@ async fn main() {
         .await
         .unwrap();
     println!("Guest book entries:");
-    while let Some(row) = results.next().unwrap() {
+    while let Some(row) = results.next().await.unwrap() {
         let text: String = row.get(0).unwrap();
         println!("  {}", text);
     }

--- a/libsql/examples/replica.rs
+++ b/libsql/examples/replica.rs
@@ -46,7 +46,7 @@ async fn main() {
             .unwrap();
 
         println!("Rows insert call");
-        while let Some(row) = rows.next().unwrap() {
+        while let Some(row) = rows.next().await.unwrap() {
             println!("Row: {}", row.get_str(0).unwrap());
         }
 
@@ -55,7 +55,7 @@ async fn main() {
         let mut rows = conn.query("SELECT * FROM foo", ()).await.unwrap();
 
         println!("Rows coming from a read after write call");
-        while let Some(row) = rows.next().unwrap() {
+        while let Some(row) = rows.next().await.unwrap() {
             println!("Row: {}", row.get_str(0).unwrap());
         }
 

--- a/libsql/src/errors.rs
+++ b/libsql/src/errors.rs
@@ -42,6 +42,13 @@ pub enum Error {
     Replication(crate::BoxError),
 }
 
+#[cfg(feature = "hrana")]
+impl From<crate::hrana::HranaError> for Error {
+    fn from(e: crate::hrana::HranaError) -> Self {
+        Error::Hrana(e.into())
+    }
+}
+
 impl From<std::convert::Infallible> for Error {
     fn from(_: std::convert::Infallible) -> Self {
         unreachable!()

--- a/libsql/src/hrana/cursor.rs
+++ b/libsql/src/hrana/cursor.rs
@@ -8,6 +8,7 @@ use serde::de::Error;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 #[derive(Serialize, Debug)]

--- a/libsql/src/hrana/cursor.rs
+++ b/libsql/src/hrana/cursor.rs
@@ -337,6 +337,12 @@ async fn get_next_step(cursor: &mut Cursor) -> Result<StepBeginEntry> {
             CursorEntry::StepEnd(_) => {
                 tracing::debug!("skipping over StepEnd message for previous cursor step")
             }
+            CursorEntry::StepEnd(end) => {
+                tracing::trace!(
+                    "end current cursor step - affected rows: {}",
+                    end.affected_row_count
+                );
+            }
             CursorEntry::StepError(e) => {
                 return Err(HranaError::CursorError(CursorResponseError::StepError {
                     step: e.step,
@@ -349,6 +355,7 @@ async fn get_next_step(cursor: &mut Cursor) -> Result<StepBeginEntry> {
         }
     }
     if let Some(begin) = begin {
+        tracing::trace!("begin cursor step: {}", begin.step);
         Ok(begin)
     } else {
         Err(HranaError::CursorError(CursorResponseError::CursorClosed))

--- a/libsql/src/hrana/cursor.rs
+++ b/libsql/src/hrana/cursor.rs
@@ -1,6 +1,6 @@
 // https://github.com/tursodatabase/libsql/blob/main/docs/HRANA_3_SPEC.md#cursor-entries
 
-use crate::hrana::proto::{Batch, BatchResult, Col, StmtResult, Value};
+use crate::hrana::proto::{Batch, BatchResult, Col, StmtResult, HttpSend, Value};
 use crate::hrana::{CursorResponseError, HranaError, Result, Row};
 use bytes::Bytes;
 use futures::{ready, Future, Stream, StreamExt};
@@ -8,7 +8,6 @@ use serde::de::Error;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 
 #[derive(Serialize, Debug)]

--- a/libsql/src/hrana/cursor.rs
+++ b/libsql/src/hrana/cursor.rs
@@ -343,12 +343,6 @@ where
             CursorEntry::StepEnd(_) => {
                 tracing::debug!("skipping over StepEnd message for previous cursor step")
             }
-            CursorEntry::StepEnd(end) => {
-                tracing::trace!(
-                    "end current cursor step - affected rows: {}",
-                    end.affected_row_count
-                );
-            }
             CursorEntry::StepError(e) => {
                 return Err(HranaError::CursorError(CursorResponseError::StepError {
                     step: e.step,

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -85,11 +85,8 @@ impl HttpSend for HttpSender {
     }
 
     fn oneshot(self, url: Arc<str>, auth: Arc<str>, body: String) {
-        if let Ok(rt) = tokio::runtime::Handle::try_current() {
-            rt.spawn(self.send(url, auth, body));
-        } else {
-            tracing::warn!("couldn't send Hrana oneshot request: no tokio runtime active")
-        }
+        let rt = tokio::runtime::Handle::current();
+        rt.spawn(self.send(url, auth, body));
     }
 }
 

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -85,8 +85,7 @@ impl HttpSend for HttpSender {
     }
 
     fn oneshot(self, url: Arc<str>, auth: Arc<str>, body: String) {
-        let rt = tokio::runtime::Handle::current();
-        rt.spawn(self.send(url, auth, body));
+        tokio::spawn(self.send(url, auth, body));
     }
 }
 

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -8,7 +8,6 @@ use crate::params::Params;
 use crate::transaction::Tx;
 use crate::util::ConnectorService;
 use crate::{Rows, Statement};
-use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::{Stream, TryStreamExt};
 use http::header::AUTHORIZATION;

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -14,9 +14,10 @@ use futures::{Stream, TryStreamExt};
 use http::header::AUTHORIZATION;
 use http::{HeaderValue, StatusCode};
 use hyper::body::HttpBody;
+use std::io::ErrorKind;
 use std::sync::Arc;
 
-pub type ByteStream = Box<dyn Stream<Item = Result<Bytes>> + Send + Sync + Unpin>;
+pub type ByteStream = Box<dyn Stream<Item = std::io::Result<Bytes>> + Send + Sync + Unpin>;
 
 #[derive(Clone, Debug)]
 pub struct HttpSender {
@@ -66,7 +67,7 @@ impl HttpSender {
             let stream = resp
                 .into_body()
                 .into_stream()
-                .map_err(|e| HranaError::Http(e.to_string()));
+                .map_err(|e| std::io::Error::new(ErrorKind::Other, e));
             super::HttpBody::Stream(Box::new(stream))
         };
 

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -84,7 +84,11 @@ impl HttpSend for HttpSender {
     }
 
     fn oneshot(self, url: Arc<str>, auth: Arc<str>, body: String) {
-        let _ = tokio::spawn(self.send(url, auth, body));
+        if let Ok(rt) = tokio::runtime::Handle::try_current() {
+            rt.spawn(self.send(url, auth, body));
+        } else {
+            tracing::warn!("couldn't send Hrana oneshot request: no tokio runtime active")
+        }
     }
 }
 

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -81,6 +81,10 @@ impl HttpSend for HttpSender {
         let fut = self.clone().send(url, auth, body);
         Box::pin(fut)
     }
+
+    fn oneshot(self, url: Arc<str>, auth: Arc<str>, body: String) {
+        let _ = tokio::spawn(async move { self.send(&url, &auth, body).await });
+    }
 }
 
 impl From<hyper::Error> for HranaError {

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -8,6 +8,7 @@ use crate::params::Params;
 use crate::transaction::Tx;
 use crate::util::ConnectorService;
 use crate::{Rows, Statement};
+use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::{Stream, TryStreamExt};
 use http::header::AUTHORIZATION;
@@ -15,7 +16,7 @@ use http::{HeaderValue, StatusCode};
 use hyper::body::HttpBody;
 use std::sync::Arc;
 
-pub type ByteStream = Box<dyn Stream<Item = Result<Bytes>> + Send + Unpin>;
+pub type ByteStream = Box<dyn Stream<Item = Result<Bytes>> + Send + Sync + Unpin>;
 
 #[derive(Clone, Debug)]
 pub struct HttpSender {
@@ -83,7 +84,7 @@ impl HttpSend for HttpSender {
     }
 
     fn oneshot(self, url: Arc<str>, auth: Arc<str>, body: String) {
-        let _ = tokio::spawn(async move { self.send(&url, &auth, body).await });
+        let _ = tokio::spawn(self.send(url, auth, body));
     }
 }
 

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -38,7 +38,7 @@ struct Cookie {
 }
 
 pub trait HttpSend: Clone {
-    type Stream: Stream<Item = Result<Bytes>> + Unpin;
+    type Stream: Stream<Item = std::io::Result<Bytes>> + Unpin;
     type Result: Future<Output = Result<Self::Stream>>;
     fn http_send(&self, url: Arc<str>, auth: Arc<str>, body: String) -> Self::Result;
 
@@ -59,9 +59,9 @@ impl<S> From<Bytes> for HttpBody<S> {
 
 impl<S> Stream for HttpBody<S>
 where
-    S: Stream<Item = Result<Bytes>> + Unpin,
+    S: Stream<Item = std::io::Result<Bytes>> + Unpin,
 {
-    type Item = Result<Bytes>;
+    type Item = std::io::Result<Bytes>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.get_mut() {
@@ -205,7 +205,7 @@ pub struct HranaRows<S> {
 
 impl<S> HranaRows<S>
 where
-    S: Stream<Item = Result<Bytes>> + Unpin,
+    S: Stream<Item = std::io::Result<Bytes>> + Unpin,
 {
     async fn from_cursor(cursor: Cursor<S>) -> Result<Self> {
         let cursor_step = cursor.next_step_owned().await?;
@@ -240,7 +240,7 @@ where
 #[async_trait::async_trait]
 impl<S> RowsInner for HranaRows<S>
 where
-    S: Stream<Item = Result<Bytes>> + Send + Sync + Unpin,
+    S: Stream<Item = std::io::Result<Bytes>> + Send + Sync + Unpin,
 {
     async fn next(&mut self) -> crate::Result<Option<super::Row>> {
         self.next().await

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -55,30 +55,6 @@ impl<S> From<Bytes> for HttpBody<S> {
     fn from(value: Bytes) -> Self {
         HttpBody::Body(Some(value))
     }
-
-    pub fn stream(self) -> ByteStream {
-        match self {
-            HttpBody::Stream(stream) => stream,
-            HttpBody::Body(bytes) => Box::new(SimpleStream::new(bytes)),
-        }
-    }
-}
-
-struct SimpleStream(Option<Bytes>);
-impl SimpleStream {
-    fn new(bytes: Bytes) -> Self {
-        SimpleStream(Some(bytes))
-    }
-}
-impl Stream for SimpleStream {
-    type Item = Result<Bytes>;
-
-    fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.0.take() {
-            None => Poll::Ready(None),
-            Some(bytes) => Poll::Ready(Some(Ok(bytes))),
-        }
-    }
 }
 
 impl<S> Stream for HttpBody<S>

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -13,7 +13,7 @@ mod stream;
 pub mod transaction;
 
 use crate::hrana::connection::HttpConnection;
-use crate::hrana::cursor::{Cursor, OwnedCursorStep};
+use crate::hrana::cursor::{Cursor, Error, OwnedCursorStep};
 pub(crate) use crate::hrana::pipeline::StreamResponseError;
 use crate::hrana::proto::{Batch, Col, Stmt};
 use crate::hrana::stream::HranaStream;
@@ -102,8 +102,8 @@ pub enum HranaError {
 pub enum CursorResponseError {
     #[error("cursor step {actual} arrived before step {expected} end message")]
     NotClosed { expected: u32, actual: u32 },
-    #[error("error at step {step}: `{error}`")]
-    StepError { step: u32, error: String },
+    #[error("error at step {step}: {error}")]
+    StepError { step: u32, error: Error },
     #[error("cursor stream ended prematurely")]
     CursorClosed,
     #[error("{0}")]

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -70,7 +70,7 @@ impl SimpleStream {
 impl Stream for SimpleStream {
     type Item = Result<Bytes>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.0.take() {
             None => Poll::Ready(None),
             Some(bytes) => Poll::Ready(Some(Ok(bytes))),

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -43,6 +43,9 @@ pub trait HttpSend: Clone {
     type Stream: Stream<Item = Result<Bytes>> + Unpin;
     type Result: Future<Output = Result<Self::Stream>>;
     fn http_send(&self, url: Arc<str>, auth: Arc<str>, body: String) -> Self::Result;
+
+    /// Schedule sending a HTTP post request without waiting for the completion.
+    fn oneshot(self, url: Arc<str>, auth: Arc<str>, body: String);
 }
 
 pub enum HttpBody<S> {

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -232,8 +232,9 @@ pub struct Rows {
     rows: VecDeque<Vec<proto::Value>>,
 }
 
+#[async_trait::async_trait]
 impl RowsInner for Rows {
-    fn next(&mut self) -> crate::Result<Option<super::Row>> {
+    async fn next(&mut self) -> crate::Result<Option<super::Row>> {
         let row = match self.rows.pop_front() {
             Some(row) => Row {
                 cols: self.cols.clone(),

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -52,6 +52,30 @@ impl<S> From<Bytes> for HttpBody<S> {
     fn from(value: Bytes) -> Self {
         HttpBody::Body(Some(value))
     }
+
+    pub fn stream(self) -> ByteStream {
+        match self {
+            HttpBody::Stream(stream) => stream,
+            HttpBody::Body(bytes) => Box::new(SimpleStream::new(bytes)),
+        }
+    }
+}
+
+struct SimpleStream(Option<Bytes>);
+impl SimpleStream {
+    fn new(bytes: Bytes) -> Self {
+        SimpleStream(Some(bytes))
+    }
+}
+impl Stream for SimpleStream {
+    type Item = Result<Bytes>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.0.take() {
+            None => Poll::Ready(None),
+            Some(bytes) => Poll::Ready(Some(Ok(bytes))),
+        }
+    }
 }
 
 impl<S> Stream for HttpBody<S>

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -19,12 +19,11 @@ use crate::hrana::proto::{Batch, Col, Stmt};
 use crate::hrana::stream::HranaStream;
 use crate::{params::Params, ValueType};
 use bytes::Bytes;
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tokio_stream::StreamExt;
 
 use super::rows::{RowInner, RowsInner};
 

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -296,12 +296,12 @@ where
 
 #[derive(Debug)]
 pub struct Row {
-    cols: Arc<Vec<Col>>,
+    cols: Arc<[Col]>,
     inner: Vec<proto::Value>,
 }
 
 impl Row {
-    pub(super) fn new(cols: Arc<Vec<Col>>, inner: Vec<proto::Value>) -> Self {
+    pub(super) fn new(cols: Arc<[Col]>, inner: Vec<proto::Value>) -> Self {
         Row { cols, inner }
     }
 }

--- a/libsql/src/hrana/proto.rs
+++ b/libsql/src/hrana/proto.rs
@@ -187,6 +187,12 @@ impl Batch {
         self.steps.push(BatchStep { condition, stmt });
     }
 
+    pub fn single(stmt: Stmt) -> Self {
+        let mut batch = Batch::new();
+        batch.step(None, stmt);
+        batch
+    }
+
     pub fn from_iter(stmts: impl IntoIterator<Item = Stmt>, protocol_v3: bool) -> Self {
         let mut batch = Batch::new();
         let mut step = -1;

--- a/libsql/src/hrana/stream.rs
+++ b/libsql/src/hrana/stream.rs
@@ -6,10 +6,10 @@ use crate::hrana::pipeline::{
 use crate::hrana::proto::{Batch, BatchResult, DescribeResult, Stmt, StmtResult};
 use crate::hrana::{CursorResponseError, HranaError, HttpSend, Result, StreamResponseError};
 use bytes::{Bytes, BytesMut};
-use futures::lock::Mutex;
 use futures::Stream;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
+use tokio::sync::Mutex;
 
 macro_rules! unexpected {
     ($value:ident) => {

--- a/libsql/src/hrana/stream.rs
+++ b/libsql/src/hrana/stream.rs
@@ -381,13 +381,13 @@ where
 
 async fn stream_to_bytes<S>(mut stream: S) -> Result<Bytes>
 where
-    S: Stream<Item = Result<Bytes>> + Unpin,
+    S: Stream<Item = std::io::Result<Bytes>> + Unpin,
 {
     use futures::StreamExt;
 
     let mut buf = BytesMut::new();
     while let Some(chunk) = stream.next().await {
-        buf.extend_from_slice(&chunk?);
+        buf.extend_from_slice(&chunk.map_err(|e| HranaError::Http(e.to_string()))?);
     }
     Ok(buf.freeze())
 }

--- a/libsql/src/hrana/transaction.rs
+++ b/libsql/src/hrana/transaction.rs
@@ -1,5 +1,5 @@
 use crate::hrana::pipeline::{ExecuteStreamReq, StreamRequest};
-use crate::hrana::proto::{Batch, BatchResult, Stmt, StmtResult};
+use crate::hrana::proto::{BatchResult, Stmt, StmtResult};
 use crate::hrana::stream::HranaStream;
 use crate::hrana::{HttpSend, Result};
 use crate::TransactionBehavior;

--- a/libsql/src/hrana/transaction.rs
+++ b/libsql/src/hrana/transaction.rs
@@ -1,5 +1,5 @@
 use crate::hrana::pipeline::{ExecuteStreamReq, StreamRequest};
-use crate::hrana::proto::{BatchResult, Stmt, StmtResult};
+use crate::hrana::proto::{Batch, BatchResult, Stmt, StmtResult};
 use crate::hrana::stream::HranaStream;
 use crate::hrana::{HttpSend, Result};
 use crate::TransactionBehavior;

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -28,7 +28,8 @@
 //!
 //! ```rust,no_run
 //! # async fn run() {
-//! use libsql::{Database, Frames};
+//! use libsql::{Database};
+//! use libsql::replication::Frames;
 //!
 //! let mut db = Database::open_with_local_sync("/tmp/test.db").await.unwrap();
 //!

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -125,8 +125,9 @@ impl Tx for LibsqlTx {
 
 pub(crate) struct LibsqlRows(pub(crate) crate::local::Rows);
 
+#[async_trait::async_trait]
 impl RowsInner for LibsqlRows {
-    fn next(&mut self) -> Result<Option<Row>> {
+    async fn next(&mut self) -> Result<Option<Row>> {
         let row = self.0.next()?.map(|r| Row {
             inner: Box::new(LibsqlRow(r)),
         });

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -573,8 +573,9 @@ impl Stmt for RemoteStatement {
 
 pub(crate) struct RemoteRows(pub(crate) ResultRows, pub(crate) usize);
 
+#[async_trait::async_trait]
 impl RowsInner for RemoteRows {
-    fn next(&mut self) -> Result<Option<Row>> {
+    async fn next(&mut self) -> Result<Option<Row>> {
         // TODO(lucio): Switch to a vecdeque and reduce allocations
         let cursor = self.1;
         self.1 += 1;

--- a/libsql/src/rows.rs
+++ b/libsql/src/rows.rs
@@ -80,12 +80,12 @@ impl Rows {
     /// one by one. This stream can be further used with [futures::StreamExt]
     /// operators.
     #[cfg(feature = "stream")]
-    pub fn into_stream(mut self) -> impl futures::Stream<Item = Result<Row>> + Unpin {
-        Box::pin(async_stream::try_stream! {
+    pub fn into_stream(mut self) -> impl futures::Stream<Item = Result<Row>> {
+        async_stream::try_stream! {
             if let Some(row) = self.next().await? {
                 yield row
             }
-        })
+        }
     }
 }
 

--- a/libsql/src/rows.rs
+++ b/libsql/src/rows.rs
@@ -1,5 +1,4 @@
 use crate::{Result, Value, ValueType};
-use futures::Stream;
 use std::fmt;
 
 /// Represents a libsql column.
@@ -80,7 +79,8 @@ impl Rows {
     /// Converts current [Rows] into asynchronous stream, fetching rows
     /// one by one. This stream can be further used with [futures::StreamExt]
     /// operators.
-    pub fn into_stream(mut self) -> impl Stream<Item = Result<Row>> + Unpin {
+    #[cfg(feature = "stream")]
+    pub fn into_stream(mut self) -> impl futures::Stream<Item = Result<Row>> + Unpin {
         Box::pin(async_stream::try_stream! {
             if let Some(row) = self.next().await? {
                 yield row

--- a/libsql/src/rows.rs
+++ b/libsql/src/rows.rs
@@ -37,8 +37,9 @@ impl Column<'_> {
     }
 }
 
+#[async_trait::async_trait]
 pub(crate) trait RowsInner {
-    fn next(&mut self) -> Result<Option<Row>>;
+    async fn next(&mut self) -> Result<Option<Row>>;
 
     fn column_count(&self) -> i32;
 
@@ -56,8 +57,8 @@ impl Rows {
     /// Get the next [`Row`] returning an error if it failed and
     /// `None` if there are no more rows.
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> Result<Option<Row>> {
-        self.inner.next()
+    pub async fn next(&mut self) -> Result<Option<Row>> {
+        self.inner.next().await
     }
 
     /// Get the count of columns in this set of rows.

--- a/libsql/src/statement.rs
+++ b/libsql/src/statement.rs
@@ -2,7 +2,6 @@ use crate::params::IntoParams;
 use crate::params::Params;
 pub use crate::Column;
 use crate::{Error, Result};
-use futures::ready;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -101,6 +100,7 @@ impl<F> MappedRows<F> {
     }
 }
 
+#[cfg(feature = "core")]
 impl<F, T> futures::Stream for MappedRows<F>
 where
     F: FnMut(Row) -> Result<T> + Unpin,
@@ -108,7 +108,7 @@ where
     type Item = Result<T>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        use futures::Future;
+        use futures::{ready, Future};
 
         let mut rows = unsafe { self.as_mut().map_unchecked_mut(|pin| &mut pin.rows) };
         let mut fut = Box::pin(rows.next());

--- a/libsql/src/statement.rs
+++ b/libsql/src/statement.rs
@@ -2,7 +2,6 @@ use crate::params::IntoParams;
 use crate::params::Params;
 pub use crate::Column;
 use crate::{Error, Result};
-use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use crate::{Row, Rows};
@@ -107,7 +106,10 @@ where
 {
     type Item = Result<T>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         use futures::{ready, Future};
 
         let mut rows = unsafe { self.as_mut().map_unchecked_mut(|pin| &mut pin.rows) };

--- a/libsql/src/value.rs
+++ b/libsql/src/value.rs
@@ -13,7 +13,7 @@ pub enum Value {
 }
 
 /// The possible types a column can be in libsql.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum ValueType {
     Integer = 1,
     Real,

--- a/libsql/src/value.rs
+++ b/libsql/src/value.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use crate::{Error, Result};
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Value {
     Null,
     Integer(i64),

--- a/libsql/src/value.rs
+++ b/libsql/src/value.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use crate::{Error, Result};
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum Value {
     Null,
     Integer(i64),

--- a/libsql/src/wasm/cloudflare.rs
+++ b/libsql/src/wasm/cloudflare.rs
@@ -62,7 +62,7 @@ impl HttpSend for CloudflareSender {
 
     fn oneshot(self, url: Arc<str>, auth: Arc<str>, body: String) {
         worker::wasm_bindgen_futures::spawn_local(async move {
-            let _ = Self::send(&url, &auth, body).await;
+            let _ = Self::send(url, auth, body).await;
         });
     }
 }

--- a/libsql/src/wasm/cloudflare.rs
+++ b/libsql/src/wasm/cloudflare.rs
@@ -2,6 +2,7 @@ use crate::hrana::{HranaError, HttpBody, HttpSend, Result};
 use bytes::Bytes;
 use futures::{ready, Stream};
 use std::future::Future;
+use std::io::ErrorKind;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -78,7 +79,7 @@ impl From<worker::Error> for HranaError {
 pub struct HttpStream(worker::ByteStream);
 
 impl Stream for HttpStream {
-    type Item = Result<Bytes>;
+    type Item = std::io::Result<Bytes>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let pin = Pin::new(&mut self.0);
@@ -86,10 +87,10 @@ impl Stream for HttpStream {
         match res {
             None => Poll::Ready(None),
             Some(Ok(data)) => Poll::Ready(Some(Ok(Bytes::from(data)))),
-            Some(Err(e)) => Poll::Ready(Some(Err(HranaError::Http(format!(
-                "cloudflare HTTP stream error: {}",
-                e
-            ))))),
+            Some(Err(e)) => Poll::Ready(Some(Err(std::io::Error::new(
+                ErrorKind::Other,
+                e.to_string(),
+            )))),
         }
     }
 }

--- a/libsql/src/wasm/cloudflare.rs
+++ b/libsql/src/wasm/cloudflare.rs
@@ -59,6 +59,12 @@ impl HttpSend for CloudflareSender {
         let fut = Self::send(url, auth, body);
         Box::pin(fut)
     }
+
+    fn oneshot(self, url: Arc<str>, auth: Arc<str>, body: String) {
+        worker::wasm_bindgen_futures::spawn_local(async move {
+            let _ = Self::send(&url, &auth, body).await;
+        });
+    }
 }
 
 impl From<worker::Error> for HranaError {

--- a/libsql/src/wasm/cloudflare.rs
+++ b/libsql/src/wasm/cloudflare.rs
@@ -22,12 +22,12 @@ impl CloudflareSender {
         };
 
         let mut response = Fetch::Request(Request::new_with_init(
-            url,
+            url.as_ref(),
             &RequestInit {
                 body: Some(JsValue::from(body)),
                 headers: {
                     let mut headers = Headers::new();
-                    headers.append("Authorization", auth)?;
+                    headers.append("Authorization", auth.as_ref())?;
                     headers
                 },
                 cf: CfProperties::new(),

--- a/libsql/src/wasm/cloudflare.rs
+++ b/libsql/src/wasm/cloudflare.rs
@@ -22,12 +22,12 @@ impl CloudflareSender {
         };
 
         let mut response = Fetch::Request(Request::new_with_init(
-            &url,
+            url,
             &RequestInit {
                 body: Some(JsValue::from(body)),
                 headers: {
                     let mut headers = Headers::new();
-                    headers.append("Authorization", &auth)?;
+                    headers.append("Authorization", auth)?;
                     headers
                 },
                 cf: CfProperties::new(),

--- a/libsql/src/wasm/rows.rs
+++ b/libsql/src/wasm/rows.rs
@@ -33,7 +33,7 @@ pub(super) trait RowsInner {
 #[async_trait::async_trait(?Send)]
 impl<S> RowsInner for HranaRows<S>
 where
-    S: Stream<Item = crate::hrana::Result<Bytes>> + Unpin,
+    S: Stream<Item = std::io::Result<Bytes>> + Unpin,
 {
     async fn next(&mut self) -> crate::Result<Option<Row>> {
         self.next().await

--- a/libsql/src/wasm/rows.rs
+++ b/libsql/src/wasm/rows.rs
@@ -1,0 +1,49 @@
+use crate::hrana::HranaRows;
+use crate::Row;
+use bytes::Bytes;
+use futures::Stream;
+
+pub struct Rows {
+    pub(super) inner: Box<dyn RowsInner>,
+}
+
+impl Rows {
+    pub async fn next(&mut self) -> crate::Result<Option<Row>> {
+        self.inner.next().await
+    }
+
+    pub fn column_count(&self) -> i32 {
+        self.inner.column_count()
+    }
+
+    pub fn column_name(&self, idx: i32) -> Option<&str> {
+        self.inner.column_name(idx)
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+pub(super) trait RowsInner {
+    async fn next(&mut self) -> crate::Result<Option<Row>>;
+
+    fn column_count(&self) -> i32;
+
+    fn column_name(&self, idx: i32) -> Option<&str>;
+}
+
+#[async_trait::async_trait(?Send)]
+impl<S> RowsInner for HranaRows<S>
+where
+    S: Stream<Item = crate::hrana::Result<Bytes>> + Unpin,
+{
+    async fn next(&mut self) -> crate::Result<Option<Row>> {
+        self.next().await
+    }
+
+    fn column_count(&self) -> i32 {
+        self.column_count()
+    }
+
+    fn column_name(&self, idx: i32) -> Option<&str> {
+        self.column_name(idx)
+    }
+}

--- a/libsql/src/wasm/rows.rs
+++ b/libsql/src/wasm/rows.rs
@@ -19,6 +19,17 @@ impl Rows {
     pub fn column_name(&self, idx: i32) -> Option<&str> {
         self.inner.column_name(idx)
     }
+
+    /// Converts current [crate::Rows] into asynchronous stream, fetching rows
+    /// one by one. This stream can be further used with [futures::StreamExt]
+    /// operators.
+    pub fn into_stream(mut self) -> impl Stream<Item = crate::Result<Row>> + Unpin {
+        Box::pin(async_stream::try_stream! {
+            if let Some(row) = self.next().await? {
+                yield row
+            }
+        })
+    }
 }
 
 #[async_trait::async_trait(?Send)]

--- a/libsql/tests/integration_tests.rs
+++ b/libsql/tests/integration_tests.rs
@@ -137,7 +137,10 @@ async fn statement_query() {
     stmt.reset();
 
     let rows = stmt.query(&params).await.unwrap();
-    let mut names = rows.into_stream().map_ok(|r| r.get::<String>(1).unwrap());
+    let mut names = rows
+        .into_stream()
+        .boxed()
+        .map_ok(|r| r.get::<String>(1).unwrap());
 
     let name = names.next().await.unwrap().unwrap();
 

--- a/libsql/tests/integration_tests.rs
+++ b/libsql/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use libsql::{
     named_params, params,
     params::{IntoParams, IntoValue},
@@ -136,10 +136,8 @@ async fn statement_query() {
 
     stmt.reset();
 
-    let mut names = stmt
-        .query_map(&params, |r: libsql::Row| r.get::<String>(1))
-        .await
-        .unwrap();
+    let rows = stmt.query(&params).await.unwrap();
+    let mut names = rows.into_stream().map_ok(|r| r.get::<String>(1).unwrap());
 
     let name = names.next().await.unwrap().unwrap();
 

--- a/libsql/tests/replication.rs
+++ b/libsql/tests/replication.rs
@@ -41,6 +41,7 @@ async fn inject_frames() {
     assert_eq!(
         *rows
             .next()
+            .await
             .unwrap()
             .unwrap()
             .get_value(0)
@@ -82,6 +83,7 @@ async fn inject_frames() {
     assert_eq!(
         *rows
             .next()
+            .await
             .unwrap()
             .unwrap()
             .get_value(0)
@@ -148,6 +150,7 @@ async fn inject_frames_split_txn() {
     assert_eq!(
         *rows
             .next()
+            .await
             .unwrap()
             .unwrap()
             .get_value(0)


### PR DESCRIPTION
This PR works on top of #750 . 

It integrates Hrana cursor API into mainline of Rows abstraction in libsql client and enables to fetch cursors asynchronously without pre-fetching or buffering.