### PR TITLE
Endpoint for executing stuff on all namespaces

### DIFF
--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -140,6 +140,7 @@ where
             "/v1/namespaces/:namespace/stats/:stats_type",
             delete(stats::handle_delete_stats),
         )
+        .route("/v1/execute_on_all", post(handle_execute_on_all))
         .route("/v1/diagnostics", get(handle_diagnostics))
         .route("/metrics", get(handle_metrics))
         .with_state(Arc::new(AppState {
@@ -195,6 +196,15 @@ async fn handle_get_config<M: MakeNamespace, C: Connector>(
     };
 
     Ok(Json(resp))
+}
+
+async fn handle_execute_on_all<M: MakeNamespace, C: Connector>(
+    State(app_state): State<Arc<AppState<M, C>>>,
+    Json(req): Json<ExecuteOnAllReq>,
+) -> crate::Result<Vec<u8>> {
+    let ret = app_state.namespaces.execute_for_each(req.sql).await?;
+
+    Ok(ret)
 }
 
 async fn handle_diagnostics<M: MakeNamespace, C>(
@@ -275,6 +285,11 @@ struct CreateNamespaceReq {
     heartbeat_url: Option<String>,
     bottomless_db_id: Option<String>,
     jwt_key: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExecuteOnAllReq {
+    sql: String,
 }
 
 async fn handle_create_namespace<M: MakeNamespace, C: Connector>(

--- a/libsql-server/src/http/user/mod.rs
+++ b/libsql-server/src/http/user/mod.rs
@@ -48,7 +48,7 @@ use crate::utils::services::idle_shutdown::IdleShutdownKicker;
 use crate::version;
 
 use self::db_factory::MakeConnectionExtractor;
-use self::result_builder::JsonHttpPayloadBuilder;
+pub use self::result_builder::JsonHttpPayloadBuilder;
 use self::types::QueryObject;
 
 impl TryFrom<query::Value> for serde_json::Value {

--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -28,7 +28,6 @@ type WalManager = WalWrapper<Option<BottomlessWalWrapper>, Sqlite3WalManager>;
 type Connection = libsql_sys::Connection<WrappedWal<Option<BottomlessWalWrapper>, Sqlite3Wal>>;
 
 pub struct MetaStore {
-    base_path: std::path::PathBuf,
     changes_tx: mpsc::Sender<ChangeMsg>,
     inner: Arc<Mutex<MetaStoreInner>>,
 }
@@ -243,7 +242,6 @@ impl MetaStore {
         });
 
         Ok(Self {
-            base_path: base_path.to_owned(),
             changes_tx,
             inner,
         })

--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -28,6 +28,7 @@ type WalManager = WalWrapper<Option<BottomlessWalWrapper>, Sqlite3WalManager>;
 type Connection = libsql_sys::Connection<WrappedWal<Option<BottomlessWalWrapper>, Sqlite3Wal>>;
 
 pub struct MetaStore {
+    base_path: PathBuf,
     changes_tx: mpsc::Sender<ChangeMsg>,
     inner: Arc<Mutex<MetaStoreInner>>,
 }
@@ -241,7 +242,11 @@ impl MetaStore {
             }
         });
 
-        Ok(Self { changes_tx, inner })
+        Ok(Self {
+            base_path,
+            changes_tx,
+            inner,
+        })
     }
 
     pub fn handle(&self, namespace: NamespaceName) -> MetaStoreHandle {

--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -313,6 +313,12 @@ impl MetaStore {
 
         Ok(())
     }
+
+    // FIXME(sarna): racy, we should actually just iterate over the namespaces
+    // under a lock.
+    pub fn namespace_names(&self) -> Vec<NamespaceName> {
+        self.inner.lock().configs.keys().cloned().collect()
+    }
 }
 
 impl MetaStoreHandle {

--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -28,7 +28,7 @@ type WalManager = WalWrapper<Option<BottomlessWalWrapper>, Sqlite3WalManager>;
 type Connection = libsql_sys::Connection<WrappedWal<Option<BottomlessWalWrapper>, Sqlite3Wal>>;
 
 pub struct MetaStore {
-    base_path: PathBuf,
+    base_path: std::path::PathBuf,
     changes_tx: mpsc::Sender<ChangeMsg>,
     inner: Arc<Mutex<MetaStoreInner>>,
 }
@@ -243,7 +243,7 @@ impl MetaStore {
         });
 
         Ok(Self {
-            base_path,
+            base_path: base_path.to_owned(),
             changes_tx,
             inner,
         })

--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -241,10 +241,7 @@ impl MetaStore {
             }
         });
 
-        Ok(Self {
-            changes_tx,
-            inner,
-        })
+        Ok(Self { changes_tx, inner })
     }
 
     pub fn handle(&self, namespace: NamespaceName) -> MetaStoreHandle {


### PR DESCRIPTION
The new admin API endpoint, `/v1/execute_on_all`, lets you execute things on all namespaces (dbs) that exist in that machine.

Example call:
```sh
$ curl -sH 'Content-Type: application/json' \
  -d '{"sql": "select libsql_server_namespace_name(), 42 as \"forty-two\""}' localhost:9090/v1/execute_on_all \
  | jq '.[].results'
{
  "columns": [
    "libsql_server_namespace_name ()",
    "forty-two"
  ],
  "rows": [
    [
      "another_12",
      42
    ],
    [
      "another_3",
      42
    ],
    [
      "another_1",
      42
    ],
    [
      "another_9",
      42
    ],
    [
      "another_10",
      42
    ],
    [
      "another_4",
      42
    ],
    [
      "another_7",
      42
    ],
    [
      "another_6",
      42
    ],
    [
      "another_2",
      42
    ],
    [
      "another_8",
      42
    ],
    [
      "another_11",
      42
    ],
    [
      "another_5",
      42
    ]
  ]
}
```