### PR TITLE
libsql: add an introspective libsql_server_namespace_name() function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ rusqlite = { path = "vendored/rusqlite", version = "0.29", default-features = fa
     "libsql-experimental",
     "column_decltype",
     "load_extension",
-    "modern_sqlite"
+    "modern_sqlite",
+    "functions",
 ] }
 
 # Config for 'cargo dist'

--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -276,6 +276,23 @@ where
             )?;
             conn.conn
                 .pragma_update(None, "max_page_count", max_db_size)?;
+            let namespace = path
+                .as_ref()
+                .file_name()
+                .unwrap_or_default()
+                .to_os_string()
+                .into_string()
+                .unwrap_or_default();
+            conn.conn.create_scalar_function(
+                "libsql_server_namespace_name",
+                0,
+                rusqlite::functions::FunctionFlags::SQLITE_UTF8
+                    | rusqlite::functions::FunctionFlags::SQLITE_DETERMINISTIC,
+                {
+                    let namespace = namespace;
+                    move |_| Ok(namespace.clone())
+                },
+            )?;
             Ok(conn)
         })
         .await


### PR DESCRIPTION
With that, you can query your namespace name -- and that can be useful as a helper function when joining results from queries that span databases.