### PR TITLE
Add a metric for out-of-sync replication values

### DIFF
--- a/libsql-server/src/metrics.rs
+++ b/libsql-server/src/metrics.rs
@@ -125,3 +125,11 @@ pub static REPLICATION_LATENCY: Lazy<Histogram> = Lazy::new(|| {
     );
     register_histogram!(NAME)
 });
+pub static REPLICATION_LATENCY_OUT_OF_SYNC: Lazy<Counter> = Lazy::new(|| {
+    const NAME: &str = "libsql_server_replication_latency_out_of_sync";
+    describe_counter!(
+        NAME,
+        "Number of replication latency timestamps that were out-of-sync (clocks likely not synchronized)"
+    );
+    register_counter!(NAME)
+});

--- a/libsql-server/src/replication/replicator_client.rs
+++ b/libsql-server/src/replication/replicator_client.rs
@@ -17,7 +17,7 @@ use tonic::metadata::{AsciiMetadataValue, BinaryMetadataValue};
 use tonic::transport::Channel;
 use tonic::Request;
 
-use crate::metrics::REPLICATION_LATENCY;
+use crate::metrics::{REPLICATION_LATENCY, REPLICATION_LATENCY_OUT_OF_SYNC};
 use crate::namespace::NamespaceName;
 use crate::replication::FrameNo;
 
@@ -121,6 +121,8 @@ impl ReplicatorClient for Client {
                             // we can record negative values if the clocks are out-of-sync. There is not
                             // point in recording those values.
                             REPLICATION_LATENCY.record(lat);
+                        } else {
+                            REPLICATION_LATENCY_OUT_OF_SYNC.increment(1);
                         }
                     }
                 }


### PR DESCRIPTION
Makes debugging replication latency issues easier.