### PR TITLE
ci: release Docker images for arm64

### DIFF
--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -5,8 +5,6 @@ on:
     branches: ['main']
     tags:
       - libsql-server-v*.*.*
-  # REMOVE BEFORE MERGING
-  pull_request:
 
 env:
   REGISTRY: ghcr.io
@@ -31,13 +29,12 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
 
-      # UNCOMMENT BEFORE MERGING
-      # - name: Log in to the Container registry
-      #   uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-      #   with:
-      #     registry: ${{ env.REGISTRY }}
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -52,8 +49,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          # SET BACK TO TRUE BEFORE MERGING
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -5,6 +5,8 @@ on:
     branches: ['main']
     tags:
       - libsql-server-v*.*.*
+  # REMOVE BEFORE MERGING
+  pull_request:
 
 env:
   REGISTRY: ghcr.io
@@ -29,12 +31,13 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # UNCOMMENT BEFORE MERGING
+      # - name: Log in to the Container registry
+      #   uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      #   with:
+      #     registry: ${{ env.REGISTRY }}
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -49,7 +52,8 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
-          push: true
+          # SET BACK TO TRUE BEFORE MERGING
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Closes https://github.com/tursodatabase/libsql/issues/795

This PR adds an additional `platform` to `docker buildx` to support arm64 (`linux/arm64`, the default for GitHub runners is `linux/amd64`).

[This commit](https://github.com/tursodatabase/libsql/pull/845/commits/c498c98e693d498f460a62fad6ed79b9cca737ec) will allow to test if it still builds successfully for both platforms before merging.