### PR TITLE
Remove Authenticated::is_anonymous

### DIFF
--- a/libsql-server/src/auth.rs
+++ b/libsql-server/src/auth.rs
@@ -231,14 +231,6 @@ impl Authenticated {
             }) => true,
         }
     }
-
-    /// Returns `true` if the authenticated is [`Anonymous`].
-    ///
-    /// [`Anonymous`]: Authenticated::Anonymous
-    #[must_use]
-    pub fn is_anonymous(&self) -> bool {
-        matches!(self, Self::Anonymous)
-    }
 }
 
 #[derive(Debug)]

--- a/libsql-server/src/http/user/dump.rs
+++ b/libsql-server/src/http/user/dump.rs
@@ -84,7 +84,7 @@ pub(super) async fn handle_dump<F: MakeNamespace>(
         state.disable_namespaces,
     )?;
 
-    if !auth.is_namespace_authorized(&namespace) | auth.is_anonymous() {
+    if !auth.is_namespace_authorized(&namespace) {
         return Err(Error::NamespaceDoesntExist(namespace.to_string()));
     }
 


### PR DESCRIPTION
Authenticated::is_namespace_authorized already returns false when Authenticated::is_anonymous() == true.