### PR TITLE
libsql-sqlite3: libsql_step: add preempting the vm after X steps

### DIFF
--- a/libsql-sqlite3/src/sqlite.h.in
+++ b/libsql-sqlite3/src/sqlite.h.in
@@ -482,6 +482,9 @@ int sqlite3_exec(
 #define SQLITE_DONE        101  /* sqlite3_step() has finished executing */
 /* end-of-error-codes */
 
+/* libSQL extension */
+#define LIBSQL_CONTINUE    159  /* libsql_step() got preempted, and should be continued */
+
 /*
 ** CAPI3REF: Extended Result Codes
 ** KEYWORDS: {extended result code definitions}
@@ -5038,6 +5041,12 @@ const void *sqlite3_column_decltype16(sqlite3_stmt*,int);
 ** by sqlite3_step().  The use of the "vX" interfaces is recommended.
 */
 int sqlite3_step(sqlite3_stmt*);
+/*
+** libSQL extension: like sqlite3_step, but returns LIBSQL_CONTINUE
+** after N virtual machine steps.
+*/
+#define LIBSQL_NEVER_PREEMPT ((sqlite3_uint64)1 << 63)
+int libsql_step(sqlite3_stmt*, sqlite_uint64);
 
 /*
 ** CAPI3REF: Number of columns in a result set

--- a/libsql-sqlite3/src/vdbeInt.h
+++ b/libsql-sqlite3/src/vdbeInt.h
@@ -595,7 +595,7 @@ void sqlite3VdbeDeleteAuxData(sqlite3*, AuxData**, int, int);
 int sqlite2BtreeKeyCompare(BtCursor *, const void *, int, int, int *);
 int sqlite3VdbeIdxKeyCompare(sqlite3*,VdbeCursor*,UnpackedRecord*,int*);
 int sqlite3VdbeIdxRowid(sqlite3*, BtCursor*, i64*);
-int sqlite3VdbeExec(Vdbe*);
+int sqlite3VdbeExec(Vdbe*, u64);
 #if !defined(SQLITE_OMIT_EXPLAIN) || defined(SQLITE_ENABLE_BYTECODE_VTAB)
 int sqlite3VdbeNextOpcode(Vdbe*,Mem*,int,int*,int*,Op**);
 char *sqlite3VdbeDisplayP4(sqlite3*,Op*);

--- a/libsql-sqlite3/src/vdbeblob.c
+++ b/libsql-sqlite3/src/vdbeblob.c
@@ -68,7 +68,7 @@ static int blobSeekToRow(Incrblob *p, sqlite3_int64 iRow, char **pzErr){
   if( v->pc>4 ){
     v->pc = 4;
     assert( v->aOp[v->pc].opcode==OP_NotExists );
-    rc = sqlite3VdbeExec(v);
+    rc = sqlite3VdbeExec(v, LIBSQL_NEVER_PREEMPT);
   }else{
     rc = sqlite3_step(p->pStmt);
   }


### PR DESCRIPTION
The idea is that after X virtual machine steps, we optionally
return LIBSQL_CONTINUE error code, which gives CPU back to the caller,
and lets them know that libsql_step should simply be called again
to continue executing the statement.

Early demo with libsql shell and debug messages:
```
$ ./libsql 
libSQL version 0.2.3 (based on SQLite version 3.44.0) 2023-11-01 11:23:50
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
libsql> create table t(id);
	[pc:0] step 0 <Init>
	[pc:12] step 1 <Transaction>
	[pc:13] step 2 <Goto>
	[pc:1] step 3 <Noop>
	[pc:2] step 4 <OpenRead>
	[pc:3] step 5 <Rewind>
	[pc:11] step 6 <Halt>
pc = 11, 5 steps done, preempting with LIBSQL_CONTINUE
	[pc:11] step 0 <Halt>
	[pc:0] step 0 <Init>
	[pc:29] step 1 <Transaction>
	[pc:30] step 2 <Goto>
	[pc:1] step 3 <ReadCookie>
	[pc:2] step 4 <If>
	[pc:3] step 5 <SetCookie>
	[pc:4] step 6 <SetCookie>
pc = 4, 5 steps done, preempting with LIBSQL_CONTINUE
	[pc:4] step 0 <SetCookie>
	[pc:5] step 1 <CreateBtree>
	[pc:6] step 2 <OpenWrite>
	[pc:7] step 3 <NewRowid>
	[pc:8] step 4 <Blob>
	[pc:9] step 5 <Insert>
	[pc:10] step 6 <Close>
pc = 10, 5 steps done, preempting with LIBSQL_CONTINUE
	[pc:10] step 0 <Close>
	[pc:11] step 1 <Close>
	[pc:12] step 2 <Null>
	[pc:13] step 3 <Noop>
	[pc:14] step 4 <OpenWrite>
	[pc:15] step 5 <SeekRowid>
	[pc:16] step 6 <Rowid>
pc = 16, 5 steps done, preempting with LIBSQL_CONTINUE
	[pc:16] step 0 <Rowid>
	[pc:17] step 1 <IsNull>
	[pc:18] step 2 <String8>
	[pc:19] step 3 <String8>
	[pc:20] step 4 <String8>
	[pc:21] step 5 <Copy>
	[pc:22] step 6 <String8>
pc = 22, 5 steps done, preempting with LIBSQL_CONTINUE
	[pc:22] step 0 <String8>
	[pc:23] step 1 <MakeRecord>
	[pc:24] step 2 <Insert>
	[pc:25] step 3 <SetCookie>
	[pc:26] step 4 <ParseSchema>
	[pc:0] step 0 <Init>
	[pc:16] step 1 <Transaction>
	[pc:17] step 2 <String8>
	[pc:18] step 3 <String8>
	[pc:19] step 4 <Goto>
	[pc:1] step 5 <Noop>
	[pc:2] step 6 <OpenRead>
pc = 2, 5 steps done, preempting with LIBSQL_CONTINUE
	[pc:2] step 0 <OpenRead>
	[pc:3] step 1 <Rewind>
	[pc:4] step 2 <Column>
	[pc:5] step 3 <Ne>
	[pc:6] step 4 <Column>
	[pc:7] step 5 <Eq>
	[pc:8] step 6 <Column>
pc = 8, 5 steps done, preempting with LIBSQL_CONTINUE
	[pc:8] step 0 <Column>
	[pc:9] step 1 <Column>
	[pc:10] step 2 <Column>
	[pc:11] step 3 <Column>
	[pc:12] step 4 <Column>
	[pc:13] step 5 <ResultRow>
	[pc:14] step 0 <Next>
	[pc:15] step 1 <Halt>
	[pc:27] step 5 <SqlExec>
	[pc:0] step 0 <Init>
	[pc:25] step 1 <Transaction>
	[pc:26] step 2 <Goto>
	[pc:1] step 3 <Expire>
	[pc:2] step 4 <Integer>
	[pc:3] step 5 <IntegrityCk>
	[pc:4] step 6 <IsNull>
pc = 4, 5 steps done, preempting with LIBSQL_CONTINUE
	[pc:4] step 0 <IsNull>
	[pc:10] step 1 <OpenRead>
	[pc:11] step 2 <Integer>
	[pc:12] step 3 <Rewind>
	[pc:16] step 4 <String8>
	[pc:17] step 5 <AddImm>
	[pc:18] step 6 <IfNotZero>
pc = 18, 5 steps done, preempting with LIBSQL_CONTINUE
	[pc:18] step 0 <IfNotZero>
	[pc:19] step 1 <String8>
	[pc:20] step 2 <ResultRow>
	[pc:21] step 0 <Halt>
	[pc:28] step 6 <Halt>
pc = 28, 5 steps done, preempting with LIBSQL_CONTINUE
	[pc:28] step 0 <Halt>
libsql> select * from sqlite_master;
	[pc:0] step 0 <Init>
	[pc:11] step 1 <Transaction>
	[pc:12] step 2 <Goto>
	[pc:1] step 3 <OpenRead>
	[pc:2] step 4 <Rewind>
	[pc:3] step 5 <Column>
	[pc:4] step 6 <Column>
pc = 4, 5 steps done, preempting with LIBSQL_CONTINUE
	[pc:4] step 0 <Column>
	[pc:5] step 1 <Column>
	[pc:6] step 2 <Column>
	[pc:7] step 3 <Column>
	[pc:8] step 4 <ResultRow>
table|t|t|2|CREATE TABLE t(id)
	[pc:9] step 0 <Next>
	[pc:10] step 1 <Halt>
```