### PR TITLE
fixing namespaces::delete_namespace uncovers a bug

### DIFF
--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -256,6 +256,16 @@ impl MetaStore {
         self.inner.lock().configs.contains_key(namespace)
     }
 
+    pub fn remove(&self, namespace: &NamespaceName) -> Result<bool> {
+        tracing::debug!("removing a namespace from meta store `{}`", namespace);
+        let mut guard = self.inner.lock();
+        guard.conn.execute(
+            "DELETE FROM namespace_configs WHERE namespace = ?",
+            [namespace.as_str()],
+        )?;
+        Ok(guard.configs.remove(namespace).is_some())
+    }
+
     pub(crate) async fn shutdown(&self) -> crate::Result<()> {
         let replicator = self
             .inner

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -279,6 +279,7 @@ impl MakeNamespace for PrimaryNamespaceMaker {
         }
 
         if ns_path.try_exists()? {
+            tracing::debug!("removing database directory: {}", ns_path.display());
             tokio::fs::remove_dir_all(ns_path).await?;
         }
 
@@ -473,7 +474,7 @@ impl<M: MakeNamespace> NamespaceStore<M> {
                 &self.inner.metadata,
             )
             .await?;
-
+        self.inner.metadata.remove(&namespace)?;
         tracing::info!("destroyed namespace: {namespace}");
 
         Ok(())

--- a/libsql-server/tests/common/http.rs
+++ b/libsql-server/tests/common/http.rs
@@ -50,4 +50,19 @@ impl Client {
 
         Ok(Response(resp))
     }
+
+    pub(crate) async fn delete<T: Serialize>(
+        &self,
+        url: &str,
+        body: T,
+    ) -> anyhow::Result<Response> {
+        let bytes: Bytes = serde_json::to_vec(&body)?.into();
+        let body = Body::from(bytes);
+        let request = hyper::Request::delete(url)
+            .header("Content-Type", "application/json")
+            .body(body)?;
+        let resp = self.0.request(request).await?;
+
+        Ok(Response(resp))
+    }
 }

--- a/libsql-server/tests/namespaces/mod.rs
+++ b/libsql-server/tests/namespaces/mod.rs
@@ -116,11 +116,12 @@ fn delete_namespace() {
         foo_conn.execute("create table test (c)", ()).await?;
 
         client
-            .post("http://primary:9090/v1/namespaces/foo/destroy", json!({}))
+            .delete("http://primary:9090/v1/namespaces/foo", json!({}))
             .await
             .unwrap();
         // namespace doesn't exist anymore
-        assert!(foo_conn.execute("create table test (c)", ()).await.is_err());
+        let res = foo_conn.execute("create table test (c)", ()).await;
+        assert!(res.is_err());
 
         Ok(())
     });


### PR DESCRIPTION
This PR uncovers and fixes issue with namespace deletion:

1. Original test `namespaces::delete_namespace` didn't work correctly, since:
    1. POST `namespaces/foo/destroy` is not a valid request/route.
    2. Test assertion was failing on error not because we sent a request to deleted namespace, but we tried to create table which already existed.
2. As it turns out, `PrimaryNamespace::destroy` removed all necessary entries, **except the namespace configuration in meta store**. The thing is that when a request was sent from a client to a deleted namespace, meta store still had a necessary config. In result we opened a new DB connection using that config: and since all sqld connections are opening DB file using open-or-create semantics, we recreated a deleted database.