### PR TITLE
Add Iterator and IntoIterator traits for Rows type

### DIFF
--- a/libsql/src/rows.rs
+++ b/libsql/src/rows.rs
@@ -76,6 +76,28 @@ impl Rows {
     }
 }
 
+impl IntoIterator for Rows {
+    type Item = Result<Row>;
+    type IntoIter = RowsIntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        RowsIntoIter { rows: self }
+    }
+}
+
+/// An iterator over a set of rows.
+pub struct RowsIntoIter {
+    rows: Rows,
+}
+
+impl Iterator for RowsIntoIter {
+    type Item = Result<Row>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.rows.next().transpose()
+    }
+}
+
 /// A libsql row.
 pub struct Row {
     pub(crate) inner: Box<dyn RowInner + Send + Sync>,


### PR DESCRIPTION
This PR adds the implementation of the `Iterator` and `IntoIterator` traits to the Rows struct.

I don't know if currently there is a better way of doing something like this, but I wanted an API that looked a bit like what we have on the `libsql-client-rs` crate where you can interact with the returned rows as an iterator (in this case because rows is a Vec<Row>) like so:

```rust
    let rows = conn.query(
        "select * from hello",
        (),
    ).await.unwrap();
    let _ = rows
        .into_iter()
        .map(|r| from_row::<MyType>(&r.unwrap()).unwrap())
        .collect::<Vec<_>>();
```

Let me know what you guys think/what should be changed about the implementation.