### PR TITLE
libsql-sqlite3: Export more API functions in Wasm

### DIFF
--- a/libsql-sqlite3/ext/wasm/api/EXPORTED_FUNCTIONS.sqlite3-api
+++ b/libsql-sqlite3/ext/wasm/api/EXPORTED_FUNCTIONS.sqlite3-api
@@ -62,6 +62,7 @@ _sqlite3_extended_result_codes
 _sqlite3_file_control
 _sqlite3_finalize
 _sqlite3_free
+_sqlite3_get_autocommit
 _sqlite3_get_auxdata
 _sqlite3_initialize
 _sqlite3_keyword_count

--- a/libsql-sqlite3/ext/wasm/api/sqlite3-api-oo1.js
+++ b/libsql-sqlite3/ext/wasm/api/sqlite3-api-oo1.js
@@ -1271,6 +1271,10 @@ globalThis.sqlite3ApiBootstrap.initializers.push(function(sqlite3){
     */
     checkRc: function(resultCode){
       return checkSqlite3Rc(this, resultCode);
+    },
+
+    getAutocommit: function(){
+      return capi.sqlite3_get_autocommit(this.pointer);
     }
   }/*DB.prototype*/;
 

--- a/libsql-sqlite3/ext/wasm/api/sqlite3-api-oo1.js
+++ b/libsql-sqlite3/ext/wasm/api/sqlite3-api-oo1.js
@@ -1275,6 +1275,10 @@ globalThis.sqlite3ApiBootstrap.initializers.push(function(sqlite3){
 
     getAutocommit: function(){
       return capi.sqlite3_get_autocommit(this.pointer);
+    },
+
+    lastInsertRowid: function(){
+      return capi.sqlite3_last_insert_rowid(this.pointer);
     }
   }/*DB.prototype*/;
 


### PR DESCRIPTION
We need the `sqlite3_get_autocomit()` and `sqlite_last_insert_rowid()` in the TypeScript SDK, for example. The fact that it's not exported seems to be just an omission so let's add it.