### PR TITLE
Add a github workflow to test brew installs

### DIFF
--- a/.github/workflows/brew-test.yml
+++ b/.github/workflows/brew-test.yml
@@ -1,0 +1,27 @@
+name: Workflow to test our brew installations
+
+on:
+  workflow_dispatch:
+
+jobs:
+  install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Brew install tap
+        run: |
+          brew tap libsql/sqld
+          brew install libsql-server
+
+      - name: Verify CLI installation
+        run: sqld --version


### PR DESCRIPTION
sample run: https://github.com/tursodatabase/libsql/actions/runs/7490407240

trigger is set to workflow dispatch, so this needs to be run manually

btw if you think its not necessary or adds noise to workflow directory, then I can move this to https://github.com/libsql/homebrew-sqld repo 