### PR TITLE
sqlite3_parser: add support for `ALTER TABLE ALTER COLUMN` syntax

### DIFF
--- a/vendored/sqlite3-parser/Cargo.toml
+++ b/vendored/sqlite3-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-sqlite3-parser"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 authors = ["gwenn"]
 description = "SQL parser (as understood by SQLite) (libsql fork)"

--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1965,6 +1965,7 @@ pub enum AlterTableBody {
     AddColumn(ColumnDefinition), // TODO distinction between ADD and ADD COLUMN
     RenameColumn { old: Name, new: Name },
     DropColumn(Name), // TODO distinction between DROP and DROP COLUMN
+    AlterColumn { old: Name, cd: ColumnDefinition },
 }
 impl ToTokens for AlterTableBody {
     fn to_tokens<S: TokenStream>(&self, s: &mut S) -> Result<(), S::Error> {
@@ -1989,6 +1990,13 @@ impl ToTokens for AlterTableBody {
                 s.append(TK_DROP, None)?;
                 s.append(TK_COLUMNKW, None)?;
                 name.to_tokens(s)
+            }
+            AlterTableBody::AlterColumn { old, cd } => {
+                s.append(TK_ALTER, None)?;
+                s.append(TK_COLUMNKW, None)?;
+                old.to_tokens(s)?;
+                s.append(TK_TO, None)?;
+                cd.to_tokens(s)
             }
         }
     }

--- a/vendored/sqlite3-parser/src/parser/parse.y
+++ b/vendored/sqlite3-parser/src/parser/parse.y
@@ -1327,6 +1327,13 @@ cmd ::= ALTER TABLE fullname(X) DROP kwcolumn_opt nm(Y). {
   self.ctx.stmt = Some(Stmt::AlterTable(X, AlterTableBody::DropColumn(Y)));
 }
 
+cmd ::= ALTER TABLE fullname(X) ALTER COLUMNKW columnname(Y) TO columnname(Z) carglist(C). {
+  let (colfrom_name, _) = Y;
+  let (col_name, col_type) = Z;
+  let cd = ColumnDefinition{ col_name, col_type, constraints: C };
+  self.ctx.stmt = Some(Stmt::AlterTable(X, AlterTableBody::AlterColumn{ old: colfrom_name, cd }));
+}
+
 kwcolumn_opt ::= .
 kwcolumn_opt ::= COLUMNKW.
 %endif  SQLITE_OMIT_ALTERTABLE


### PR DESCRIPTION
We support it in libSQL already, so we just add appropriate entry in sqlite3_parser's parse.y as well

Fixes #447 