### PR TITLE
configurable txn timeout

### DIFF
--- a/libsql-replication/proto/metadata.proto
+++ b/libsql-replication/proto/metadata.proto
@@ -14,4 +14,5 @@ message DatabaseConfig {
     optional string heartbeat_url = 5;
     optional string bottomless_db_id = 6; 
     optional string jwt_key = 7;
+    optional uint64 txn_timeout_s = 8;
 }

--- a/libsql-replication/src/generated/metadata.rs
+++ b/libsql-replication/src/generated/metadata.rs
@@ -19,4 +19,6 @@ pub struct DatabaseConfig {
     pub bottomless_db_id: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag = "7")]
     pub jwt_key: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(uint64, optional, tag = "8")]
+    pub txn_timeout_s: ::core::option::Option<u64>,
 }

--- a/libsql-server/src/connection/config.rs
+++ b/libsql-server/src/connection/config.rs
@@ -2,6 +2,9 @@ use crate::LIBSQL_PAGE_SIZE;
 use url::Url;
 
 use libsql_replication::rpc::metadata;
+use tokio::time::Duration;
+
+use super::TXN_TIMEOUT;
 
 #[derive(Debug, Clone)]
 pub struct DatabaseConfig {
@@ -14,6 +17,7 @@ pub struct DatabaseConfig {
     pub heartbeat_url: Option<Url>,
     pub bottomless_db_id: Option<String>,
     pub jwt_key: Option<String>,
+    pub txn_timeout: Option<Duration>,
 }
 
 const fn default_max_size() -> u64 {
@@ -30,6 +34,7 @@ impl Default for DatabaseConfig {
             heartbeat_url: None,
             bottomless_db_id: None,
             jwt_key: None,
+            txn_timeout: Some(TXN_TIMEOUT),
         }
     }
 }
@@ -47,6 +52,7 @@ impl From<&metadata::DatabaseConfig> for DatabaseConfig {
                 .map(|s| Url::parse(&s).unwrap()),
             bottomless_db_id: value.bottomless_db_id.clone(),
             jwt_key: value.jwt_key.clone(),
+            txn_timeout: value.txn_timeout_s.map(Duration::from_secs),
         }
     }
 }
@@ -61,6 +67,7 @@ impl From<&DatabaseConfig> for metadata::DatabaseConfig {
             heartbeat_url: value.heartbeat_url.as_ref().map(|s| s.to_string()),
             bottomless_db_id: value.bottomless_db_id.clone(),
             jwt_key: value.jwt_key.clone(),
+            txn_timeout_s: value.txn_timeout.map(|d| d.as_secs()),
         }
     }
 }

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -275,6 +275,7 @@ struct CreateNamespaceReq {
     heartbeat_url: Option<String>,
     bottomless_db_id: Option<String>,
     jwt_key: Option<String>,
+    txn_timeout_s: Option<u64>,
 }
 
 async fn handle_create_namespace<M: MakeNamespace, C: Connector>(
@@ -311,6 +312,11 @@ async fn handle_create_namespace<M: MakeNamespace, C: Connector>(
     if let Some(url) = req.heartbeat_url {
         config.heartbeat_url = Some(Url::parse(&url)?)
     }
+
+    if let Some(txn_timeout_s) = req.txn_timeout_s {
+        config.txn_timeout = Some(Duration::from_secs(txn_timeout_s));
+    }
+
     config.jwt_key = req.jwt_key;
     store.store(config).await?;
 


### PR DESCRIPTION
This PR makes txn timeout configurable per-namespace thanks to the `txn_timeout_s` option in the namespace configuration
