### PR TITLE
Hrana URL strings: don't append pipeline/cursor routes blindly

### DIFF
--- a/libsql/src/hrana/connection.rs
+++ b/libsql/src/hrana/connection.rs
@@ -1,7 +1,7 @@
 use crate::hrana::cursor::Cursor;
 use crate::hrana::pipeline::{BatchStreamReq, StreamRequest, StreamResponse};
 use crate::hrana::proto::{Batch, BatchResult, Stmt};
-use crate::hrana::stream::HranaStream;
+use crate::hrana::stream::{parse_hrana_urls, HranaStream};
 use crate::hrana::{HranaError, HttpSend, Result, Statement};
 use crate::util::coerce_url_scheme;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
@@ -32,9 +32,8 @@ where
 {
     pub fn new(url: String, token: String, inner: T) -> Self {
         // The `libsql://` protocol is an alias for `https://`.
-        let base_url = coerce_url_scheme(&url);
-        let pipeline_url = Arc::from(format!("{base_url}/v3/pipeline"));
-        let cursor_url = Arc::from(format!("{base_url}/v3/cursor"));
+        let base_url = coerce_url_scheme(url);
+        let (pipeline_url, cursor_url) = parse_hrana_urls(&base_url);
         HttpConnection(Arc::new(InnerClient {
             inner,
             pipeline_url,

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -53,7 +53,16 @@ impl Database {
         auth_token: String,
         encryption_key: Option<bytes::Bytes>,
     ) -> Result<Database> {
-        Self::open_http_sync_internal(connector, db_path, endpoint, auth_token, None, false, encryption_key).await
+        Self::open_http_sync_internal(
+            connector,
+            db_path,
+            endpoint,
+            auth_token,
+            None,
+            false,
+            encryption_key,
+        )
+        .await
     }
 
     #[cfg(feature = "replication")]
@@ -73,7 +82,7 @@ impl Database {
 
         let mut db = Database::open(&db_path, OpenFlags::default())?;
 
-        let endpoint = coerce_url_scheme(&endpoint);
+        let endpoint = coerce_url_scheme(endpoint);
         let remote = crate::replication::client::Client::new(
             connector,
             endpoint.as_str().try_into().unwrap(),
@@ -98,7 +107,11 @@ impl Database {
     }
 
     #[cfg(feature = "replication")]
-    pub async fn open_local_sync(db_path: impl Into<String>, flags: OpenFlags, encryption_key: Option<bytes::Bytes>) -> Result<Database> {
+    pub async fn open_local_sync(
+        db_path: impl Into<String>,
+        flags: OpenFlags,
+        encryption_key: Option<bytes::Bytes>,
+    ) -> Result<Database> {
         use std::path::PathBuf;
 
         let db_path = db_path.into();

--- a/libsql/src/util/mod.rs
+++ b/libsql/src/util/mod.rs
@@ -7,7 +7,7 @@ cfg_replication_or_remote! {
 }
 
 cfg_replication_or_remote_or_hrana! {
-    pub(crate) fn coerce_url_scheme(url: &str) -> String {
+    pub(crate) fn coerce_url_scheme(url: String) -> String {
         let mut url = url.replace("libsql://", "https://");
 
         if !url.contains("://") {


### PR DESCRIPTION
Atm. Hrana connection takes in a base_url and internally constructs a pipeline (/v3/pipeline) and cursor (/v3/cursor) URLs out of it. The thing is that it did so without properly checking if it's ok to do so. Therefore if someone set a base URL to ie. `libsql://pen.turso.io/?authToken=` it wouldn't immediately fail, but instead the requests would be send to an invalid endpoint (`/?authToken=/v3/cursor` instead of `/v3/cursor/?authToken=`). This PR changes that behaviour.

Now, we could think: why not use native URL parsing capabilities and use Url all the way down:
1. Hyper and Cloudflare use different parsing libraries. Hyper uses `http` based one which comes with dependencies that we don't want on Cloudflare end.
2. Cloudflare (and `url` crate, which it uses internally) comes with some limitations ie. `url.set_scheme` (which we need for things like switching `libsql`&rarr;`https`) [explicitly disallows switching schemes of specific kinds](https://docs.rs/url/latest/url/struct.Url.html#examples-35), our use case included. Moreover it doesn't provide API to override that behaviour. Btw. `url` crate is the most popular Rust crate used for this purpose.