### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:slim-bullseye AS chef
 RUN apt update \
     && apt install -y libclang-dev clang \
         build-essential tcl protobuf-compiler file \
-        libssl-dev pkg-config git tcl \
+        libssl-dev pkg-config git tcl cmake \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -252,7 +252,8 @@ fn build_multiple_ciphers(out_dir: &str, out_path: &Path) {
     #[cfg(feature = "libsql-wasm-experimental")]
     cmd.arg("-DLIBSQL_ENABLE_WASM_RUNTIME");
 
-    cmd.output().unwrap();
+    let out = cmd.output().unwrap();
+    assert!(out.status.success(), "{:?}", out);
     std::fs::copy(
         format!("{BUNDLED_DIR}/SQLite3MultipleCiphers/build/libsqlite3mc_static.a"),
         format!("{out_dir}/libsqlite3mc.a"),

--- a/libsql-ffi/bundled/SQLite3MultipleCiphers/CMakeLists.txt
+++ b/libsql-ffi/bundled/SQLite3MultipleCiphers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.24.0.0)
+cmake_minimum_required(VERSION 3.18.0.0)
 project(sqlite3mc)
 
 # Helper macro


### PR DESCRIPTION
Fix the docker build:
- check the output of multi-cipher build command
- add cmake as a build dependency
- downgrade cmake require version to meet what's available on debian
