### PR TITLE
Add UUID to stats

### DIFF
--- a/libsql-server/src/http/admin/stats.rs
+++ b/libsql-server/src/http/admin/stats.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 use axum::extract::{Path, State};
 use axum::Json;
+use uuid::Uuid;
 
 use crate::namespace::{MakeNamespace, NamespaceName};
 use crate::replication::FrameNo;
@@ -13,6 +14,7 @@ use super::AppState;
 
 #[derive(Serialize)]
 pub struct StatsResponse {
+    pub id: Option<Uuid>,
     pub rows_read_count: u64,
     pub rows_written_count: u64,
     pub storage_bytes_used: u64,
@@ -25,6 +27,7 @@ pub struct StatsResponse {
 impl From<&Stats> for StatsResponse {
     fn from(stats: &Stats) -> Self {
         Self {
+            id: stats.id(),
             rows_read_count: stats.rows_read(),
             rows_written_count: stats.rows_written(),
             storage_bytes_used: stats.storage_bytes_used(),

--- a/libsql-server/src/stats.rs
+++ b/libsql-server/src/stats.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeSet;
 use tokio::io::AsyncWriteExt;
 use tokio::task::JoinSet;
 use tokio::time::Duration;
+use uuid::Uuid;
 
 use crate::namespace::NamespaceName;
 use crate::replication::FrameNo;
@@ -57,6 +58,8 @@ pub struct Stats {
     namespace: NamespaceName,
 
     #[serde(default)]
+    id: Option<Uuid>,
+    #[serde(default)]
     rows_written: AtomicU64,
     #[serde(default)]
     rows_read: AtomicU64,
@@ -92,6 +95,10 @@ impl Stats {
         } else {
             Stats::default()
         };
+
+        if this.id.is_none() {
+            this.id = Some(Uuid::new_v4());
+        }
 
         this.namespace = namespace;
         let this = Arc::new(this);
@@ -225,6 +232,10 @@ impl Stats {
         counter!("libsql_server_query_rows_read", rows_read);
         counter!("libsql_server_query_rows_written", rows_written);
         counter!("libsql_server_query_mem_used", mem_used);
+    }
+
+    pub fn id(&self) -> Option<Uuid> {
+        self.id.clone()
     }
 }
 


### PR DESCRIPTION
This should allow any stats consumer to know when the file has been lost and the counters should be restarted.

Replaces https://github.com/tursodatabase/libsql/pull/883.