### PR TITLE
reset replica when injector detects potential corruption

### DIFF
--- a/libsql-replication/src/frame.rs
+++ b/libsql-replication/src/frame.rs
@@ -104,6 +104,12 @@ impl From<FrameBorrowed> for FrameMut {
     }
 }
 
+impl From<Box<FrameBorrowed>> for FrameMut {
+    fn from(inner: Box<FrameBorrowed>) -> Self {
+        Self { inner }
+    }
+}
+
 impl Frame {
     pub fn from_parts(header: &FrameHeader, data: &[u8]) -> Self {
         FrameBorrowed::from_parts(header, data).into()
@@ -132,6 +138,10 @@ impl FrameBorrowed {
     /// returns this frame's page data.
     pub fn page(&self) -> &[u8] {
         &self.page
+    }
+
+    pub fn page_mut(&mut self) -> &mut [u8] {
+        &mut self.page
     }
 
     pub fn header(&self) -> &FrameHeader {

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -77,7 +77,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 http-body = "0.4"
 url = { version = "2.3", features = ["serde"] }
 uuid = { version = "1.3", features = ["v4", "serde"] }
-zerocopy = { version = "0.7.28", features = ["derive"] }
+zerocopy = { version = "0.7.28", features = ["derive", "alloc"] }
 
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive_arbitrary"] }

--- a/libsql-server/tests/cluster/replication.rs
+++ b/libsql-server/tests/cluster/replication.rs
@@ -1,5 +1,5 @@
-use std::time::Duration;
 use std::sync::Arc;
+use std::time::Duration;
 
 use insta::assert_debug_snapshot;
 use libsql::Database;

--- a/libsql-server/tests/cluster/replication.rs
+++ b/libsql-server/tests/cluster/replication.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use std::time::Duration;
+use std::sync::Arc;
 
 use insta::assert_debug_snapshot;
 use libsql::Database;
@@ -14,7 +14,7 @@ use crate::common::{
 /// In this test, we first create a primary with a very small max_log_size, and then add a good
 /// amount of data to it. This will cause the primary to create a bunch of snaphots a large enough
 /// to prevent the replica from applying them all at once. We then start the replica, and check
-/// that it replicates correctly to the primary's replicaton index.
+/// that it replicates correctly to the primary's replicaton index. #[test]
 #[test]
 fn apply_partial_snapshot() {
     let mut sim = turmoil::Builder::new()


### PR DESCRIPTION
When we detect an error from the injector, we threat it a potential corruption, and reset the replica.
