### PR TITLE
SQLite3MultipleCiphers: enable session extension by default

### DIFF
--- a/libsql-ffi/bundled/SQLite3MultipleCiphers/CMakeLists.txt
+++ b/libsql-ffi/bundled/SQLite3MultipleCiphers/CMakeLists.txt
@@ -33,8 +33,8 @@ OPTION(SQLITE_ENABLE_RTREE "Enable extension 'rtree'" ON)
 OPTION(SQLITE_ENABLE_UUID "Enable extension 'uuid'" ON)
 OPTION(SQLITE_USE_URI "Enable the URI filename process logic" ON)
 OPTION(SQLITE_USER_AUTHENTICATION "Enable extension 'user authentication'" ON)
-OPTION(SQLITE_ENABLE_PREUPDATE_HOOK "Enable preupdate hooks" OFF)
-OPTION(SQLITE_ENABLE_SESSION "Enable session extension" OFF)
+OPTION(SQLITE_ENABLE_PREUPDATE_HOOK "Enable preupdate hooks" ON)
+OPTION(SQLITE_ENABLE_SESSION "Enable session extension" ON)
 OPTION(SQLITE_SHELL_IS_UTF8 "Shell command line arguments in UTF-8 encoding" ON)
 
 # Options for library only


### PR DESCRIPTION
So that it's compiled in.

Checked with:
```
$ nm -a ../target/debug/sqld | grep sqlite3session
0000000002cb87a0 T sqlite3session_attach
0000000002d00750 T sqlite3session_changeset
0000000002c57d00 T sqlite3session_changeset_size
0000000002d00780 T sqlite3session_changeset_strm
0000000002c57e80 T sqlite3session_config
0000000002c72af0 T sqlite3session_create
0000000002ca6020 T sqlite3session_delete
0000000002cff090 T sqlite3session_diff
0000000002c57b00 T sqlite3session_enable
0000000002c57b70 T sqlite3session_indirect
0000000002c57be0 T sqlite3session_isempty
0000000002c57c60 T sqlite3session_memory_used
0000000002c57c70 T sqlite3session_object_config
0000000002d007e0 T sqlite3session_patchset
0000000002d007b0 T sqlite3session_patchset_strm
0000000002c57af0 T sqlite3session_table_filter
```

... which used to not print any symbols before the patch.