### PR TITLE
Update example.rs

### DIFF
--- a/libsql/examples/example.rs
+++ b/libsql/examples/example.rs
@@ -35,7 +35,7 @@ async fn main() {
 
     let mut rows = stmt.query(["foo@example.com"]).await.unwrap();
 
-    let row = rows.next().await.unwrap().unwrap();
+    let row = rows.next().unwrap().unwrap();
 
     let value = row.get_value(0).unwrap();
 


### PR DESCRIPTION
Remove await due to this error:
```rs
Diagnostics:
1. `Result<Option<Row>, libsql::Error>` is not a future
   the trait `Future` is not implemented for `Result<Option<Row>, libsql::Error>`
   Result<Option<Row>, libsql::Error> must be a future or must implement `IntoFuture` to be awaited
   required for `Result<Option<Row>, libsql::Error>` to implement `IntoFuture` [E0277]
2. remove the `.await` [E0277]
```