### PR TITLE
limit the number of retries of the busy handler

### DIFF
--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -649,8 +649,9 @@ impl<W: Wal> Connection<W> {
         {
             let mut lock = this.lock();
             let is_autocommit = lock.conn.is_autocommit();
+            let current_fno = *lock.current_frame_no_receiver.borrow_and_update();
             builder.finish(
-                *(lock.current_frame_no_receiver.borrow_and_update()),
+                current_fno,
                 is_autocommit,
             )?;
         }


### PR DESCRIPTION
This PR fixes a series of bugs that caused hangs on the platform.

- Replace `is_stolen` `AtomicBool` by a `Mutex<bool>`. I'm not sure this one was necessary, but I was desperate.
- Always update the state for a connection, even in case of error during execution.
- An instance of `borrow_and_update` in a channel was borrowing too long, causing a dead_lock. This was caused by some obscure rules about temporaries, causing the reference to be dropped after the call, even though it was being dereferenced. This is best exemplified by https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=3c7bf7fbc2471c9bce121c781ebc982b, and elements of explanation can be found here: https://blog.m-ou.se/super-let/
