### PR TITLE
libsql client: don't reset last_insert_rowid

### DIFF
--- a/libsql-server/tests/hrana/batch.rs
+++ b/libsql-server/tests/hrana/batch.rs
@@ -117,3 +117,37 @@ fn multistatement_query() {
 
     sim.run().unwrap();
 }
+
+#[test]
+fn affected_rows_and_last_rowid() {
+    let mut sim = turmoil::Builder::new().build();
+    sim.host("primary", super::make_standalone_server);
+    sim.client("client", async {
+        let db = Database::open_remote_with_connector("http://primary:8080", "", TurmoilConnector)?;
+        let conn = db.connect()?;
+
+        conn.execute(
+            "create table t(id integer primary key autoincrement, x text);",
+            (),
+        )
+        .await?;
+
+        let r = conn.execute("insert into t(x) values('a');", ()).await?;
+        assert_eq!(r, 1, "1st row inserted");
+        assert_eq!(conn.last_insert_rowid(), 1, "1st row id");
+
+        let r = conn
+            .execute("insert into t(x) values('b'),('c');", ())
+            .await?;
+        assert_eq!(r, 2, "2nd and 3rd rows inserted");
+        assert_eq!(conn.last_insert_rowid(), 3, "3rd row id");
+
+        let r = conn.execute("update t set x = 'd';", ()).await?;
+        assert_eq!(r, 3, "all three rows updated");
+        assert_eq!(conn.last_insert_rowid(), 3, "last row id unchanged");
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}

--- a/libsql/src/hrana/stream.rs
+++ b/libsql/src/hrana/stream.rs
@@ -158,9 +158,11 @@ where
                     self.inner
                         .affected_row_count
                         .store(result.affected_row_count, Ordering::SeqCst);
-                    self.inner
-                        .last_insert_rowid
-                        .store(result.last_insert_rowid.unwrap_or(0), Ordering::SeqCst);
+                    if let Some(last_insert_rowid) = result.last_insert_rowid {
+                        self.inner
+                            .last_insert_rowid
+                            .store(last_insert_rowid, Ordering::SeqCst);
+                    }
                 }
                 Ok(resp.result)
             }


### PR DESCRIPTION
This PR fixes the Hrana client issue when we were resetting last_insert_rowid in situations when sqld didn't return it. The correct behaviour (using SQLite local connection as reference) is to leave the last_insert_rowid unchanged. This PR fixes that and includes some tests to verify.