### PR TITLE
scripted replication

### DIFF
--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -521,7 +521,6 @@ where
             max_response_size: self.db_config.max_response_size,
             max_total_response_size: self.db_config.max_total_response_size,
             checkpoint_interval: self.db_config.checkpoint_interval,
-            disable_namespace: self.disable_namespaces,
             encryption_key: self.db_config.encryption_key.clone(),
             max_concurrent_connections: Arc::new(Semaphore::new(self.max_concurrent_connections)),
             scripted_backup,

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -3,7 +3,6 @@
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::process::Command;
 use std::str::FromStr;
 use std::sync::{Arc, Weak};
 
@@ -34,7 +33,6 @@ use namespace::{
 };
 use net::Connector;
 use once_cell::sync::Lazy;
-use replication::NamespacedSnapshotCallback;
 use tokio::runtime::Runtime;
 use tokio::sync::{mpsc, Notify, Semaphore};
 use tokio::task::JoinSet;
@@ -44,6 +42,7 @@ use utils::services::idle_shutdown::IdleShutdownKicker;
 
 use self::config::MetaStoreConfig;
 use self::net::AddrIncoming;
+use self::replication::script_backup_manager::{ScriptBackupManager, CommandHandler};
 
 pub mod config;
 pub mod connection;
@@ -305,23 +304,6 @@ where
         }
     }
 
-    pub fn make_snapshot_callback(&self) -> NamespacedSnapshotCallback {
-        let snapshot_exec = self.db_config.snapshot_exec.clone();
-        Arc::new(move |snapshot_file: &Path, namespace: &NamespaceName| {
-            if let Some(exec) = snapshot_exec.as_ref() {
-                let status = Command::new(exec)
-                    .arg(snapshot_file)
-                    .arg(namespace.as_str())
-                    .status()?;
-                anyhow::ensure!(
-                    status.success(),
-                    "Snapshot exec process failed with status {status}"
-                );
-            }
-            Ok(())
-        })
-    }
-
     fn spawn_monitoring_tasks(
         &self,
         join_set: &mut JoinSet<anyhow::Result<()>>,
@@ -375,7 +357,6 @@ where
         let db_is_dirty = init_sentinel_file(&self.path)?;
         let idle_shutdown_kicker = self.setup_shutdown();
 
-        let snapshot_callback = self.make_snapshot_callback();
         let auth = self.user_api_config.get_auth().map(Arc::new)?;
         let extensions = self.db_config.validate_extensions()?;
         let namespace_store_shutdown_fut: Pin<Box<dyn Future<Output = Result<()>> + Send>>;
@@ -429,7 +410,6 @@ where
                     idle_shutdown_kicker: idle_shutdown_kicker.clone(),
                     stats_sender,
                     db_is_dirty,
-                    snapshot_callback,
                     extensions,
                     base_path: self.path.clone(),
                     disable_namespaces: self.disable_namespaces,
@@ -439,6 +419,7 @@ where
                     meta_store_config: self.meta_store_config.take(),
                     max_concurrent_connections: self.max_concurrent_connections,
                 };
+
                 let (namespaces, proxy_service, replication_service) = primary.configure().await?;
                 self.rpc_server_config = None;
                 self.spawn_monitoring_tasks(&mut join_set, stats_receiver, namespaces.clone())?;
@@ -498,7 +479,6 @@ struct Primary<'a, A> {
     idle_shutdown_kicker: Option<IdleShutdownKicker>,
     stats_sender: StatsSender,
     db_is_dirty: bool,
-    snapshot_callback: NamespacedSnapshotCallback,
     extensions: Arc<[PathBuf]>,
     base_path: Arc<Path>,
     disable_namespaces: bool,
@@ -520,12 +500,22 @@ where
         ProxyService,
         ReplicationLogService,
     )> {
+
+        let scripted_backup = match self.db_config.snapshot_exec {
+            Some(command) => {
+                let (scripted_backup, script_backup_task) = ScriptBackupManager::new(&self.base_path, CommandHandler::new(command)).await?;
+                self.join_set.spawn(script_backup_task.run());
+                Some(scripted_backup)
+            }
+            None => None,
+        };
+
+
         let conf = PrimaryNamespaceConfig {
             base_path: self.base_path.clone(),
             max_log_size: self.db_config.max_log_size,
             db_is_dirty: self.db_is_dirty,
             max_log_duration: self.db_config.max_log_duration.map(Duration::from_secs_f32),
-            snapshot_callback: self.snapshot_callback,
             bottomless_replication: self.db_config.bottomless_replication.clone(),
             extensions: self.extensions,
             stats_sender: self.stats_sender.clone(),
@@ -535,6 +525,7 @@ where
             disable_namespace: self.disable_namespaces,
             encryption_key: self.db_config.encryption_key.clone(),
             max_concurrent_connections: Arc::new(Semaphore::new(self.max_concurrent_connections)),
+            scripted_backup,
         };
 
         let factory = PrimaryNamespaceMaker::new(conf);

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -42,7 +42,7 @@ use utils::services::idle_shutdown::IdleShutdownKicker;
 
 use self::config::MetaStoreConfig;
 use self::net::AddrIncoming;
-use self::replication::script_backup_manager::{ScriptBackupManager, CommandHandler};
+use self::replication::script_backup_manager::{CommandHandler, ScriptBackupManager};
 
 pub mod config;
 pub mod connection;
@@ -500,16 +500,15 @@ where
         ProxyService,
         ReplicationLogService,
     )> {
-
         let scripted_backup = match self.db_config.snapshot_exec {
             Some(command) => {
-                let (scripted_backup, script_backup_task) = ScriptBackupManager::new(&self.base_path, CommandHandler::new(command)).await?;
+                let (scripted_backup, script_backup_task) =
+                    ScriptBackupManager::new(&self.base_path, CommandHandler::new(command)).await?;
                 self.join_set.spawn(script_backup_task.run());
                 Some(scripted_backup)
             }
             None => None,
         };
-
 
         let conf = PrimaryNamespaceConfig {
             base_path: self.base_path.clone(),

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -997,7 +997,6 @@ pub struct PrimaryNamespaceConfig {
     pub(crate) max_response_size: u64,
     pub(crate) max_total_response_size: u64,
     pub(crate) checkpoint_interval: Option<Duration>,
-    pub(crate) disable_namespace: bool,
     pub(crate) encryption_key: Option<bytes::Bytes>,
     pub(crate) max_concurrent_connections: Arc<Semaphore>,
     pub(crate) scripted_backup: Option<ScriptBackupManager>,

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -42,7 +42,8 @@ use crate::connection::MakeConnection;
 use crate::database::{Database, PrimaryDatabase, ReplicaDatabase};
 use crate::error::{Error, LoadDumpError};
 use crate::metrics::NAMESPACE_LOAD_LATENCY;
-use crate::replication::{FrameNo, NamespacedSnapshotCallback, ReplicationLogger};
+use crate::replication::script_backup_manager::ScriptBackupManager;
+use crate::replication::{FrameNo, ReplicationLogger};
 use crate::stats::Stats;
 use crate::{
     run_periodic_checkpoint, StatsSender, BLOCKING_RT, DB_CREATE_TIMEOUT, DEFAULT_AUTO_CHECKPOINT,
@@ -75,6 +76,12 @@ impl Default for NamespaceName {
 impl AsRef<str> for NamespaceName {
     fn as_ref(&self) -> &str {
         self.as_str()
+    }
+}
+
+impl From<&'static str> for NamespaceName {
+    fn from(value: &'static str) -> Self {
+        Self::from_bytes(Bytes::from_static(value.as_bytes())).unwrap()
     }
 }
 
@@ -980,20 +987,20 @@ impl Namespace<ReplicaDatabase> {
 }
 
 pub struct PrimaryNamespaceConfig {
-    pub base_path: Arc<Path>,
-    pub max_log_size: u64,
-    pub db_is_dirty: bool,
-    pub max_log_duration: Option<Duration>,
-    pub snapshot_callback: NamespacedSnapshotCallback,
-    pub bottomless_replication: Option<bottomless::replicator::Options>,
-    pub extensions: Arc<[PathBuf]>,
-    pub stats_sender: StatsSender,
-    pub max_response_size: u64,
-    pub max_total_response_size: u64,
-    pub checkpoint_interval: Option<Duration>,
-    pub disable_namespace: bool,
-    pub encryption_key: Option<bytes::Bytes>,
-    pub max_concurrent_connections: Arc<Semaphore>,
+    pub(crate) base_path: Arc<Path>,
+    pub(crate) max_log_size: u64,
+    pub(crate) db_is_dirty: bool,
+    pub(crate) max_log_duration: Option<Duration>,
+    pub(crate) bottomless_replication: Option<bottomless::replicator::Options>,
+    pub(crate) extensions: Arc<[PathBuf]>,
+    pub(crate) stats_sender: StatsSender,
+    pub(crate) max_response_size: u64,
+    pub(crate) max_total_response_size: u64,
+    pub(crate) checkpoint_interval: Option<Duration>,
+    pub(crate) disable_namespace: bool,
+    pub(crate) encryption_key: Option<bytes::Bytes>,
+    pub(crate) max_concurrent_connections: Arc<Semaphore>,
+    pub(crate) scripted_backup: Option<ScriptBackupManager>,
 }
 
 pub type DumpStream =
@@ -1110,11 +1117,8 @@ impl Namespace<PrimaryDatabase> {
             config.max_log_duration,
             is_dirty,
             auto_checkpoint,
-            Box::new({
-                let name = name.clone();
-                let cb = config.snapshot_callback.clone();
-                move |path: &Path| cb(path, &name)
-            }),
+            config.scripted_backup.clone(),
+            name.clone(),
         )?);
 
         let stats = make_stats(

--- a/libsql-server/src/replication/mod.rs
+++ b/libsql-server/src/replication/mod.rs
@@ -2,6 +2,7 @@ pub mod primary;
 pub mod replicator_client;
 mod snapshot;
 pub mod snapshot_store;
+mod script_backup_manager;
 
 use crc::Crc;
 pub use primary::logger::{LogReadError, ReplicationLogger};

--- a/libsql-server/src/replication/mod.rs
+++ b/libsql-server/src/replication/mod.rs
@@ -2,11 +2,10 @@ pub mod primary;
 pub mod replicator_client;
 mod snapshot;
 pub mod snapshot_store;
-mod script_backup_manager;
+pub mod script_backup_manager;
 
 use crc::Crc;
 pub use primary::logger::{LogReadError, ReplicationLogger};
-pub use snapshot::{NamespacedSnapshotCallback, SnapshotCallback};
 
 pub const WAL_MAGIC: u64 = u64::from_le_bytes(*b"SQLDWAL\0");
 const CRC_64_GO_ISO: Crc<u64> = Crc::<u64>::new(&crc::CRC_64_GO_ISO);

--- a/libsql-server/src/replication/mod.rs
+++ b/libsql-server/src/replication/mod.rs
@@ -1,8 +1,8 @@
 pub mod primary;
 pub mod replicator_client;
+pub mod script_backup_manager;
 mod snapshot;
 pub mod snapshot_store;
-pub mod script_backup_manager;
 
 use crc::Crc;
 pub use primary::logger::{LogReadError, ReplicationLogger};

--- a/libsql-server/src/replication/primary/logger.rs
+++ b/libsql-server/src/replication/primary/logger.rs
@@ -543,9 +543,21 @@ impl ReplicationLogger {
         };
 
         if should_recover {
-            Self::recover(log_file, data_path, auto_checkpoint, scripted_backup, namespace)
+            Self::recover(
+                log_file,
+                data_path,
+                auto_checkpoint,
+                scripted_backup,
+                namespace,
+            )
         } else {
-            Self::from_log_file(db_path.to_path_buf(), log_file, auto_checkpoint, scripted_backup, namespace)
+            Self::from_log_file(
+                db_path.to_path_buf(),
+                log_file,
+                auto_checkpoint,
+                scripted_backup,
+                namespace,
+            )
         }
     }
 
@@ -641,7 +653,13 @@ impl ReplicationLogger {
 
         assert!(data_path.pop());
 
-        Self::from_log_file(data_path, log_file, auto_checkpoint, scripted_backup, namespace)
+        Self::from_log_file(
+            data_path,
+            log_file,
+            auto_checkpoint,
+            scripted_backup,
+            namespace,
+        )
     }
 
     pub fn log_id(&self) -> Uuid {

--- a/libsql-server/src/replication/primary/replication_logger_wal.rs
+++ b/libsql-server/src/replication/primary/replication_logger_wal.rs
@@ -394,7 +394,7 @@ mod test {
                 false,
                 100000,
                 None,
-                "test".into()
+                "test".into(),
             )
             .unwrap(),
         );
@@ -446,7 +446,7 @@ mod test {
                 false,
                 100000,
                 None,
-                "test".into()
+                "test".into(),
             )
             .unwrap(),
         );

--- a/libsql-server/src/replication/primary/replication_logger_wal.rs
+++ b/libsql-server/src/replication/primary/replication_logger_wal.rs
@@ -393,7 +393,8 @@ mod test {
                 None,
                 false,
                 100000,
-                Box::new(|_| Ok(())),
+                None,
+                "test".into()
             )
             .unwrap(),
         );
@@ -444,7 +445,8 @@ mod test {
                 None,
                 false,
                 100000,
-                Box::new(|_| Ok(())),
+                None,
+                "test".into()
             )
             .unwrap(),
         );

--- a/libsql-server/src/replication/script_backup_manager.rs
+++ b/libsql-server/src/replication/script_backup_manager.rs
@@ -381,7 +381,10 @@ mod test {
         impl Handler for FailHandler {
             async fn handle(&mut self, entry: &SnapshotEntry) -> Result<()> {
                 self.last_entry = Some(entry.clone());
-                Err(Error::HandlerFailure)
+                Err(Error::HandlerFailure {
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
             }
         }
 
@@ -460,7 +463,10 @@ mod test {
         impl Handler for FailHandler {
             async fn handle(&mut self, entry: &SnapshotEntry) -> Result<()> {
                 tokio::fs::remove_file(&entry.path).await.unwrap();
-                Err(Error::HandlerFailure)
+                Err(Error::HandlerFailure {
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
             }
         }
 

--- a/libsql-server/src/replication/script_backup_manager.rs
+++ b/libsql-server/src/replication/script_backup_manager.rs
@@ -78,6 +78,7 @@ impl Ord for SnapshotEntry {
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct ScriptBackupManager {
     path: PathBuf,
     queue: Arc<Mutex<BinaryHeap<SnapshotEntry>>>,

--- a/libsql-server/src/replication/script_backup_manager.rs
+++ b/libsql-server/src/replication/script_backup_manager.rs
@@ -1,0 +1,429 @@
+use std::cmp::Ordering;
+use std::sync::Arc;
+use std::path::{Path, PathBuf};
+use std::collections::BinaryHeap;
+
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use regex::Regex;
+use tokio::sync::Notify;
+use tokio::time::Duration;
+
+use crate::namespace::NamespaceName;
+
+use super::FrameNo;
+
+const MAX_RETRIES_THRESHOLD: u32 = 64;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Snaphot handler failure")]
+    HandlerFailure,
+    #[error("Could not parse snapshot path: {0}")]
+    InvalidSnapshotPath(PathBuf),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SnapshotEntry {
+    namespace: NamespaceName,
+    start_frame_no: FrameNo,
+    end_frame_no: FrameNo,
+    path: PathBuf,
+    retries: u32,
+}
+
+pub(crate) trait Handler {
+    async fn handle(&mut self, entry: &SnapshotEntry) -> Result<()>;
+}
+
+impl PartialEq for SnapshotEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.namespace == other.namespace
+            && self.start_frame_no == other.start_frame_no
+            && self.end_frame_no == other.end_frame_no
+    }
+}
+
+impl Eq for SnapshotEntry {}
+
+impl PartialOrd for SnapshotEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SnapshotEntry {
+    // the ordering are reversed because we use a max queue, so entry a ordered by priority
+    fn cmp(&self, other: &Self) -> Ordering {
+        // it doesn't matter the order in which we process snapshots for different namespaces
+        if self.namespace != other.namespace {
+            Ordering::Equal
+        } else {
+            match self.start_frame_no.cmp(&other.start_frame_no) {
+                Ordering::Equal => {
+                    // if the two snapshot have the same start frame_no, then we process first
+                    // whichever has the greated end frame no. That way the script can decide to
+                    // drop the following
+                    self.end_frame_no.cmp(&other.end_frame_no)
+                },
+                // we process first a snapshot that has a lower start_frame_no
+                Ordering::Less => Ordering::Greater,
+                Ordering::Greater => Ordering::Less,
+            }
+        }
+    }
+}
+
+pub(crate) struct ScriptBackupManager {
+    path: PathBuf,
+    queue: Arc<Mutex<BinaryHeap<SnapshotEntry>>>,
+    notifier: Arc<Notify>,
+}
+
+pub(crate) struct ScriptBackupTask<H> {
+    queue: Arc<Mutex<BinaryHeap<SnapshotEntry>>>,
+    notifier: Arc<Notify>,
+    handler: H,
+}
+
+struct CommandHandler {
+    command: String,
+}
+
+impl Handler for CommandHandler {
+    async fn handle(&mut self, entry: &SnapshotEntry) -> Result<()> {
+        tokio::process::Command::new(&self.command)
+            .arg(&entry.path)
+            .arg(entry.namespace.as_str())
+            .arg(entry.start_frame_no.to_string())
+            .arg(entry.end_frame_no.to_string())
+            .status()
+            .await?;
+
+        Ok(())
+    }
+}
+
+impl<H: Handler> ScriptBackupTask<H> {
+    pub async fn run(&mut self) -> crate::Result<()> {
+        loop {
+            self.process_one().await?;
+        }
+    }
+
+    async fn process_one(&mut self) -> crate::Result<()> {
+        loop {
+            let entry = self.queue.lock().pop();
+            match entry {
+                Some(mut entry) => {
+                    match self.handler.handle(&entry).await {
+                        Ok(_) => {
+                            assert!(!entry.path.try_exists()?, "snapshot handler returned success, yet snapshot file is still present.");
+                        },
+                        Err(e) => {
+                            tracing::error!("failed to process scripted snapshot backup for {entry:?}: {e}");
+                            assert!(entry.path.try_exists()?, "snapshot file was removed, but script returned an error. Can't ensure consistency");
+                            // exponential backoff
+                            tokio::time::sleep(Duration::from_millis(500) * 2u32.pow(entry.retries)).await;
+
+                            entry.retries += 1;
+                            if entry.retries > MAX_RETRIES_THRESHOLD {
+                                todo!("failure to make any progress, what do we do?");
+                            }
+                            self.queue.lock().push(entry);
+                        }
+                    }
+
+                    return Ok(());
+                }
+                None => {
+                    self.notifier.notified().await;
+                },
+            }
+        }
+    }
+}
+
+fn make_snapshot_path(
+    base_path: impl AsRef<Path>,
+    namespace: &NamespaceName,
+    start_frame_no: FrameNo,
+    end_frame_no: FrameNo,
+) -> PathBuf {
+    base_path.as_ref().join(format!(
+        "{namespace}:{start_frame_no:020x}-{end_frame_no:020x}.snap"
+    ))
+}
+
+fn parse_snapshot_path(path: PathBuf) -> Result<SnapshotEntry> {
+    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"([\w-]+?):([0-9a-f]{20})-([0-9a-f]{20}).snap"#).unwrap());
+
+    let name = path.file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| Error::InvalidSnapshotPath(path.clone()))?;
+
+    let captures = RE.captures(name).ok_or_else(|| Error::InvalidSnapshotPath(path.clone()))?;
+    let namespace = NamespaceName::from_string(captures[1].to_string()).unwrap();
+    let start_frame_no = FrameNo::from_str_radix(&captures[2], 16).unwrap();
+    let end_frame_no = FrameNo::from_str_radix(&captures[3], 16).unwrap();
+
+    Ok(SnapshotEntry { namespace, start_frame_no, end_frame_no, path, retries: 0 })
+}
+
+async fn seed_queue(queue_dir: &Path) -> Result<BinaryHeap<SnapshotEntry>> {
+    let mut dir = tokio::fs::read_dir(queue_dir).await?;
+    let mut queue = BinaryHeap::new();
+    while let Some(entry) = dir.next_entry().await? {
+        let entry = parse_snapshot_path(entry.path())?;
+        queue.push(entry);
+    }
+
+    Ok(queue)
+}
+
+impl ScriptBackupManager {
+    pub async fn new<H: Handler>(base_path: &Path, handler: H) -> Result<(Self, ScriptBackupTask<H>)> {
+        let script_backup_path = base_path.join("script_backup");
+
+        tokio::fs::create_dir_all(&script_backup_path).await?;
+        
+        let notifier = Arc::new(Notify::new());
+        // on startup we recover missing snapshots
+        let queue = Arc::new(Mutex::new(seed_queue(&script_backup_path).await?));
+        let task = ScriptBackupTask {
+            queue: queue.clone(),
+            notifier: notifier.clone(),
+            handler,
+        };
+        let this = Self {
+            path: script_backup_path,
+            queue,
+            notifier,
+        };
+
+        Ok((this, task))
+    }
+
+    pub async fn register(
+        &self,
+        namespace: NamespaceName,
+        start_frame_no: FrameNo,
+        end_frame_no: FrameNo,
+        src_path: &Path,
+    ) -> crate::Result<()> {
+        let dst_path = make_snapshot_path(&self.path, &namespace, start_frame_no, end_frame_no);
+        tokio::fs::hard_link(src_path, &dst_path).await?;
+        let entry = SnapshotEntry {
+            namespace,
+            start_frame_no,
+            end_frame_no,
+            path: dst_path,
+            retries: 0,
+        };
+        self.queue.lock().push(entry);
+        self.notifier.notify_waiters();
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use proptest::prelude::*;
+    use tempfile::tempdir;
+    use uuid::Uuid;
+
+    proptest! {
+        #[test]
+        fn parse_rountrip_snapshot_path(
+            snapshot_name in r#"[\w-]+"#,
+            start_frame_no in 0u64..u64::MAX,
+            end_frame_no in 0u64..u64::MAX,
+            ){
+            let namespace = NamespaceName::from_string(snapshot_name.to_string()).unwrap();
+            let path = make_snapshot_path("/test", &namespace, start_frame_no, end_frame_no);
+            let entry = parse_snapshot_path(path.clone()).unwrap();
+            assert_eq!(entry.end_frame_no, end_frame_no);
+            assert_eq!(entry.start_frame_no, start_frame_no);
+            assert_eq!(entry.namespace, namespace);
+            assert_eq!(entry.path, path);
+        }
+    }
+
+    fn dummy_entry(name: &str, start: FrameNo, end: FrameNo) -> SnapshotEntry {
+        SnapshotEntry {
+            namespace: NamespaceName::from_string(name.to_string()).unwrap(),
+            start_frame_no: start,
+            end_frame_no: end,
+            path: PathBuf::new(),
+            retries: 0,
+        }
+    }
+
+    #[test]
+    fn compare_entries() {
+        // different namespace name can be processed in any order
+        assert!(dummy_entry("test2", 1, 50).cmp(&dummy_entry("test1", 30, 50)).is_eq());
+        // the relation is reflexive
+        assert!(dummy_entry("test1", 1, 50).cmp(&dummy_entry("test2", 30, 50)).is_eq());
+
+        // snapshot with lower frameno has priority
+        assert!(dummy_entry("test1", 1, 50).cmp(&dummy_entry("test1", 30, 50)).is_gt());
+        assert!(dummy_entry("test1", 30, 50).cmp(&dummy_entry("test1", 1, 50)).is_lt());
+
+        // same start point, the largest has a higher priority
+        assert!(dummy_entry("test1", 1, 50).cmp(&dummy_entry("test1", 1, 100)).is_lt());
+        assert!(dummy_entry("test1", 1, 100).cmp(&dummy_entry("test1", 1, 50)).is_gt());
+    }
+
+    #[test]
+    fn queue() {
+        let mut queue = BinaryHeap::new();
+        queue.push(dummy_entry("test1", 1, 12));
+        queue.push(dummy_entry("test1", 29, 31));
+        queue.push(dummy_entry("test1", 1, 52));
+
+        assert!(matches!(queue.pop().unwrap(), SnapshotEntry {start_frame_no: 1, end_frame_no: 52, .. }));
+        assert!(matches!(queue.pop().unwrap(), SnapshotEntry {start_frame_no: 1, end_frame_no: 12, .. }));
+        assert!(matches!(queue.pop().unwrap(), SnapshotEntry {start_frame_no: 29, end_frame_no: 31, .. }));
+        assert!(queue.pop().is_none());
+    }
+
+    async fn dummy_entry_in(path: &Path, name: &str, start: FrameNo, end: FrameNo) -> SnapshotEntry {
+        let dummy_path = path.join(Uuid::new_v4().to_string());
+        tokio::fs::File::create(&dummy_path).await.unwrap();
+        let mut entry = dummy_entry(name, start, end);
+        entry.path = dummy_path;
+        entry
+    }
+
+    #[tokio::test]
+    async fn retry_failed_entry() {
+
+        #[derive(Default)]
+        struct FailHandler {
+            last_entry: Option<SnapshotEntry>
+        }
+
+        impl Handler for FailHandler {
+            async fn handle(&mut self, entry: &SnapshotEntry) -> Result<()> {
+                self.last_entry = Some(entry.clone());
+                Err(Error::HandlerFailure)
+            }
+        }
+
+        let tmp = tempdir().unwrap();
+        let (manager, mut task) = ScriptBackupManager::new(tmp.path(), FailHandler::default()).await.unwrap();
+        
+        let entry = dummy_entry_in(tmp.path(), "test1", 1, 10).await;
+        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+
+        let entry = dummy_entry_in(tmp.path(), "test1", 11, 21).await;
+        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+
+        task.process_one().await.unwrap();
+        assert_eq!(task.handler.last_entry.as_ref().unwrap().start_frame_no(), 1);
+        assert_eq!(task.handler.last_entry.as_ref().unwrap().retries, 0);
+        assert_eq!(task.queue.lock().len(), 2);
+
+        // next step, we retry
+        task.process_one().await.unwrap();
+        assert_eq!(task.handler.last_entry.as_ref().unwrap().start_frame_no(), 1);
+        assert_eq!(task.handler.last_entry.as_ref().unwrap().retries, 1);
+        assert_eq!(task.queue.lock().len(), 2);
+    }
+
+    #[should_panic]
+    #[tokio::test]
+    async fn panic_if_snapshot_no_removed_on_success() {
+        struct OkHandler;
+        impl Handler for OkHandler {
+            async fn handle(&mut self, _entry: &SnapshotEntry) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        let tmp = tempdir().unwrap();
+        let (manager, mut task) = ScriptBackupManager::new(tmp.path(), OkHandler).await.unwrap();
+        
+        let entry = dummy_entry_in(tmp.path(), "test1", 1, 10).await;
+        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+
+        task.process_one().await.unwrap();
+    }
+
+    #[should_panic]
+    #[tokio::test]
+    async fn panic_if_snapshot_is_removed_on_failure() {
+        struct FailHandler;
+        impl Handler for FailHandler {
+            async fn handle(&mut self, entry: &SnapshotEntry) -> Result<()> {
+                tokio::fs::remove_file(entry.path()).await.unwrap();
+                Err(Error::HandlerFailure)
+            }
+        }
+
+        let tmp = tempdir().unwrap();
+        let (manager, mut task) = ScriptBackupManager::new(tmp.path(), FailHandler).await.unwrap();
+        
+        let entry = dummy_entry_in(tmp.path(), "test1", 1, 10).await;
+        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+
+        task.process_one().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn normal_operation() {
+        struct OkHandler;
+        impl Handler for OkHandler {
+            async fn handle(&mut self, entry: &SnapshotEntry) -> Result<()> {
+                tokio::fs::remove_file(entry.path()).await.unwrap();
+                Ok(())
+            }
+        }
+
+        let tmp = tempdir().unwrap();
+        let (manager, mut task) = ScriptBackupManager::new(tmp.path(), OkHandler).await.unwrap();
+        
+        let entry = dummy_entry_in(tmp.path(), "test1", 1, 10).await;
+        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+
+        let entry = dummy_entry_in(tmp.path(), "test1", 11, 50).await;
+        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+
+        task.process_one().await.unwrap();
+        assert_eq!(task.queue.lock().len(), 1);
+        task.process_one().await.unwrap();
+        assert_eq!(task.queue.lock().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn new_snapshot_notified() {
+        let tmp = tempdir().unwrap();
+        struct OkHandler;
+        impl Handler for OkHandler {
+            async fn handle(&mut self, entry: &SnapshotEntry) -> Result<()> {
+                tokio::fs::remove_file(entry.path()).await.unwrap();
+                Ok(())
+            }
+        }
+
+        let (manager, mut task) = ScriptBackupManager::new(tmp.path(), OkHandler).await.unwrap();
+        
+        let step_fut = task.process_one();
+        tokio::pin!(step_fut);
+
+        // nothing to do, waiting
+        assert!(tokio::time::timeout(Duration::from_millis(50), &mut step_fut).await.is_err());
+
+        let entry = dummy_entry_in(tmp.path(), "test1", 1, 10).await;
+        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+
+        assert!(step_fut.await.is_ok());
+    }
+}

--- a/libsql-server/src/replication/script_backup_manager.rs
+++ b/libsql-server/src/replication/script_backup_manager.rs
@@ -321,19 +321,19 @@ mod test {
         let (manager, mut task) = ScriptBackupManager::new(tmp.path(), FailHandler::default()).await.unwrap();
         
         let entry = dummy_entry_in(tmp.path(), "test1", 1, 10).await;
-        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+        manager.register(entry.namespace.clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
 
         let entry = dummy_entry_in(tmp.path(), "test1", 11, 21).await;
-        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+        manager.register(entry.namespace.clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
 
         task.process_one().await.unwrap();
-        assert_eq!(task.handler.last_entry.as_ref().unwrap().start_frame_no(), 1);
+        assert_eq!(task.handler.last_entry.as_ref().unwrap().start_frame_no, 1);
         assert_eq!(task.handler.last_entry.as_ref().unwrap().retries, 0);
         assert_eq!(task.queue.lock().len(), 2);
 
         // next step, we retry
         task.process_one().await.unwrap();
-        assert_eq!(task.handler.last_entry.as_ref().unwrap().start_frame_no(), 1);
+        assert_eq!(task.handler.last_entry.as_ref().unwrap().start_frame_no, 1);
         assert_eq!(task.handler.last_entry.as_ref().unwrap().retries, 1);
         assert_eq!(task.queue.lock().len(), 2);
     }
@@ -352,7 +352,7 @@ mod test {
         let (manager, mut task) = ScriptBackupManager::new(tmp.path(), OkHandler).await.unwrap();
         
         let entry = dummy_entry_in(tmp.path(), "test1", 1, 10).await;
-        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+        manager.register(entry.namespace.clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
 
         task.process_one().await.unwrap();
     }
@@ -363,7 +363,7 @@ mod test {
         struct FailHandler;
         impl Handler for FailHandler {
             async fn handle(&mut self, entry: &SnapshotEntry) -> Result<()> {
-                tokio::fs::remove_file(entry.path()).await.unwrap();
+                tokio::fs::remove_file(&entry.path).await.unwrap();
                 Err(Error::HandlerFailure)
             }
         }
@@ -372,7 +372,7 @@ mod test {
         let (manager, mut task) = ScriptBackupManager::new(tmp.path(), FailHandler).await.unwrap();
         
         let entry = dummy_entry_in(tmp.path(), "test1", 1, 10).await;
-        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+        manager.register(entry.namespace.clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
 
         task.process_one().await.unwrap();
     }
@@ -382,7 +382,7 @@ mod test {
         struct OkHandler;
         impl Handler for OkHandler {
             async fn handle(&mut self, entry: &SnapshotEntry) -> Result<()> {
-                tokio::fs::remove_file(entry.path()).await.unwrap();
+                tokio::fs::remove_file(&entry.path).await.unwrap();
                 Ok(())
             }
         }
@@ -391,10 +391,10 @@ mod test {
         let (manager, mut task) = ScriptBackupManager::new(tmp.path(), OkHandler).await.unwrap();
         
         let entry = dummy_entry_in(tmp.path(), "test1", 1, 10).await;
-        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+        manager.register(entry.namespace.clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
 
         let entry = dummy_entry_in(tmp.path(), "test1", 11, 50).await;
-        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+        manager.register(entry.namespace.clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
 
         task.process_one().await.unwrap();
         assert_eq!(task.queue.lock().len(), 1);
@@ -408,7 +408,7 @@ mod test {
         struct OkHandler;
         impl Handler for OkHandler {
             async fn handle(&mut self, entry: &SnapshotEntry) -> Result<()> {
-                tokio::fs::remove_file(entry.path()).await.unwrap();
+                tokio::fs::remove_file(&entry.path).await.unwrap();
                 Ok(())
             }
         }
@@ -422,7 +422,7 @@ mod test {
         assert!(tokio::time::timeout(Duration::from_millis(50), &mut step_fut).await.is_err());
 
         let entry = dummy_entry_in(tmp.path(), "test1", 1, 10).await;
-        manager.register(entry.namespace().clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
+        manager.register(entry.namespace.clone(), entry.start_frame_no, entry.end_frame_no, &entry.path).await.unwrap();
 
         assert!(step_fut.await.is_ok());
     }

--- a/libsql-server/tests/standalone/mod.rs
+++ b/libsql-server/tests/standalone/mod.rs
@@ -5,13 +5,11 @@ use crate::common::{http::Client, snapshot_metrics};
 
 use super::common;
 
-use std::fs::Permissions;
-use std::os::unix::prelude::PermissionsExt;
 use std::{sync::Arc, time::Duration};
 
 use insta::assert_debug_snapshot;
 use libsql::{Database, Value};
-use tempfile::{tempdir, NamedTempFile};
+use tempfile::tempdir;
 use tokio::sync::Notify;
 
 use libsql_server::config::{AdminApiConfig, UserApiConfig};

--- a/libsql-server/tests/standalone/mod.rs
+++ b/libsql-server/tests/standalone/mod.rs
@@ -5,11 +5,13 @@ use crate::common::{http::Client, snapshot_metrics};
 
 use super::common;
 
+use std::fs::Permissions;
+use std::os::unix::prelude::PermissionsExt;
 use std::{sync::Arc, time::Duration};
 
 use insta::assert_debug_snapshot;
 use libsql::{Database, Value};
-use tempfile::tempdir;
+use tempfile::{tempdir, NamedTempFile};
 use tokio::sync::Notify;
 
 use libsql_server::config::{AdminApiConfig, UserApiConfig};

--- a/libsql/src/local/mod.rs
+++ b/libsql/src/local/mod.rs
@@ -11,9 +11,8 @@ pub mod transaction;
 pub(crate) mod impls;
 
 pub use libsql_sys::ffi;
-pub use libsql_sys::ValueType;
 
-pub use crate::{errors, Error, Result};
+pub use crate::{Error, Result};
 pub use connection::Connection;
 pub use database::Database;
 pub use rows::Row;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.73.0"
+channel = "1.75.0"


### PR DESCRIPTION
This is a revision of scripted backups. This code was left unused for a long time, and it started to rot a bit, so I refreshed it with some improvements.

- The script is called with 4 arguments:
    - The path where the snapshot can be found
    - The namespace for that snapshot
    - The starting replication index
    - The end replication index

- The path passed as an argument is a hard link to the snapshot file. It is expected that the script removes it after the snapshot was ingested. Sqld will check for the existence of the snapshot file, on success, if the file is still present, this is considered, it will panic. On error, if the snapshot file *is not present* sqld will also panic. On restart, the leftover snapshots will be passed again to the script. The script must, therefore, ensure idempotency.
- If the script file, with the assumption above, holds true, then sqld will re-enqueue the script for retry, with an exponential backoff.
- Snapshots for different namespaces are processed in an undefined order
- Snapshots for the same namespace are always processed in an order such that the first snapshot to be processed is that which has the lowest starting replication index. On ties, that which covers the most replication indexed is processed first, allowing the script to discard the smaller one if that's what they want to do.


## Testing:
I have tested this feature with the following script:
```bash
#!/bin/sh

SUCCESS=1

echo "$1 $2 $3 $4 $SUCCESS" >> log

if [ $SUCCESS == 1 ]
then
    rm $1
else
    exit 1
fi
```

start sqld with: `cargo r -- --snapshot-exec ./script.sh  --max-log-duration 5`
and while perform insertion with:
```
repeat 10000 echo '{"requests":[{"type": "execute", "stmt": {"sql": "insert into test values (12)"}}]}'| http post localhost:8080/v2/pipeline
```
flip the `SUCCESS` flag from 0 to 1 randomly to simulate failure.

here is a sample log:
```
data.sqld/script_backup/default:00000000000000000000-00000000000000000001.snap default 0 1 1
data.sqld/script_backup/default:00000000000000000002-00000000000000000002.snap default 2 2 1
data.sqld/script_backup/default:00000000000000000003-00000000000000000027.snap default 3 39 1
data.sqld/script_backup/default:00000000000000000000-00000000000000000027.snap default 0 39 1
data.sqld/script_backup/default:00000000000000000028-0000000000000000004c.snap default 40 76 1
data.sqld/script_backup/default:0000000000000000004d-00000000000000000071.snap default 77 113 0
data.sqld/script_backup/default:00000000000000000000-00000000000000000071.snap default 0 113 0
data.sqld/script_backup/default:00000000000000000000-00000000000000000071.snap default 0 113 0
data.sqld/script_backup/default:00000000000000000000-00000000000000000071.snap default 0 113 0
data.sqld/script_backup/default:00000000000000000000-00000000000000000071.snap default 0 113 0
data.sqld/script_backup/default:00000000000000000000-00000000000000000071.snap default 0 113 1
data.sqld/script_backup/default:0000000000000000004d-00000000000000000071.snap default 77 113 1
data.sqld/script_backup/default:00000000000000000072-00000000000000000095.snap default 114 149 1
data.sqld/script_backup/default:00000000000000000096-000000000000000000ba.snap default 150 186 1
data.sqld/script_backup/default:00000000000000000000-000000000000000000ba.snap default 0 186 1
data.sqld/script_backup/default:000000000000000000bb-000000000000000000de.snap default 187 222 1
data.sqld/script_backup/default:000000000000000000df-00000000000000000103.snap default 223 259 1
data.sqld/script_backup/default:00000000000000000000-00000000000000000103.snap default 0 259 1
data.sqld/script_backup/default:00000000000000000104-00000000000000000128.snap default 260 296 1
data.sqld/script_backup/default:00000000000000000129-0000000000000000014d.snap default 297 333 1
data.sqld/script_backup/default:00000000000000000000-0000000000000000014d.snap default 0 333 1
data.sqld/script_backup/default:0000000000000000014e-00000000000000000172.snap default 334 370 1
```

We can see that after failure, the snapshots are retried, as expected.

close #508 