### PR TITLE
query_analysis: allow defer_foreign_keys pragma on primary

### DIFF
--- a/libsql-server/src/query_analysis.rs
+++ b/libsql-server/src/query_analysis.rs
@@ -128,7 +128,7 @@ impl StmtKind {
             // that already created a database, which is always the case for sqld
             "encoding" => Some(Self::Read),
             // always ok to be served by primary
-            "foreign_keys" | "foreign_key_list" | "foreign_key_check" | "collation_list"
+            "defer_foreign_keys" | "foreign_keys" | "foreign_key_list" | "foreign_key_check" | "collation_list"
             | "data_version" | "freelist_count" | "integrity_check" | "legacy_file_format"
             | "page_count" | "quick_check" | "stats" | "user_version" => Some(Self::Write),
             // ok to be served by primary without args
@@ -141,7 +141,6 @@ impl StmtKind {
             | "cache_spill"
             | "cell_size_check"
             | "checkpoint_fullfsync"
-            | "defer_foreign_keys"
             | "fullfsync"
             | "hard_heap_limit"
             | "journal_mode"

--- a/libsql/src/parser.rs
+++ b/libsql/src/parser.rs
@@ -131,7 +131,7 @@ impl StmtKind {
             // that already created a database, which is always the case for sqld
             "encoding" => Some(Self::Read),
             // always ok to be served by primary
-            "foreign_keys" | "foreign_key_list" | "foreign_key_check" | "collation_list"
+            "defer_foreign_keys" | "foreign_keys" | "foreign_key_list" | "foreign_key_check" | "collation_list"
             | "data_version" | "freelist_count" | "integrity_check" | "legacy_file_format"
             | "page_count" | "quick_check" | "stats" | "user_version" => Some(Self::Write),
             // ok to be served by primary without args
@@ -144,7 +144,6 @@ impl StmtKind {
             | "cache_spill"
             | "cell_size_check"
             | "checkpoint_fullfsync"
-            | "defer_foreign_keys"
             | "fullfsync"
             | "hard_heap_limit"
             | "journal_mode"


### PR DESCRIPTION
This pragma is useful for turning off foreign keys as a oneshot operation within current transaction.

Example from turso shell:
```
→  create table t(id);
→  create table t2(id, v references t(id));
```
```
-- First insert to t2 fails, because t has no row with value (6)
→  pragma foreign_keys=on; begin; insert into t2 values(5,6); insert into t values (6); commit;
Error: SQLite error: FOREIGN KEY constraint failed
```
```
-- First insert doesn't fail, because checking foreign keys is deferred
-- until the transaction finishes
→  pragma foreign_keys=on; begin; pragma defer_foreign_keys=true; insert into t2 values(5,6); insert into t values (6); commit;
OK
```