### PR TITLE
libsql: add `Builder` to construct the db

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,6 +76,9 @@ jobs:
       - uses: taiki-e/install-action@cargo-udeps
       - uses: Swatinem/rust-cache@v2
       - run: cargo +nightly hack udeps -p libsql --each-feature
+      - run: RUSTFLAGS="-D warnings" cargo check -p libsql --no-default-features --features core 
+      - run: RUSTFLAGS="-D warnings" cargo check -p libsql --no-default-features --features replication 
+      - run: RUSTFLAGS="-D warnings" cargo check -p libsql --no-default-features --features remote
 
   test:
     runs-on: ubuntu-latest

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -9,6 +9,7 @@ pub struct Database {
 #[wasm_bindgen]
 impl Database {
     #[wasm_bindgen(constructor)]
+    #[allow(deprecated)]
     pub fn new() -> Database {
         Database {
             inner: libsql::Database::open(":memory:").unwrap(),

--- a/libsql-server/tests/cluster/mod.rs
+++ b/libsql-server/tests/cluster/mod.rs
@@ -1,4 +1,5 @@
 //! Tests for sqld in cluster mode
+#![allow(deprecated)]
 
 use super::common;
 

--- a/libsql-server/tests/common/net.rs
+++ b/libsql-server/tests/common/net.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::io::Error as IoError;
 use std::net::SocketAddr;
 use std::pin::Pin;

--- a/libsql-server/tests/embedded_replica/mod.rs
+++ b/libsql-server/tests/embedded_replica/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 mod local;
 
 use std::path::PathBuf;

--- a/libsql-server/tests/hrana/mod.rs
+++ b/libsql-server/tests/hrana/mod.rs
@@ -1,4 +1,5 @@
 //! Test hrana related functionalities
+#![allow(deprecated)]
 
 use libsql_server::config::UserApiConfig;
 use tempfile::tempdir;

--- a/libsql-server/tests/namespaces/mod.rs
+++ b/libsql-server/tests/namespaces/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 mod dumps;
 mod meta;
 

--- a/libsql-server/tests/standalone/mod.rs
+++ b/libsql-server/tests/standalone/mod.rs
@@ -1,4 +1,5 @@
 //! Tests for standalone primary configuration
+#![allow(deprecated)]
 
 use crate::common::net::{SimServer, TurmoilAcceptor};
 use crate::common::{http::Client, snapshot_metrics};

--- a/libsql/benches/benchmark.rs
+++ b/libsql/benches/benchmark.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use libsql::Database;
 use pprof::criterion::{Output, PProfProfiler};

--- a/libsql/examples/deserialization.rs
+++ b/libsql/examples/deserialization.rs
@@ -1,4 +1,4 @@
-use libsql::{de, Database};
+use libsql::{de, Builder};
 
 #[tokio::main]
 async fn main() {
@@ -8,9 +8,9 @@ async fn main() {
             "".to_string()
         });
 
-        Database::open_remote(url, token).unwrap()
+        Builder::new_remote(url, token).build().await.unwrap()
     } else {
-        Database::open_in_memory().unwrap()
+        Builder::new_local(":memory:").build().await.unwrap()
     };
 
     let conn = db.connect().unwrap();

--- a/libsql/examples/example.rs
+++ b/libsql/examples/example.rs
@@ -1,4 +1,4 @@
-use libsql::Database;
+use libsql::Builder;
 
 #[tokio::main]
 async fn main() {
@@ -8,9 +8,9 @@ async fn main() {
             "".to_string()
         });
 
-        Database::open_remote(url, token).unwrap()
+        Builder::new_remote(url, token).build().await.unwrap()
     } else {
-        Database::open_in_memory().unwrap()
+        Builder::new_local(":memory:").build().await.unwrap()
     };
 
     let conn = db.connect().unwrap();

--- a/libsql/examples/example_v2.rs
+++ b/libsql/examples/example_v2.rs
@@ -1,4 +1,4 @@
-use libsql::Database;
+use libsql::Builder;
 
 #[tokio::main]
 async fn main() {
@@ -8,9 +8,9 @@ async fn main() {
             "".to_string()
         });
 
-        Database::open_remote(url, token).unwrap()
+        Builder::new_remote(url, token).build().await.unwrap()
     } else {
-        Database::open_in_memory().unwrap()
+        Builder::new_local(":memory:").build().await.unwrap()
     };
 
     let conn = db.connect().unwrap();

--- a/libsql/examples/flutter.rs
+++ b/libsql/examples/flutter.rs
@@ -1,4 +1,4 @@
-use libsql::Database;
+use libsql::Builder;
 
 #[tokio::main]
 async fn main() {
@@ -14,11 +14,14 @@ async fn main() {
             .enable_http1()
             .build();
 
-        Database::open_remote_with_connector(url, token, https).unwrap()
+        Builder::new_remote(url, token)
+            .connector(https)
+            .build()
+            .await
+            .unwrap()
     } else {
-        Database::open_in_memory().unwrap()
+        Builder::new_local(":memory:").build().await.unwrap()
     };
-
     let conn = db.connect().unwrap();
 
     conn.query("select 1; select 1;", ()).await.unwrap();

--- a/libsql/examples/local_sync.rs
+++ b/libsql/examples/local_sync.rs
@@ -1,15 +1,13 @@
 use libsql::{
     replication::{Frames, SnapshotFile},
-    Database,
+    Builder,
 };
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let db = Database::open_with_local_sync("test.db", None)
-        .await
-        .unwrap();
+    let db = Builder::new_local_replica("test.db").build().await.unwrap();
     let conn = db.connect().unwrap();
 
     let args = std::env::args().collect::<Vec<String>>();

--- a/libsql/examples/remote_sync.rs
+++ b/libsql/examples/remote_sync.rs
@@ -1,6 +1,6 @@
 // Example of using a remote sync server with libsql.
 
-use libsql::{params, Database};
+use libsql::{params, Builder};
 
 #[tokio::main]
 async fn main() {
@@ -31,7 +31,10 @@ async fn main() {
     // The authentication token to use.
     let auth_token = std::env::var("LIBSQL_AUTH_TOKEN").unwrap_or("".to_string());
 
-    let db = match Database::open_with_remote_sync(db_path, sync_url, auth_token, None).await {
+    let db = match Builder::new_remote_replica(db_path, sync_url, auth_token)
+        .build()
+        .await
+    {
         Ok(db) => db,
         Err(error) => {
             eprintln!("Error connecting to remote sync server: {}", error);

--- a/libsql/examples/replica.rs
+++ b/libsql/examples/replica.rs
@@ -1,4 +1,4 @@
-use libsql::{Database, Value};
+use libsql::{Builder, Value};
 use std::time::Duration;
 
 #[tokio::main]
@@ -20,15 +20,12 @@ async fn main() {
         })
         .replace("libsql", "https");
 
-    let encryption_key = Some(bytes::Bytes::from("s3cr3t"));
-    let db = Database::open_with_remote_sync(
-        db_file.path().to_str().unwrap(),
-        url,
-        auth_token,
-        encryption_key,
-    )
-    .await
-    .unwrap();
+    let db = Builder::new_remote_replica(db_file.path(), url, auth_token)
+        .encryption_key("s3cr3t")
+        .build()
+        .await
+        .unwrap();
+
     let conn = db.connect().unwrap();
 
     let f = db.sync().await.unwrap();

--- a/libsql/examples/transaction.rs
+++ b/libsql/examples/transaction.rs
@@ -1,4 +1,4 @@
-use libsql::Database;
+use libsql::Builder;
 
 #[tokio::main]
 async fn main() {
@@ -12,12 +12,12 @@ async fn main() {
         "".to_string()
     });
 
-    let db = Database::open_with_remote_sync(
-        db_file.path().to_str().unwrap(),
-        "http://localhost:8080",
+    let db = Builder::new_remote_replica(
+        db_file.path(),
+        "http://localhost:8080".to_string(),
         auth_token,
-        None,
     )
+    .build()
     .await
     .unwrap();
 

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -1,3 +1,9 @@
+#![allow(deprecated)]
+
+mod builder;
+
+pub use builder::Builder;
+
 use std::fmt;
 
 use crate::{Connection, Result};
@@ -68,6 +74,7 @@ pub struct Database {
 cfg_core! {
     impl Database {
         /// Open an in-memory libsql database.
+        #[deprecated = "Use the new `Builder` to construct `Database`"]
         pub fn open_in_memory() -> Result<Self> {
             Ok(Database {
                 db_type: DbType::Memory,
@@ -75,11 +82,13 @@ cfg_core! {
         }
 
         /// Open a file backed libsql database.
+        #[deprecated = "Use the new `Builder` to construct `Database`"]
         pub fn open(db_path: impl Into<String>) -> Result<Database> {
             Database::open_with_flags(db_path, OpenFlags::default())
         }
 
         /// Open a file backed libsql database with flags.
+        #[deprecated = "Use the new `Builder` to construct `Database`"]
         pub fn open_with_flags(db_path: impl Into<String>, flags: OpenFlags) -> Result<Database> {
             Ok(Database {
                 db_type: DbType::File {
@@ -98,6 +107,7 @@ cfg_replication! {
 
     impl Database {
         /// Open a local database file with the ability to sync from snapshots from local filesystem.
+        #[deprecated = "Use the new `Builder` to construct `Database`"]
         pub async fn open_with_local_sync(
             db_path: impl Into<String>,
             encryption_key: Option<bytes::Bytes>
@@ -116,6 +126,7 @@ cfg_replication! {
 
         /// Open a local database file with the ability to sync from snapshots from local filesystem
         /// and forward writes to the provided endpoint.
+        #[deprecated = "Use the new `Builder` to construct `Database`"]
         pub async fn open_with_local_sync_remote_writes(
             db_path: impl Into<String>,
             endpoint: String,
@@ -135,6 +146,7 @@ cfg_replication! {
 
         /// Open a local database file with the ability to sync from snapshots from local filesystem
         /// and forward writes to the provided endpoint and a custom http connector.
+        #[deprecated = "Use the new `Builder` to construct `Database`"]
         pub async fn open_with_local_sync_remote_writes_connector<C>(
             db_path: impl Into<String>,
             endpoint: String,
@@ -172,6 +184,7 @@ cfg_replication! {
         }
 
         /// Open a local database file with the ability to sync from a remote database.
+        #[deprecated = "Use the new `Builder` to construct `Database`"]
         pub async fn open_with_remote_sync(
             db_path: impl Into<String>,
             url: impl Into<String>,
@@ -188,6 +201,7 @@ cfg_replication! {
         ///
         /// Consistent mode means that when a write happens it will not complete until
         /// that write is visible in the local db.
+        #[deprecated = "Use the new `Builder` to construct `Database`"]
         pub async fn open_with_remote_sync_consistent(
             db_path: impl Into<String>,
             url: impl Into<String>,
@@ -201,6 +215,7 @@ cfg_replication! {
 
         /// Connect an embedded replica to a remote primary with a custom
         /// http connector.
+        #[deprecated = "Use the new `Builder` to construct `Database`"]
         pub async fn open_with_remote_sync_connector<C>(
             db_path: impl Into<String>,
             url: impl Into<String>,
@@ -334,6 +349,7 @@ impl Database {}
 cfg_remote! {
     impl Database {
         /// Open a remote based HTTP database using libsql's hrana protocol.
+        #[deprecated = "Use the new `Builder` to construct `Database`"]
         pub fn open_remote(url: impl Into<String>, auth_token: impl Into<String>) -> Result<Self> {
             let https = connector();
 
@@ -352,6 +368,7 @@ cfg_remote! {
         }
 
         /// Connect to a remote libsql using libsql's hrana protocol with a custom connector.
+        #[deprecated = "Use the new `Builder` to construct `Database`"]
         pub fn open_remote_with_connector<C>(
             url: impl Into<String>,
             auth_token: impl Into<String>,

--- a/libsql/src/database/builder.rs
+++ b/libsql/src/database/builder.rs
@@ -1,0 +1,373 @@
+use crate::{Database, Result};
+
+use super::DbType;
+
+/// A builder for [`Database`]. This struct can be used to build
+/// all variants of [`Database`]. These variants include:
+///
+/// - `new_local`/`Local` which means a `Database` that is just a local libsql database
+///     it does no networking and does not connect to any remote database.
+/// - `new_remote_replica`/`RemoteReplica` creates an embedded replica database that will be able
+///     to sync from the remote url and delegate writes to the remote primary.
+/// - `new_local_replica`/`LocalReplica` creates an embedded replica similar to the remote version
+///     except you must use `Database::sync_frames` to sync with the remote. This version also
+///     includes the ability to delegate writes to a remote primary.
+/// - `new_remote`/`Remote` creates a database that does not create anything locally but will
+///     instead run all queries on the remote database. This is essentially the pure HTTP api.
+pub struct Builder<T = ()> {
+    inner: T,
+}
+
+impl Builder<()> {
+    cfg_core! {
+        /// Create a new local database.
+        pub fn new_local(path: impl AsRef<std::path::Path>) -> Builder<Local> {
+            Builder {
+                inner: Local {
+                    path: path.as_ref().to_path_buf(),
+                    flags: crate::OpenFlags::default(),
+                },
+            }
+        }
+    }
+
+    cfg_replication! {
+        /// Create a new remote embedded replica.
+        pub fn new_remote_replica(
+            path: impl AsRef<std::path::Path>,
+            url: String,
+            auth_token: String,
+        ) -> Builder<RemoteReplica> {
+            Builder {
+                inner: RemoteReplica {
+                    path: path.as_ref().to_path_buf(),
+                    remote: Remote {
+                        url,
+                        auth_token,
+                        connector: None,
+                        version: None,
+                    },
+                    encryption_key: None,
+                    read_your_writes: false,
+                },
+            }
+        }
+
+        /// Create a new local replica.
+        pub fn new_local_replica(path: impl AsRef<std::path::Path>) -> Builder<LocalReplica> {
+            Builder {
+                inner: LocalReplica {
+                    path: path.as_ref().to_path_buf(),
+                    flags: crate::OpenFlags::default(),
+                    remote: None,
+                    encryption_key: None,
+                },
+            }
+        }
+    }
+
+    cfg_remote! {
+        /// Create a new remote database.
+        pub fn new_remote(url: String, auth_token: String) -> Builder<Remote> {
+            Builder {
+                inner: Remote {
+                    url,
+                    auth_token,
+                    connector: None,
+                    version: None,
+                },
+            }
+        }
+    }
+}
+
+cfg_replication_or_remote! {
+    /// Remote configuration type used in [`Builder`].
+    pub struct Remote {
+        url: String,
+        auth_token: String,
+        connector: Option<crate::util::ConnectorService>,
+        version: Option<String>,
+    }
+}
+
+cfg_core! {
+    /// Local database configuration type in [`Builder`].
+    pub struct Local {
+        path: std::path::PathBuf,
+        flags: crate::OpenFlags,
+    }
+
+    impl Builder<Local> {
+        /// Set [`OpenFlags`] for this database.
+        pub fn flags(mut self, flags: crate::OpenFlags) -> Builder<Local> {
+            self.inner.flags = flags;
+            self
+        }
+
+        /// Build the local database.
+        pub async fn build(self) -> Result<Database> {
+            let db = if self.inner.path == std::path::Path::new(":memory:") {
+                Database {
+                    db_type: DbType::Memory,
+                }
+            } else {
+                let path = self
+                    .inner
+                    .path
+                    .to_str()
+                    .ok_or(crate::Error::InvalidUTF8Path)?
+                    .to_owned();
+
+                Database {
+                    db_type: DbType::File {
+                        path,
+                        flags: self.inner.flags,
+                    },
+                }
+            };
+
+            Ok(db)
+        }
+    }
+}
+
+cfg_replication! {
+    /// Remote replica configuration type in [`Builder`].
+    pub struct RemoteReplica {
+        path: std::path::PathBuf,
+        remote: Remote,
+        encryption_key: Option<bytes::Bytes>,
+        read_your_writes: bool,
+    }
+
+    /// Local replica configuration type in [`Builder`].
+    pub struct LocalReplica {
+        path: std::path::PathBuf,
+        flags: crate::OpenFlags,
+        remote: Option<Remote>,
+        encryption_key: Option<bytes::Bytes>,
+    }
+
+    impl Builder<RemoteReplica> {
+        /// Provide a custom http connector that will be used to create http connections.
+        pub fn connector<C>(mut self, connector: C) -> Builder<RemoteReplica>
+        where
+            C: tower::Service<http::Uri> + Send + Clone + Sync + 'static,
+            C::Response: crate::util::Socket,
+            C::Future: Send + 'static,
+            C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        {
+            self.inner.remote = self.inner.remote.connector(connector);
+            self
+        }
+
+        /// Set an encryption key that will encrypt the local database.
+        pub fn encryption_key(
+            mut self,
+            encryption_key: impl Into<bytes::Bytes>,
+        ) -> Builder<RemoteReplica> {
+            self.inner.encryption_key = Some(encryption_key.into());
+            self
+        }
+
+        /// Set weather you want writes to be visible locally before the write query returns. This
+        /// means that you will be able to read your own writes if this is set to `true`.
+        pub fn read_your_writes(mut self, read_your_writes: bool) -> Builder<RemoteReplica> {
+            self.inner.read_your_writes = read_your_writes;
+            self
+        }
+
+        #[doc(hidden)]
+        pub fn version(mut self, version: String) -> Builder<RemoteReplica> {
+            self.inner.remote = self.inner.remote.version(version);
+            self
+        }
+
+        /// Build the remote embedded replica database.
+        pub async fn build(self) -> Result<Database> {
+            let RemoteReplica {
+                path,
+                remote:
+                    Remote {
+                        url,
+                        auth_token,
+                        connector,
+                        version,
+                    },
+                encryption_key,
+                read_your_writes,
+            } = self.inner;
+
+            let connector = if let Some(connector) = connector {
+                connector
+            } else {
+                let https = super::connector();
+                use tower::ServiceExt;
+
+                let svc = https
+                    .map_err(|e| e.into())
+                    .map_response(|s| Box::new(s) as Box<dyn crate::util::Socket>);
+
+                crate::util::ConnectorService::new(svc)
+            };
+
+            let path = path.to_str().ok_or(crate::Error::InvalidUTF8Path)?.to_owned();
+
+            let db = crate::local::Database::open_http_sync_internal(
+                connector,
+                path,
+                url,
+                auth_token,
+                version,
+                read_your_writes,
+                encryption_key.clone(),
+            )
+            .await?;
+
+            Ok(Database {
+                db_type: DbType::Sync { db, encryption_key },
+            })
+        }
+    }
+
+    impl Builder<LocalReplica> {
+        /// Set [`OpenFlags`] for this database.
+        pub fn flags(mut self, flags: crate::OpenFlags) -> Builder<LocalReplica> {
+            self.inner.flags = flags;
+            self
+        }
+
+        /// Build the local embedded replica database.
+        pub async fn build(self) -> Result<Database> {
+            let LocalReplica {
+                path,
+                flags,
+                remote,
+                encryption_key,
+            } = self.inner;
+
+            let path = path.to_str().ok_or(crate::Error::InvalidUTF8Path)?.to_owned();
+
+            let db = if let Some(Remote {
+                url,
+                auth_token,
+                connector,
+                version,
+            }) = remote
+            {
+                let connector = if let Some(connector) = connector {
+                    connector
+                } else {
+                    let https = super::connector();
+                    use tower::ServiceExt;
+
+                    let svc = https
+                        .map_err(|e| e.into())
+                        .map_response(|s| Box::new(s) as Box<dyn crate::util::Socket>);
+
+                    crate::util::ConnectorService::new(svc)
+                };
+
+                crate::local::Database::open_local_sync_remote_writes(
+                    connector,
+                    path,
+                    url,
+                    auth_token,
+                    version,
+                    flags,
+                    encryption_key.clone(),
+                )
+                .await?
+            } else {
+                crate::local::Database::open_local_sync(path, flags, encryption_key.clone()).await?
+            };
+
+            Ok(Database {
+                db_type: DbType::Sync { db, encryption_key },
+            })
+        }
+    }
+}
+
+cfg_remote! {
+    impl Builder<Remote> {
+        /// Provide a custom http connector that will be used to create http connections.
+        pub fn connector<C>(mut self, connector: C) -> Builder<Remote>
+        where
+            C: tower::Service<http::Uri> + Send + Clone + Sync + 'static,
+            C::Response: crate::util::Socket,
+            C::Future: Send + 'static,
+            C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        {
+            self.inner = self.inner.connector(connector);
+            self
+        }
+
+        #[doc(hidden)]
+        pub fn version(mut self, version: String) -> Builder<Remote> {
+            self.inner = self.inner.version(version);
+            self
+        }
+
+        /// Build the remote database client.
+        pub async fn build(self) -> Result<Database> {
+            let Remote {
+                url,
+                auth_token,
+                connector,
+                version,
+            } = self.inner;
+
+            let connector = if let Some(connector) = connector {
+                connector
+            } else {
+                let https = super::connector();
+                use tower::ServiceExt;
+
+                let svc = https
+                    .map_err(|e| e.into())
+                    .map_response(|s| Box::new(s) as Box<dyn crate::util::Socket>);
+
+                crate::util::ConnectorService::new(svc)
+            };
+
+            Ok(Database {
+                db_type: DbType::Remote {
+                    url,
+                    auth_token,
+                    connector,
+                    version,
+                },
+            })
+        }
+    }
+}
+
+cfg_replication_or_remote! {
+    impl Remote {
+        fn connector<C>(mut self, connector: C) -> Remote
+        where
+            C: tower::Service<http::Uri> + Send + Clone + Sync + 'static,
+            C::Response: crate::util::Socket,
+            C::Future: Send + 'static,
+            C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        {
+            use tower::ServiceExt;
+
+            let svc = connector
+                .map_err(|e| e.into())
+                .map_response(|s| Box::new(s) as Box<dyn crate::util::Socket>);
+
+            let svc = crate::util::ConnectorService::new(svc);
+
+            self.connector = Some(svc);
+            self
+        }
+
+        fn version(mut self, version: String) -> Remote {
+            self.version = Some(version);
+            self
+        }
+    }
+}

--- a/libsql/src/errors.rs
+++ b/libsql/src/errors.rs
@@ -40,6 +40,8 @@ pub enum Error {
     RemoteSqliteFailure(i32, i32, String),
     #[error("replication error: {0}")]
     Replication(crate::BoxError),
+    #[error("path has invalid UTF-8")]
+    InvalidUTF8Path,
 }
 
 #[cfg(feature = "hrana")]

--- a/libsql/tests/integration_tests.rs
+++ b/libsql/tests/integration_tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use futures::{StreamExt, TryStreamExt};
 use libsql::{
     named_params, params,

--- a/libsql/tests/replication.rs
+++ b/libsql/tests/replication.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use libsql::{replication::Frames, Database};
 use libsql_replication::{
     frame::{FrameBorrowed, FrameHeader, FrameMut},


### PR DESCRIPTION
This adds a new `Builder` type that can now be used to construct the `Database` type. This will scale better as we add more varied options. This commit also deprecates the old builder types and will produce a warning that will push users to using the new `Builder` type. This will then allow us to remove the old deprecated constructors at some point in the future.