### PR TITLE
Allow vacuum block to be configured with SQLD_BLOCK_VACUUM env var

### DIFF
--- a/libsql-server/src/config.rs
+++ b/libsql-server/src/config.rs
@@ -126,6 +126,7 @@ pub struct DbConfig {
     pub checkpoint_interval: Option<Duration>,
     pub snapshot_at_shutdown: bool,
     pub encryption_key: Option<bytes::Bytes>,
+    pub block_vacuum: bool,
 }
 
 impl Default for DbConfig {
@@ -143,6 +144,7 @@ impl Default for DbConfig {
             checkpoint_interval: None,
             snapshot_at_shutdown: false,
             encryption_key: None,
+            block_vacuum: true,
         }
     }
 }

--- a/libsql-server/src/connection/write_proxy.rs
+++ b/libsql-server/src/connection/write_proxy.rs
@@ -45,6 +45,7 @@ pub struct MakeWriteProxyConn {
     primary_replication_index: Option<FrameNo>,
     make_read_only_conn: MakeLibSqlConn<Sqlite3WalManager>,
     encryption_key: Option<bytes::Bytes>,
+    block_vacuum: bool,
 }
 
 impl MakeWriteProxyConn {
@@ -62,6 +63,7 @@ impl MakeWriteProxyConn {
         namespace: NamespaceName,
         primary_replication_index: Option<FrameNo>,
         encryption_key: Option<bytes::Bytes>,
+        block_vacuum: bool,
     ) -> crate::Result<Self> {
         let client = ProxyClient::with_origin(channel, uri);
         let make_read_only_conn = MakeLibSqlConn::new(
@@ -75,6 +77,7 @@ impl MakeWriteProxyConn {
             DEFAULT_AUTO_CHECKPOINT,
             applied_frame_no_receiver.clone(),
             encryption_key.clone(),
+            block_vacuum,
         )
         .await?;
 
@@ -88,6 +91,7 @@ impl MakeWriteProxyConn {
             make_read_only_conn,
             primary_replication_index,
             encryption_key,
+            block_vacuum,
         })
     }
 }
@@ -105,6 +109,7 @@ impl MakeConnection for MakeWriteProxyConn {
                 max_total_size: Some(self.max_total_response_size),
                 auto_checkpoint: DEFAULT_AUTO_CHECKPOINT,
                 encryption_key: self.encryption_key.clone(),
+                block_vacuum: self.block_vacuum,
             },
             self.namespace.clone(),
             self.primary_replication_index,

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -535,6 +535,7 @@ where
             disable_namespace: self.disable_namespaces,
             encryption_key: self.db_config.encryption_key.clone(),
             max_concurrent_connections: Arc::new(Semaphore::new(self.max_concurrent_connections)),
+            block_vacuum: self.db_config.block_vacuum,
         };
 
         let factory = PrimaryNamespaceMaker::new(conf);
@@ -648,6 +649,7 @@ impl<C: Connector> Replica<C> {
             max_total_response_size: self.db_config.max_total_response_size,
             encryption_key: self.db_config.encryption_key.clone(),
             max_concurrent_connections: Arc::new(Semaphore::new(self.max_concurrent_connections)),
+            block_vacuum: self.db_config.block_vacuum,
         };
 
         let factory = ReplicaNamespaceMaker::new(conf);

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -228,6 +228,9 @@ struct Cli {
     /// encryption_key for encryption at rest
     #[clap(long, env = "SQLD_ENCRYPTION_KEY")]
     encryption_key: Option<bytes::Bytes>,
+    /// encryption_key for encryption at rest
+    #[clap(long, env = "SQLD_BLOCK_VACUUM")]
+    block_vacuum: bool,
 
     #[clap(long, default_value = "128")]
     max_concurrent_connections: usize,
@@ -348,6 +351,7 @@ fn make_db_config(config: &Cli) -> anyhow::Result<DbConfig> {
         checkpoint_interval: config.checkpoint_interval_s.map(Duration::from_secs),
         snapshot_at_shutdown: config.snapshot_at_shutdown,
         encryption_key: config.encryption_key.clone(),
+        block_vacuum: config.block_vacuum,
     })
 }
 

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -843,6 +843,7 @@ pub struct ReplicaNamespaceConfig {
     pub stats_sender: StatsSender,
     pub encryption_key: Option<bytes::Bytes>,
     pub max_concurrent_connections: Arc<Semaphore>,
+    pub block_vacuum: bool,
 }
 
 impl Namespace<ReplicaDatabase> {
@@ -963,6 +964,7 @@ impl Namespace<ReplicaDatabase> {
             name.clone(),
             primary_current_replicatio_index,
             config.encryption_key.clone(),
+            config.block_vacuum,
         )
         .await?
         .throttled(
@@ -997,6 +999,7 @@ pub struct PrimaryNamespaceConfig {
     pub checkpoint_interval: Option<Duration>,
     pub disable_namespace: bool,
     pub encryption_key: Option<bytes::Bytes>,
+    pub block_vacuum: bool,
     pub max_concurrent_connections: Arc<Semaphore>,
 }
 
@@ -1143,6 +1146,7 @@ impl Namespace<PrimaryDatabase> {
             auto_checkpoint,
             logger.new_frame_notifier.subscribe(),
             config.encryption_key.clone(),
+            config.block_vacuum,
         )
         .await?
         .throttled(

--- a/libsql-server/src/query_analysis.rs
+++ b/libsql-server/src/query_analysis.rs
@@ -29,6 +29,7 @@ pub enum StmtKind {
     Read,
     Write,
     Savepoint,
+    Vacuum,
     Release,
     Other,
 }
@@ -108,6 +109,7 @@ impl StmtKind {
             }) => Some(Self::Write),
             Cmd::Stmt(Stmt::DropView { .. }) => Some(Self::Write),
             Cmd::Stmt(Stmt::Savepoint(_)) => Some(Self::Savepoint),
+            Cmd::Stmt(Stmt::Vacuum(_, _)) => Some(Self::Vacuum),
             Cmd::Stmt(Stmt::Release(_))
             | Cmd::Stmt(Stmt::Rollback {
                 savepoint_name: Some(_),

--- a/libsql-server/src/query_result_builder.rs
+++ b/libsql-server/src/query_result_builder.rs
@@ -88,6 +88,7 @@ pub struct QueryBuilderConfig {
     pub max_total_size: Option<u64>,
     pub auto_checkpoint: u32,
     pub encryption_key: Option<bytes::Bytes>,
+    pub block_vacuum: bool,
 }
 
 pub trait QueryResultBuilder: Send + 'static {

--- a/libsql-server/src/test/bottomless.rs
+++ b/libsql-server/src/test/bottomless.rs
@@ -93,6 +93,7 @@ async fn configure_server(
             checkpoint_interval: Some(Duration::from_secs(3)),
             snapshot_at_shutdown: false,
             encryption_key: None,
+            block_vacuum: true,
         },
         admin_api_config: None,
         disable_namespaces: true,


### PR DESCRIPTION
This would allow `libsql-server` users to run vacuum locally. 