### PR TITLE
libsql: add periodic background sync

### DIFF
--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -238,6 +238,7 @@ cfg_replication! {
                 None,
                 read_your_writes,
                 encryption_key,
+                None
             ).await
         }
 
@@ -249,6 +250,7 @@ cfg_replication! {
             version: Option<String>,
             read_your_writes: bool,
             encryption_key: Option<bytes::Bytes>,
+            periodic_sync: Option<std::time::Duration>,
         ) -> Result<Database> {
             let https = connector();
 
@@ -260,6 +262,7 @@ cfg_replication! {
                 version,
                 read_your_writes,
                 encryption_key,
+                periodic_sync
             ).await
         }
 
@@ -272,6 +275,7 @@ cfg_replication! {
             version: Option<String>,
             read_your_writes: bool,
             encryption_key: Option<bytes::Bytes>,
+            periodic_sync: Option<std::time::Duration>,
         ) -> Result<Database>
         where
             C: tower::Service<http::Uri> + Send + Clone + Sync + 'static,
@@ -294,7 +298,8 @@ cfg_replication! {
                 token.into(),
                 version,
                 read_your_writes,
-                encryption_key.clone()
+                encryption_key.clone(),
+                periodic_sync
             ).await?;
 
             Ok(Database {

--- a/libsql/src/database/builder.rs
+++ b/libsql/src/database/builder.rs
@@ -49,6 +49,7 @@ impl Builder<()> {
                     },
                     encryption_key: None,
                     read_your_writes: false,
+                    periodic_sync: None
                 },
             }
         }
@@ -139,6 +140,7 @@ cfg_replication! {
         remote: Remote,
         encryption_key: Option<bytes::Bytes>,
         read_your_writes: bool,
+        periodic_sync: Option<std::time::Duration>,
     }
 
     /// Local replica configuration type in [`Builder`].
@@ -178,6 +180,14 @@ cfg_replication! {
             self
         }
 
+        /// Set the duration at which the replicator will automatically call `sync` in the
+        /// background. The sync will continue for the duration that the resulted `Database`
+        /// type is alive for, once it is dropped the background task will get dropped and stop.
+        pub fn periodic_sync(mut self, duration: std::time::Duration) -> Builder<RemoteReplica> {
+            self.inner.periodic_sync = Some(duration);
+            self
+        }
+
         #[doc(hidden)]
         pub fn version(mut self, version: String) -> Builder<RemoteReplica> {
             self.inner.remote = self.inner.remote.version(version);
@@ -197,6 +207,7 @@ cfg_replication! {
                     },
                 encryption_key,
                 read_your_writes,
+                periodic_sync
             } = self.inner;
 
             let connector = if let Some(connector) = connector {
@@ -222,6 +233,7 @@ cfg_replication! {
                 version,
                 read_your_writes,
                 encryption_key.clone(),
+                periodic_sync
             )
             .await?;
 

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -52,6 +52,7 @@ impl Database {
         endpoint: String,
         auth_token: String,
         encryption_key: Option<bytes::Bytes>,
+        periodic_sync: Option<std::time::Duration>,
     ) -> Result<Database> {
         Self::open_http_sync_internal(
             connector,
@@ -61,6 +62,7 @@ impl Database {
             None,
             false,
             encryption_key,
+            periodic_sync,
         )
         .await
     }
@@ -75,6 +77,7 @@ impl Database {
         version: Option<String>,
         read_your_writes: bool,
         encryption_key: Option<bytes::Bytes>,
+        periodic_sync: Option<std::time::Duration>,
     ) -> Result<Database> {
         use std::path::PathBuf;
 
@@ -95,7 +98,9 @@ impl Database {
             .await
             .map_err(|e| crate::errors::Error::ConnectionFailed(e.to_string()))?;
 
-        let replicator = EmbeddedReplicator::with_remote(client, path, 1000, encryption_key).await;
+        let replicator =
+            EmbeddedReplicator::with_remote(client, path, 1000, encryption_key, periodic_sync)
+                .await;
 
         db.replication_ctx = Some(ReplicationContext {
             replicator,


### PR DESCRIPTION
This adds a new periodic sync configuration item to the `Builder` that will allow users to set a duration at which they want the background sync to sync.