### PR TITLE
rusqlite: enable libsql-ffi/wasmtime-bindings feature for wasm

### DIFF
--- a/vendored/rusqlite/Cargo.toml
+++ b/vendored/rusqlite/Cargo.toml
@@ -46,7 +46,7 @@ limits = []
 hooks = []
 i128_blob = []
 sqlcipher = []
-libsql-experimental = []
+libsql-experimental = ["libsql-ffi/wasmtime-bindings"]
 libsql-wasm-experimental = ["libsql-experimental"]
 # xSavepoint, xRelease and xRollbackTo: 3.7.7 (2011-06-23)
 vtab = []


### PR DESCRIPTION
Otherwise linker errors are to be expected -- wasmtime-bindings crate provides symbols necessary for WebAssembly runtime.