### PR TITLE
Fix replication bug

### DIFF
--- a/libsql-replication/src/injector/mod.rs
+++ b/libsql-replication/src/injector/mod.rs
@@ -162,6 +162,8 @@ impl Injector {
 
     fn begin_txn(&mut self) -> Result<(), Error> {
         let conn = self.connection.lock();
+        conn.pragma_update(None, "writable_schema", "true")?;
+
         let mut stmt = conn.prepare_cached("BEGIN IMMEDIATE")?;
         stmt.execute(())?;
         // we create a dummy table. This table MUST not be persisted, otherwise the replica schema


### PR DESCRIPTION
This PR fixes a replication bug that would happens sometimes when shcema changes where replicated. Sqlite would freak out because the schema was being modified without its knowledge. Setting `writable_schema=true` before injection solves the issue.
