### PR TITLE
Add a step to free disk space in nemesis tests

### DIFF
--- a/.github/workflows/nemesis.yml
+++ b/.github/workflows/nemesis.yml
@@ -20,6 +20,14 @@ jobs:
     steps:
       - uses: hecrj/setup-rust-action@v1
 
+      # needed because we run out of disk space during tests
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # when set to "true" but frees about 6 GB
+          tool-cache: true
+
       - name: Install deps
         run: sudo apt update && sudo apt install -y libclang-dev
 


### PR DESCRIPTION
Nemesis tests are failing due to lack of free space - https://github.com/tursodatabase/libsql/actions/runs/7884104131