### PR TITLE
libsq-ffi: Drop git submodule trickery from sqlite3mc build

### DIFF
--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -284,13 +284,6 @@ fn build_multiple_ciphers(out_path: &Path) {
 
     let bundled_dir = fs::canonicalize(BUNDLED_DIR).unwrap();
 
-    let mut cmd = Command::new("git");
-    cmd.args(&["submodule", "update", "--init", "SQLite3MultipleCiphers"]);
-    cmd.current_dir(bundled_dir.clone());
-    // The submodule is there only for development builds, but the
-    // command is expected to fail when libsql is fetched via cargo.
-    cmd.status().unwrap();
-
     let build_dir = bundled_dir.join("SQLite3MultipleCiphers").join("build");
     let _ = fs::remove_dir_all(build_dir.clone());
     fs::create_dir_all(build_dir.clone()).unwrap();


### PR DESCRIPTION
As Lucio points out, we no longer do submodules for sqlite3mc so let's just drop the bogus `git submodule update` invocation.