### PR TITLE
remove to_compact on recovery

### DIFF
--- a/libsql-server/src/replication/primary/logger.rs
+++ b/libsql-server/src/replication/primary/logger.rs
@@ -681,6 +681,9 @@ impl ReplicationLogger {
         let snapshot_path = data_path.parent().unwrap().join("snapshots");
         // best effort, there may be no snapshots
         let _ = remove_dir_all(snapshot_path);
+        let to_compact_path = data_path.parent().unwrap().join("to_compact");
+        // best effort, there may nothing to compact
+        let _ = remove_dir_all(to_compact_path);
 
         let data_file = File::open(&data_path)?;
         let size = data_path.metadata()?.len();


### PR DESCRIPTION
Remove the `to_compact` directory on recovery to prevent piling on files in case of crash.
