### PR TITLE
recover metastore from fs

### DIFF
--- a/libsql-server/src/config.rs
+++ b/libsql-server/src/config.rs
@@ -203,7 +203,14 @@ pub struct HeartbeatConfig {
     pub heartbeat_auth: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
 pub struct MetaStoreConfig {
+    pub bottomless: Option<BottomlessConfig>,
+    pub allow_recover_from_fs: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct BottomlessConfig {
     pub access_key_id: String,
     pub secret_access_key: String,
     pub region: String,

--- a/libsql-server/src/connection/config.rs
+++ b/libsql-server/src/connection/config.rs
@@ -6,7 +6,7 @@ use tokio::time::Duration;
 
 use super::TXN_TIMEOUT;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Deserialize)]
 pub struct DatabaseConfig {
     pub block_reads: bool,
     pub block_writes: bool,
@@ -16,8 +16,11 @@ pub struct DatabaseConfig {
     pub max_db_pages: u64,
     pub heartbeat_url: Option<Url>,
     pub bottomless_db_id: Option<String>,
+    #[serde(default)]
     pub jwt_key: Option<String>,
+    #[serde(default)]
     pub txn_timeout: Option<Duration>,
+    #[serde(default)]
     pub allow_attach: bool,
 }
 

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -103,7 +103,7 @@ pub struct Server<C = HttpConnector, A = AddrIncoming, D = HttpsConnector<HttpCo
     pub disable_namespaces: bool,
     pub shutdown: Arc<Notify>,
     pub max_active_namespaces: usize,
-    pub meta_store_config: Option<MetaStoreConfig>,
+    pub meta_store_config: MetaStoreConfig,
     pub max_concurrent_connections: usize,
 }
 
@@ -123,7 +123,7 @@ impl<C, A, D> Default for Server<C, A, D> {
             disable_namespaces: true,
             shutdown: Default::default(),
             max_active_namespaces: 100,
-            meta_store_config: None,
+            meta_store_config: Default::default(),
             max_concurrent_connections: 128,
         }
     }
@@ -395,7 +395,7 @@ where
                     auth: auth.clone(),
                     disable_namespaces: self.disable_namespaces,
                     max_active_namespaces: self.max_active_namespaces,
-                    meta_store_config: self.meta_store_config.take(),
+                    meta_store_config: self.meta_store_config.clone(),
                     max_concurrent_connections: self.max_concurrent_connections,
                 };
                 let (namespaces, proxy_service, replication_service) = replica.configure().await?;
@@ -437,7 +437,7 @@ where
                     max_active_namespaces: self.max_active_namespaces,
                     join_set: &mut join_set,
                     auth: auth.clone(),
-                    meta_store_config: self.meta_store_config.take(),
+                    meta_store_config: self.meta_store_config.clone(),
                     max_concurrent_connections: self.max_concurrent_connections,
                 };
 
@@ -506,7 +506,7 @@ struct Primary<'a, A> {
     max_active_namespaces: usize,
     auth: Arc<Auth>,
     join_set: &'a mut JoinSet<anyhow::Result<()>>,
-    meta_store_config: Option<MetaStoreConfig>,
+    meta_store_config: MetaStoreConfig,
     max_concurrent_connections: usize,
 }
 
@@ -635,7 +635,7 @@ struct Replica<C> {
     auth: Arc<Auth>,
     disable_namespaces: bool,
     max_active_namespaces: usize,
-    meta_store_config: Option<MetaStoreConfig>,
+    meta_store_config: MetaStoreConfig,
     max_concurrent_connections: usize,
 }
 

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -237,7 +237,7 @@ struct Cli {
 
     /// Allow meta store to recover config from filesystem from older version, if meta store is
     /// empty on startup
-    #[clap(long)]
+    #[clap(long, env = "SQLD_ALLOW_METASTORE_RECOVERY")]
     allow_metastore_recovery: bool,
 }
 

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -419,7 +419,7 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         snapshot_at_shutdown: bool,
         max_active_namespaces: usize,
         base_path: &Path,
-        meta_store_config: Option<MetaStoreConfig>,
+        meta_store_config: MetaStoreConfig,
     ) -> crate::Result<Self> {
         let metadata = MetaStore::new(meta_store_config, base_path).await?;
         tracing::trace!("Max active namespaces: {max_active_namespaces}");

--- a/libsql-server/src/test/bottomless.rs
+++ b/libsql-server/src/test/bottomless.rs
@@ -114,7 +114,7 @@ async fn configure_server(
         rpc_server_config: None,
         rpc_client_config: None,
         shutdown: Default::default(),
-        meta_store_config: None,
+        meta_store_config: Default::default(),
         max_concurrent_connections: 128,
     }
 }


### PR DESCRIPTION
To help migration to 0.23, this pr adds the flag `--allow-metastore-recovery`: if this flag is set, and the metastore is empty, then the metastore is seeded from the config files found in the `/dbs` subdirectories.
