### PR TITLE
limit row size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rusqlite = { package = "libsql-rusqlite", path = "vendored/rusqlite", version = 
     "load_extension",
     "modern_sqlite",
     "functions",
+    "limits",
 ] }
 
 # Config for 'cargo dist'

--- a/libsql-replication/proto/metadata.proto
+++ b/libsql-replication/proto/metadata.proto
@@ -16,4 +16,5 @@ message DatabaseConfig {
     optional string jwt_key = 7;
     optional uint64 txn_timeout_s = 8;
     bool allow_attach = 9;
+    optional uint64 max_row_size = 10;
 }

--- a/libsql-replication/src/generated/metadata.rs
+++ b/libsql-replication/src/generated/metadata.rs
@@ -23,4 +23,6 @@ pub struct DatabaseConfig {
     pub txn_timeout_s: ::core::option::Option<u64>,
     #[prost(bool, tag = "9")]
     pub allow_attach: bool,
+    #[prost(uint64, optional, tag = "10")]
+    pub max_row_size: ::core::option::Option<u64>,
 }

--- a/libsql-server/src/connection/config.rs
+++ b/libsql-server/src/connection/config.rs
@@ -1,4 +1,5 @@
 use crate::LIBSQL_PAGE_SIZE;
+use bytesize::mb;
 use url::Url;
 
 use libsql_replication::rpc::metadata;
@@ -22,10 +23,15 @@ pub struct DatabaseConfig {
     pub txn_timeout: Option<Duration>,
     #[serde(default)]
     pub allow_attach: bool,
+    pub max_row_size: u64,
 }
 
 const fn default_max_size() -> u64 {
     bytesize::ByteSize::pb(1000).as_u64() / LIBSQL_PAGE_SIZE
+}
+
+fn default_max_row_size() -> u64 {
+    mb(5u64)
 }
 
 impl Default for DatabaseConfig {
@@ -40,6 +46,7 @@ impl Default for DatabaseConfig {
             jwt_key: None,
             txn_timeout: Some(TXN_TIMEOUT),
             allow_attach: false,
+            max_row_size: default_max_row_size(),
         }
     }
 }
@@ -56,6 +63,7 @@ impl From<&metadata::DatabaseConfig> for DatabaseConfig {
             jwt_key: value.jwt_key.clone(),
             txn_timeout: value.txn_timeout_s.map(Duration::from_secs),
             allow_attach: value.allow_attach,
+            max_row_size: value.max_row_size.unwrap_or_else(default_max_row_size),
         }
     }
 }
@@ -72,6 +80,7 @@ impl From<&DatabaseConfig> for metadata::DatabaseConfig {
             jwt_key: value.jwt_key.clone(),
             txn_timeout_s: value.txn_timeout.map(|d| d.as_secs()),
             allow_attach: value.allow_attach,
+            max_row_size: Some(value.max_row_size),
         }
     }
 }

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -280,6 +280,7 @@ struct CreateNamespaceReq {
     bottomless_db_id: Option<String>,
     jwt_key: Option<String>,
     txn_timeout_s: Option<u64>,
+    max_row_size: Option<u64>,
 }
 
 async fn handle_create_namespace<M: MakeNamespace, C: Connector>(
@@ -319,6 +320,10 @@ async fn handle_create_namespace<M: MakeNamespace, C: Connector>(
 
     if let Some(txn_timeout_s) = req.txn_timeout_s {
         config.txn_timeout = Some(Duration::from_secs(txn_timeout_s));
+    }
+
+    if let Some(max_row_size) = req.max_row_size {
+        config.max_row_size = max_row_size;
     }
 
     config.jwt_key = req.jwt_key;


### PR DESCRIPTION
Limit the maximum row size. The default is set to 5mb. This limit is configurable per-namespace with the `max_row_size` key.
