### PR TITLE
Parametrize namespace creation for shared schema db

### DIFF
--- a/libsql-replication/proto/metadata.proto
+++ b/libsql-replication/proto/metadata.proto
@@ -16,4 +16,6 @@ message DatabaseConfig {
     optional string jwt_key = 7;
     optional uint64 txn_timeout_s = 8;
     bool allow_attach = 9;
+    bool shared_schema = 10;
+    optional string shared_schema_name = 11;
 }

--- a/libsql-replication/src/generated/metadata.rs
+++ b/libsql-replication/src/generated/metadata.rs
@@ -23,4 +23,8 @@ pub struct DatabaseConfig {
     pub txn_timeout_s: ::core::option::Option<u64>,
     #[prost(bool, tag = "9")]
     pub allow_attach: bool,
+    #[prost(bool, tag = "10")]
+    pub is_shared_schema: bool,
+    #[prost(string, optional, tag = "11")]
+    pub shared_schema_name: ::core::option::Option<::prost::alloc::string::String>,
 }

--- a/libsql-server/src/connection/config.rs
+++ b/libsql-server/src/connection/config.rs
@@ -22,6 +22,10 @@ pub struct DatabaseConfig {
     pub txn_timeout: Option<Duration>,
     #[serde(default)]
     pub allow_attach: bool,
+    #[serde(default)]
+    pub is_shared_schema: bool,
+    #[serde(default)]
+    pub shared_schema_name: Option<String>,
 }
 
 const fn default_max_size() -> u64 {
@@ -40,6 +44,8 @@ impl Default for DatabaseConfig {
             jwt_key: None,
             txn_timeout: Some(TXN_TIMEOUT),
             allow_attach: false,
+            is_shared_schema: false,
+            shared_schema_name: None,
         }
     }
 }
@@ -56,6 +62,8 @@ impl From<&metadata::DatabaseConfig> for DatabaseConfig {
             jwt_key: value.jwt_key.clone(),
             txn_timeout: value.txn_timeout_s.map(Duration::from_secs),
             allow_attach: value.allow_attach,
+            is_shared_schema: value.is_shared_schema,
+            shared_schema_name: value.shared_schema_name.clone(),
         }
     }
 }
@@ -72,6 +80,8 @@ impl From<&DatabaseConfig> for metadata::DatabaseConfig {
             jwt_key: value.jwt_key.clone(),
             txn_timeout_s: value.txn_timeout.map(|d| d.as_secs()),
             allow_attach: value.allow_attach,
+            is_shared_schema: value.is_shared_schema,
+            shared_schema_name: value.shared_schema_name.clone(),
         }
     }
 }

--- a/libsql-server/src/error.rs
+++ b/libsql-server/src/error.rs
@@ -101,6 +101,8 @@ pub enum Error {
     Ref(#[from] std::sync::Arc<Self>),
     #[error("Unable to decode protobuf: {0}")]
     ProstDecode(#[from] prost::DecodeError),
+    #[error("Shared schema error: {0}")]
+    SharedSchemaError(String),
 }
 
 impl AsRef<Self> for Error {
@@ -178,6 +180,7 @@ impl IntoResponse for &Error {
             MetaStoreUpdateFailure(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             Ref(this) => this.as_ref().into_response(),
             ProstDecode(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
+            SharedSchemaError(_) => self.format_err(StatusCode::BAD_REQUEST),
         }
     }
 }

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -24,7 +24,7 @@ use crate::error::LoadDumpError;
 use crate::hrana;
 use crate::namespace::{
     DumpStream, MakeNamespace, NamespaceBottomlessDbId, NamespaceName, NamespaceStore,
-    RestoreOption,
+    RestoreOption, SharedSchemaOptions,
 };
 use crate::net::Connector;
 use crate::LIBSQL_PAGE_SIZE;
@@ -280,6 +280,12 @@ struct CreateNamespaceReq {
     bottomless_db_id: Option<String>,
     jwt_key: Option<String>,
     txn_timeout_s: Option<u64>,
+    /// If true, current namespace acts as a DB used solely for multi-db schema updates.
+    #[serde(default)]
+    shared_schema: bool,
+    /// If some, this is a [NamespaceName] reference to a shared schema DB.
+    #[serde(default)]
+    shared_schema_name: Option<String>,
 }
 
 async fn handle_create_namespace<M: MakeNamespace, C: Connector>(
@@ -287,6 +293,8 @@ async fn handle_create_namespace<M: MakeNamespace, C: Connector>(
     Path(namespace): Path<String>,
     Json(req): Json<CreateNamespaceReq>,
 ) -> crate::Result<()> {
+    let shared_schema_options =
+        SharedSchemaOptions::new(req.shared_schema, req.shared_schema_name)?;
     if let Some(jwt_key) = req.jwt_key.as_deref() {
         // Check that the jwt key is correct
         parse_jwt_key(jwt_key)?;
@@ -302,10 +310,16 @@ async fn handle_create_namespace<M: MakeNamespace, C: Connector>(
         Some(db_id) => NamespaceBottomlessDbId::Namespace(db_id),
         None => NamespaceBottomlessDbId::NotProvided,
     };
+
     let namespace = NamespaceName::from_string(namespace)?;
     app_state
         .namespaces
-        .create(namespace.clone(), dump, bottomless_db_id)
+        .create(
+            namespace.clone(),
+            dump,
+            bottomless_db_id,
+            shared_schema_options,
+        )
         .await?;
 
     let store = app_state.namespaces.config_store(namespace).await?;

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -566,6 +566,7 @@ where
                     NamespaceName::default(),
                     namespace::RestoreOption::Latest,
                     NamespaceBottomlessDbId::NotProvided,
+                    None,
                 )
                 .await?;
         }

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -710,6 +710,7 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         namespace: NamespaceName,
         restore_option: RestoreOption,
         bottomless_db_id: NamespaceBottomlessDbId,
+        shared_schema: Option<SharedSchemaOptions>,
     ) -> crate::Result<()> {
         // With namespaces disabled, the default namespace can be auto-created,
         // otherwise it's an error.
@@ -833,6 +834,34 @@ impl<T: Database> Namespace<T> {
 
     pub fn stats(&self) -> Arc<Stats> {
         self.stats.clone()
+    }
+}
+
+pub enum SharedSchemaOptions {
+    Seed,
+    Link(NamespaceName),
+}
+
+impl SharedSchemaOptions {
+    pub fn new(
+        is_shared_schema: bool,
+        shared_schema_name: Option<String>,
+    ) -> crate::Result<Option<Self>> {
+        if is_shared_schema {
+            if shared_schema_name.is_some() {
+                Err(Error::SharedSchemaError(
+                    "shared-schema database cannot reference to other shared schema database"
+                        .to_string(),
+                ))
+            } else {
+                Ok(Some(Self::Seed))
+            }
+        } else if let Some(name) = shared_schema_name {
+            let ns = NamespaceName::from_string(name)?;
+            Ok(Some(SharedSchemaOptions::Link(ns)))
+        } else {
+            Ok(None)
+        }
     }
 }
 


### PR DESCRIPTION
HTTP POST for `/v1/namespaces/:namespace/create` now accepts 2 new params: 
- `shared_schema: bool` to mark that this namespace is going to work as shared schema
- `shared_schema_name: Option<String>` to reference shared schema namespace for databases using it