### PR TITLE
Enable parsing `ATTACH` statement for any db

### DIFF
--- a/libsql/src/parser.rs
+++ b/libsql/src/parser.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Result};
 use fallible_iterator::FallibleIterator;
-use sqlite3_parser::ast::{Cmd, PragmaBody, QualifiedName, Stmt, TransactionType, Expr, Id};
+use sqlite3_parser::ast::{Cmd, Expr, Id, PragmaBody, QualifiedName, Stmt, TransactionType};
 use sqlite3_parser::lexer::sql::{Parser, ParserError};
 
 /// A group of statements to be executed together.
@@ -260,5 +260,45 @@ impl Statement {
             self.kind,
             StmtKind::Read | StmtKind::TxnBeginReadOnly | StmtKind::TxnEnd
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_attach_same_db() {
+        let input = "ATTACH test AS test;";
+        let mut result = Statement::parse(input);
+
+        let stmt = result.next().unwrap().unwrap();
+        assert_eq!(stmt.kind, StmtKind::Attach);
+    }
+
+    #[test]
+    fn test_attach_database() {
+        let input = "ATTACH DATABASE test AS test;";
+        let mut result = Statement::parse(input);
+
+        let stmt = result.next().unwrap().unwrap();
+        assert_eq!(stmt.kind, StmtKind::Attach);
+    }
+
+    #[test]
+    fn test_attach_diff_db() {
+        let input = "ATTACH \"random\" AS test;";
+        let mut result = Statement::parse(input);
+
+        let stmt = result.next().unwrap().unwrap();
+        assert_eq!(stmt.kind, StmtKind::Attach);
+    }
+
+    #[test]
+    fn test_attach_database_diff_db() {
+        let input = "ATTACH DATABASE \"random\" AS test;";
+        let mut result = Statement::parse(input);
+
+        let stmt = result.next().unwrap().unwrap();
+        assert_eq!(stmt.kind, StmtKind::Attach);
     }
 }

--- a/libsql/src/parser.rs
+++ b/libsql/src/parser.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, Result};
 use fallible_iterator::FallibleIterator;
-use sqlite3_parser::ast::{Cmd, Expr, Id, PragmaBody, QualifiedName, Stmt, TransactionType};
+use sqlite3_parser::ast::{Cmd, PragmaBody, QualifiedName, Stmt, TransactionType};
 use sqlite3_parser::lexer::sql::{Parser, ParserError};
 
 /// A group of statements to be executed together.
@@ -118,11 +118,7 @@ impl StmtKind {
                 savepoint_name: Some(_),
                 ..
             }) => Some(Self::Release),
-            Cmd::Stmt(Stmt::Attach {
-                expr: Expr::Id(Id(expr)),
-                db_name: Expr::Id(Id(name)),
-                ..
-            }) if expr == name => Some(Self::Attach),
+            Cmd::Stmt(Stmt::Attach { .. }) => Some(Self::Attach),
             Cmd::Stmt(Stmt::Detach(_)) => Some(Self::Detach),
             _ => None,
         }


### PR DESCRIPTION
- Enable parsing `ATTACH` statement for any db
- Add tests for parsing `ATTACH` statements