### PR TITLE
Fix configuration not being synced with replicas

### DIFF
--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -840,6 +840,10 @@ impl<T: Database> Namespace<T> {
     pub fn stats(&self) -> Arc<Stats> {
         self.stats.clone()
     }
+
+    pub fn config_changed(&self) -> impl Future<Output = ()> {
+        self.db_config_store.changed()
+    }
 }
 
 pub struct ReplicaNamespaceConfig {

--- a/libsql-server/src/rpc/replication_log.rs
+++ b/libsql-server/src/rpc/replication_log.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, RwLock};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::stream::BoxStream;
+use futures_core::Future;
 pub use libsql_replication::rpc::replication as rpc;
 use libsql_replication::rpc::replication::replication_log_server::ReplicationLog;
 use libsql_replication::rpc::replication::{
@@ -13,7 +14,7 @@ use libsql_replication::rpc::replication::{
     NEED_SNAPSHOT_ERROR_MSG, NO_HELLO_ERROR_MSG, SESSION_TOKEN_KEY,
 };
 use md5::{Digest, Md5};
-use tokio_stream::StreamExt;
+use tokio_stream::StreamExt as _;
 use tonic::transport::server::TcpConnectInfo;
 use tonic::Status;
 use uuid::Uuid;
@@ -139,18 +140,20 @@ impl ReplicationLogService {
             Arc<DatabaseConfig>,
             usize,
             Arc<Stats>,
+            impl Future<Output = ()>,
         ),
         Status,
     > {
-        let (logger, config, version, stats) = self
+        let (logger, config, version, stats, config_changed) = self
             .namespaces
             .with(namespace, |ns| {
                 let logger = ns.db.wal_manager.wrapped().logger().clone();
+                let config_changed = ns.config_changed();
                 let config = ns.config();
                 let version = ns.config_version();
                 let stats = ns.stats();
 
-                (logger, config, version, stats)
+                (logger, config, version, stats, config_changed)
             })
             .await
             .map_err(|e| {
@@ -165,7 +168,7 @@ impl ReplicationLogService {
             self.verify_session_token(req, version)?;
         }
 
-        Ok((logger, config, version, stats))
+        Ok((logger, config, version, stats, config_changed))
     }
 
     fn encode_session_token(&self, version: usize) -> Uuid {
@@ -249,7 +252,8 @@ impl ReplicationLog for ReplicationLogService {
 
         self.authenticate(&req, namespace.clone()).await?;
 
-        let (logger, _, _, stats) = self.logger_from_namespace(namespace, &req, true).await?;
+        let (logger, _, _, stats, config_changed) =
+            self.logger_from_namespace(namespace, &req, true).await?;
 
         let stats = if self.collect_stats {
             Some(stats)
@@ -259,12 +263,28 @@ impl ReplicationLog for ReplicationLogService {
 
         let req = req.into_inner();
 
-        let stream = StreamGuard::new(
+        let mut stream = StreamGuard::new(
             FrameStream::new(logger, req.next_offset, true, None, stats)
                 .map_err(|e| Status::internal(e.to_string()))?,
             self.idle_shutdown_layer.clone(),
         )
         .map(map_frame_stream_output);
+
+        // if only tokio_stream had futures::Stream::take_until...
+        let stream = async_stream::stream! {
+            tokio::pin!(config_changed);
+            loop {
+                tokio::select! {
+                    _ = &mut config_changed => {
+                        break
+                    },
+                    Some(next) = stream.next() => {
+                        yield next
+                    }
+                    else => break,
+                }
+            }
+        };
 
         Ok(tonic::Response::new(Box::pin(stream)))
     }
@@ -276,7 +296,7 @@ impl ReplicationLog for ReplicationLogService {
         let namespace = super::extract_namespace(self.disable_namespaces, &req)?;
         self.authenticate(&req, namespace.clone()).await?;
 
-        let (logger, _, _, stats) = self.logger_from_namespace(namespace, &req, true).await?;
+        let (logger, _, _, stats, _) = self.logger_from_namespace(namespace, &req, true).await?;
 
         let stats = if self.collect_stats {
             Some(stats)
@@ -324,7 +344,7 @@ impl ReplicationLog for ReplicationLogService {
             }
         }
 
-        let (logger, config, version, _) =
+        let (logger, config, version, _, _) =
             self.logger_from_namespace(namespace, &req, false).await?;
 
         let session_hash = self.encode_session_token(version);
@@ -348,7 +368,7 @@ impl ReplicationLog for ReplicationLogService {
         let namespace = super::extract_namespace(self.disable_namespaces, &req)?;
         self.authenticate(&req, namespace.clone()).await?;
 
-        let (logger, _, _, stats) = self.logger_from_namespace(namespace, &req, true).await?;
+        let (logger, _, _, stats, _) = self.logger_from_namespace(namespace, &req, true).await?;
 
         let stats = if self.collect_stats {
             Some(stats)


### PR DESCRIPTION
Config changes were not being replicated to the replica, because it required the replication stream to the interupted. The PR interupts the replication stream when a config change for that namespace is detected, forcing the replica into a new handshake.
