### PR TITLE
ci: fix duplicated rust suites test

### DIFF
--- a/.github/workflows/extensions-test.yml
+++ b/.github/workflows/extensions-test.yml
@@ -76,4 +76,5 @@ jobs:
       - name: test
         run: |
           cd libsql-sqlite3/test/rust_suite
-          cargo test --features extensions
+          # Only execute extensions tests
+          cargo test --features=extensions extensions


### PR DESCRIPTION
Closes: #1077 
ci: fix duplicated rust suites test
Only the `extensions` tests