### PR TITLE
Shared schema

### DIFF
--- a/libsql-server/src/error.rs
+++ b/libsql-server/src/error.rs
@@ -102,7 +102,7 @@ pub enum Error {
     #[error("Unable to decode protobuf: {0}")]
     ProstDecode(#[from] prost::DecodeError),
     #[error("Shared schema error: {0}")]
-    SharedSchemaError(String),
+    SharedSchemaCreationError(String),
 }
 
 impl AsRef<Self> for Error {
@@ -180,7 +180,7 @@ impl IntoResponse for &Error {
             MetaStoreUpdateFailure(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             Ref(this) => this.as_ref().into_response(),
             ProstDecode(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
-            SharedSchemaError(_) => self.format_err(StatusCode::BAD_REQUEST),
+            SharedSchemaCreationError(_) => self.format_err(StatusCode::BAD_REQUEST),
         }
     }
 }

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -305,7 +305,7 @@ async fn handle_create_namespace<M: MakeNamespace, C: Connector>(
             ));
         }
         let namespace = NamespaceName::from_string(ns)?;
-        if !app_state.namespaces.exists(&namespace).await {
+        if !app_state.namespaces.exists(&namespace) {
             return Err(Error::NamespaceDoesntExist(namespace.to_string()));
         }
         Some(namespace.to_string())

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -300,7 +300,7 @@ async fn handle_create_namespace<M: MakeNamespace, C: Connector>(
     }
     let shared_schema_name = if let Some(ns) = req.shared_schema_name {
         if req.shared_schema {
-            return Err(Error::SharedSchemaError(
+            return Err(Error::SharedSchemaCreationError(
                 "shared schema database cannot reference another shared schema".to_string(),
             ));
         }

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -458,9 +458,8 @@ impl<M: MakeNamespace> NamespaceStore<M> {
         })
     }
 
-    pub async fn exists(&self, namespace: &NamespaceName) -> bool {
-        let e = self.inner.store.get(namespace).await;
-        e.is_some()
+    pub fn exists(&self, namespace: &NamespaceName) -> bool {
+        self.inner.metadata.exists(namespace)
     }
 
     pub async fn destroy(&self, namespace: NamespaceName) -> crate::Result<()> {


### PR DESCRIPTION
Redo of https://github.com/tursodatabase/libsql/pull/1055

It basically stores the relationship between shared schema db and databases linked to it:

The relationships are stored in form of shared_schema_links table in the meta store of a shared-schema db.
When we create a dependent db, we store a link in shared-schema.
When we destroy dependent db, we remove link from shared-schema.
When we destroy shared-schema, we first check if all dependent dbs are already destroyed. We fail if they don't.

Some known decifiencies:
1. No way to fetch the schema links yet
2. ~~Forking a db that links to a shared schema should add a link between a new fork and a shared schema but doesn't do it right now.~~