### PR TITLE
Bottomless savepoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,7 @@ dependencies = [
  "libsql-sys",
  "libsql_replication",
  "rand",
+ "serde",
  "tokio",
  "tokio-util",
  "tracing",

--- a/bottomless/Cargo.toml
+++ b/bottomless/Cargo.toml
@@ -25,6 +25,7 @@ chrono = "0.4.23"
 uuid = "1.4.1"
 rand = "0.8.5"
 futures-core = "0.3.29"
+serde = { version = "1.0.196", features = ["derive"] }
 
 [features]
 default = []

--- a/bottomless/src/bottomless_wal.rs
+++ b/bottomless/src/bottomless_wal.rs
@@ -1,6 +1,7 @@
 use std::ffi::c_int;
 use std::sync::{Arc, Mutex};
 
+use crate::completion_progress::SavepointTracker;
 use libsql_sys::ffi::{SQLITE_BUSY, SQLITE_IOERR_WRITE};
 use libsql_sys::wal::wrapper::{WalWrapper, WrapWal};
 use libsql_sys::wal::{
@@ -26,6 +27,14 @@ impl BottomlessWalWrapper {
         match &mut *lock {
             Some(replicator) => Ok(f(replicator)),
             None => Err(Error::new(SQLITE_IOERR_WRITE)),
+        }
+    }
+
+    pub fn backup_savepoint(&self) -> Option<SavepointTracker> {
+        let lock = self.replicator.lock().unwrap();
+        match &*lock {
+            None => None,
+            Some(replicator) => Some(replicator.savepoint()),
         }
     }
 

--- a/bottomless/src/bottomless_wal.rs
+++ b/bottomless/src/bottomless_wal.rs
@@ -171,10 +171,10 @@ impl<T: Wal> WrapWal<T> for BottomlessWalWrapper {
         {
             let runtime = tokio::runtime::Handle::current();
             self.try_with_replicator(|replicator| {
-                let _prev = replicator.new_generation();
-                if let Err(e) =
-                    runtime.block_on(async move { replicator.snapshot_main_db_file().await })
-                {
+                if let Err(e) = runtime.block_on(async move {
+                    replicator.new_generation().await;
+                    replicator.snapshot_main_db_file().await
+                }) {
                     tracing::error!("Failed to snapshot the main db file during checkpoint: {e}");
                     return Err(Error::new(SQLITE_IOERR_WRITE));
                 }

--- a/bottomless/src/completion_progress.rs
+++ b/bottomless/src/completion_progress.rs
@@ -1,0 +1,42 @@
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::sync::watch::{channel, Receiver, Sender};
+
+/// Track completion progress for WAL frame segments uploaded in parallel.
+#[derive(Debug)]
+pub(crate) struct CompletionProgress {
+    baseline: u32,
+    detached_ranges: BTreeMap<u32, u32>,
+    tx: Sender<u32>,
+}
+
+impl CompletionProgress {
+    pub fn new(baseline: u32) -> (Self, Receiver<u32>) {
+        let (tx, rx) = channel(baseline);
+        let completion = CompletionProgress {
+            baseline,
+            detached_ranges: BTreeMap::new(),
+            tx,
+        };
+        (completion, rx)
+    }
+
+    pub fn update(&mut self, mut start_frame: u32, mut end_frame: u32) {
+        if start_frame - 1 == self.baseline {
+            while start_frame - 1 == self.baseline {
+                self.baseline = end_frame;
+                if let Some((s, e)) = self.detached_ranges.pop_first() {
+                    start_frame = s;
+                    end_frame = e;
+                } else {
+                    break;
+                }
+            }
+            self.tx.send_replace(self.baseline);
+        } else {
+            self.detached_ranges.insert(start_frame, end_frame);
+        }
+    }
+}

--- a/bottomless/src/completion_progress.rs
+++ b/bottomless/src/completion_progress.rs
@@ -1,8 +1,67 @@
+use anyhow::{bail, Result};
+use arc_swap::ArcSwapOption;
 use std::collections::BTreeMap;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::path::Path;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
 use tokio::sync::watch::{channel, Receiver, Sender};
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub struct SavepointTracker {
+    next_frame_no: Arc<AtomicU32>,
+    receiver: Receiver<u32>,
+    pub generation: Arc<ArcSwapOption<Uuid>>,
+    pub generation_snapshot: Receiver<Result<Option<Uuid>>>,
+    pub db_path: String,
+}
+
+impl SavepointTracker {
+    pub(crate) fn new(
+        generation: Arc<ArcSwapOption<Uuid>>,
+        generation_snapshot: Receiver<Result<Option<Uuid>>>,
+        next_frame_no: Arc<AtomicU32>,
+        receiver: Receiver<u32>,
+        db_path: String,
+    ) -> Self {
+        SavepointTracker {
+            generation,
+            generation_snapshot,
+            next_frame_no,
+            receiver,
+            db_path,
+        }
+    }
+
+    pub async fn confirm_snapshotted(&mut self) -> Result<Option<Uuid>> {
+        if Path::new(&self.db_path).try_exists()? {
+            if let Some(generation) = self.generation.load_full() {
+                let res = self
+                    .generation_snapshot
+                    .wait_for(|gen| match gen {
+                        Ok(Some(gen)) => gen == &*generation,
+                        Ok(None) => false,
+                        Err(e) => true,
+                    })
+                    .await?;
+                return match &*res {
+                    Ok(gen) => Ok(gen.clone()),
+                    Err(e) => bail!(e.to_string()),
+                };
+            }
+        }
+        Ok(None)
+    }
+
+    /// Wait until WAL segment upload has been confirmed up until the frame which number has been
+    /// snapshotted at the beginning of the call.
+    pub async fn confirmed(&mut self) -> Result<u32> {
+        let last_frame_no = self.next_frame_no.load(Ordering::SeqCst) - 1;
+        let res = *self.receiver.wait_for(|fno| *fno >= last_frame_no).await?;
+        self.confirm_snapshotted().await?;
+        Ok(res)
+    }
+}
 
 /// Track completion progress for WAL frame segments uploaded in parallel.
 #[derive(Debug)]
@@ -38,5 +97,9 @@ impl CompletionProgress {
         } else {
             self.detached_ranges.insert(start_frame, end_frame);
         }
+    }
+
+    pub(crate) fn subscribe(&mut self) -> Receiver<u32> {
+        self.tx.subscribe()
     }
 }

--- a/bottomless/src/completion_progress.rs
+++ b/bottomless/src/completion_progress.rs
@@ -11,9 +11,9 @@ use uuid::Uuid;
 pub struct SavepointTracker {
     next_frame_no: Arc<AtomicU32>,
     receiver: Receiver<u32>,
-    pub generation: Arc<ArcSwapOption<Uuid>>,
-    pub generation_snapshot: Receiver<Result<Option<Uuid>>>,
-    pub db_path: String,
+    generation: Arc<ArcSwapOption<Uuid>>,
+    generation_snapshot: Receiver<Result<Option<Uuid>>>,
+    db_path: String,
 }
 
 impl SavepointTracker {
@@ -41,7 +41,7 @@ impl SavepointTracker {
                     .wait_for(|gen| match gen {
                         Ok(Some(gen)) => gen == &*generation,
                         Ok(None) => false,
-                        Err(e) => true,
+                        Err(_) => true,
                     })
                     .await?;
                 return match &*res {
@@ -97,9 +97,5 @@ impl CompletionProgress {
         } else {
             self.detached_ranges.insert(start_frame, end_frame);
         }
-    }
-
-    pub(crate) fn subscribe(&mut self) -> Receiver<u32> {
-        self.tx.subscribe()
     }
 }

--- a/bottomless/src/lib.rs
+++ b/bottomless/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod backup;
 pub mod bottomless_wal;
+mod completion_progress;
 pub mod read;
 pub mod replicator;
 pub mod transaction_cache;

--- a/bottomless/src/lib.rs
+++ b/bottomless/src/lib.rs
@@ -10,3 +10,5 @@ pub mod replicator;
 pub mod transaction_cache;
 pub mod uuid_utils;
 mod wal;
+
+pub use crate::completion_progress::{BackupThreshold, SavepointTracker};

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -1,4 +1,5 @@
 use crate::backup::WalCopier;
+use crate::completion_progress::CompletionProgress;
 use crate::read::BatchReader;
 use crate::uuid_utils::decode_unix_timestamp;
 use crate::wal::WalFileReader;
@@ -24,6 +25,7 @@ use std::sync::Arc;
 use tokio::fs::{File, OpenOptions};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::watch::{channel, Receiver, Sender};
+use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio::task::JoinSet;
 use tokio::time::Duration;
@@ -65,6 +67,8 @@ pub struct Replicator {
     max_frames_per_batch: usize,
     s3_upload_max_parallelism: usize,
     join_set: JoinSet<()>,
+    upload_progress: Arc<Mutex<CompletionProgress>>,
+    last_uploaded_frame_no: Receiver<u32>,
 }
 
 #[derive(Debug)]
@@ -317,27 +321,31 @@ impl Replicator {
             })
         };
 
+        let (upload_progress, last_uploaded_frame_no) = CompletionProgress::new(0);
+        let upload_progress = Arc::new(Mutex::new(upload_progress));
         let _s3_upload = {
             let client = client.clone();
             let bucket = options.bucket_name.clone();
             let max_parallelism = options.s3_upload_max_parallelism;
+            let upload_progress = upload_progress.clone();
             join_set.spawn(async move {
                 let sem = Arc::new(tokio::sync::Semaphore::new(max_parallelism));
                 let mut join_set = JoinSet::new();
-                while let Some(fdesc) = frames_inbox.recv().await {
-                    tracing::trace!("Received S3 upload request: {}", fdesc);
+                while let Some(req) = frames_inbox.recv().await {
+                    tracing::trace!("Received S3 upload request: {}", req.path);
                     let start = Instant::now();
                     let sem = sem.clone();
                     let permit = sem.acquire_owned().await.unwrap();
                     let client = client.clone();
                     let bucket = bucket.clone();
+                    let upload_progress = upload_progress.clone();
                     join_set.spawn(async move {
-                        let fpath = format!("{}/{}", bucket, fdesc);
+                        let fpath = format!("{}/{}", bucket, req.path);
                         let body = ByteStream::from_path(&fpath).await.unwrap();
                         if let Err(e) = client
                             .put_object()
                             .bucket(bucket)
-                            .key(fdesc)
+                            .key(req.path)
                             .body(body)
                             .send()
                             .await
@@ -347,6 +355,10 @@ impl Replicator {
                             tokio::fs::remove_file(&fpath).await.unwrap();
                             let elapsed = Instant::now() - start;
                             tracing::debug!("Uploaded to S3: {} in {:?}", fpath, elapsed);
+                        }
+                        if let Some(frames) = req.frames {
+                            let mut up = upload_progress.lock().await;
+                            up.update(*frames.start(), *frames.end());
                         }
                         drop(permit);
                     });
@@ -375,6 +387,8 @@ impl Replicator {
             max_frames_per_batch: options.max_frames_per_batch,
             s3_upload_max_parallelism: options.s3_upload_max_parallelism,
             join_set,
+            upload_progress,
+            last_uploaded_frame_no,
         })
     }
 
@@ -464,6 +478,16 @@ impl Replicator {
         } else {
             Ok(false)
         }
+    }
+
+    pub async fn savepoint(&mut self) -> Result<u32> {
+        self.wait_until_snapshotted().await?;
+        let frame_no = self.last_known_frame();
+        let res = self
+            .last_uploaded_frame_no
+            .wait_for(|frame| *frame >= frame_no)
+            .await?;
+        Ok(*res)
     }
 
     /// Waits until the commit for a given frame_no or higher was given.
@@ -1211,6 +1235,10 @@ impl Replicator {
         }
 
         db.shutdown().await?;
+        {
+            let mut guard = self.upload_progress.lock().await;
+            guard.update(1, last_frame);
+        }
 
         if applied_wal_frame {
             tracing::info!("WAL file has been applied onto database file in generation {}. Requesting snapshot.", generation);

--- a/libsql-server/src/database/primary.rs
+++ b/libsql-server/src/database/primary.rs
@@ -1,3 +1,4 @@
+use bottomless::SavepointTracker;
 use std::sync::Arc;
 
 use bottomless::bottomless_wal::BottomlessWalWrapper;
@@ -49,5 +50,14 @@ impl PrimaryDatabase {
         }
 
         Ok(())
+    }
+
+    pub fn backup_savepoint(&self) -> Result<Option<SavepointTracker>> {
+        if let Some(wal) = self.wal_manager.wrapper() {
+            if let Some(savepoint) = wal.backup_savepoint() {
+                return Ok(Some(savepoint));
+            }
+        }
+        Ok(None)
     }
 }

--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -96,7 +96,7 @@ impl MetaStoreInner {
                 // TODO: this logic should probably be moved to bottomless.
                 match action {
                     bottomless::replicator::RestoreAction::SnapshotMainDbFile => {
-                        replicator.new_generation();
+                        replicator.new_generation().await;
                         if let Some(_handle) = replicator.snapshot_main_db_file().await? {
                             tracing::trace!(
                                 "got snapshot handle after restore with generation upgrade"

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -777,7 +777,7 @@ pub async fn init_bottomless_replicator(
     let (action, did_recover) = replicator.restore(generation, timestamp).await?;
     match action {
         bottomless::replicator::RestoreAction::SnapshotMainDbFile => {
-            replicator.new_generation();
+            replicator.new_generation().await;
             if let Some(_handle) = replicator.snapshot_main_db_file().await? {
                 tracing::trace!("got snapshot handle after restore with generation upgrade");
             }


### PR DESCRIPTION
This PR introduces a new feature to bottomless - ability to materialise tracker object, that can be awaited for in order to confirm that bottomless asynchronous upload matched the replication status at the moment of method call.