### PR TITLE
docs: updated docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Use ".open FILENAME" to reopen on a persistent database.
 libsql>
 ```
 
+### Docker
+To run libSQL using docker, refer to the [Docker Docs](docs/DOCKER.md)
+
 ## Why a fork?
 
 SQLite has solidified its place in modern technology stacks, embedded in nearly any computing device you can think of. Its open source nature and public domain availability make it a popular choice for modification to meet specific use cases.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,30 +1,110 @@
 # Docker image quick reference
 
-# How to use this image
-
 ## Launch a primary instance
 
 ```
-docker run --name some-sqld -e SQLD_NODE=primary -d ghcr.io/libsql/sqld:main
+docker run --name some-sqld -p 8080:8080 -ti \ 
+    -e SQLD_NODE=primary \
+    ghcr.io/tursodatabase/libsql-server:main
 ```
 
 ## Launch a replica instance
 
 ```
-docker run --name some-sqld -e SQLD_NODE=replica -D SQLD_PRIMARY_URL=https://<host>:<port> -d ghcr.io/libsql/sqld:main
+docker run --name some-sqld-replica -p 8081:8080 -ti 
+    -e SQLD_NODE=replica \
+    -e SQLD_PRIMARY_URL=https://<host>:<port> \
+    ghcr.io/tursodatabase/libsql-server:main
+````
+
+## Running on Apple Silicon
+
+```
+docker run --name some-sqld  -p 8080:8080 -ti \ 
+    -e SQLD_NODE=primary \
+    --platform linux/amd64 \
+    ghcr.io/tursodatabase/libsql-server:main
 ```
 
+_Note: the latest images for arm64 are available under the tag
+`ghcr.io/tursodatabase/libsql-server:latest-arm`, however for tagged versions,
+and stable releases please use the x86_64 versions via Rosetta._
+
+## Docker Repository
+
+[https://github.com/tursodatabase/libsql/pkgs/container/libsql-server](https://github.com/tursodatabase/libsql/pkgs/container/libsql-server)
+
 # How to extend this image
+
+## Data Persistance
+
+Database files are stored in the `/var/lib/sqld` in the image. To persist the 
+database across runs, mount this location to either a docker volume or a bind 
+mount on your local disk.
+
+```
+docker run --name some-sqld -ti \
+    -v ./.data/libsql \
+    -e SQLD_NODE=primary \ 
+    ghcr.io/tursodatabase/libsql-server:main
+```
 
 ## Environment variables
 
 ### `SQLD_NODE`
 
-The `SQLD_NODE` environment variable configures the type of the launched instance. Possible values are: `primary` (default), `replica`, and `standalone`.
-Please note that replica instances also need the `SQLD_PRIMARY_URL` environment variable to be defined.
+**default:** `primary`
+
+The `SQLD_NODE` environment variable configures the type of the launched
+instance. Possible values are: `primary` (default), `replica`, and `standalone`.
+Please note that replica instances also need the `SQLD_PRIMARY_URL` environment
+variable to be defined.
 
 ### `SQLD_PRIMARY_URL`
 
 The `SQLD_PRIMARY_URL` environment variable configures the gRPC URL of the primary instance for replica instances.
 
 **See:** `SQLD_NODE` environment variable
+
+### `SQLD_DB_PATH`
+
+**default:** `iku.db`
+
+The location of the db file inside the container. Specifying only a filename
+will place the file in the default directory inside the container at
+`/var/lib/sqld`.
+
+### `SQLD_HTTP_LISTEN_ADDR`
+
+**default:** `0.0.0.0:8080`
+
+Defines the HTTP listen address that sqld listens on and clients will connect
+to. Recommended to leave this on the default port and remap ports at the
+container networking level.
+
+### `SQLD_GRPC_LISTEN_ADDR`
+
+**default:** `0.0.0.0:5001`
+
+Defines the GRPC listen address and port for sqld. Primarily used for
+inter-node communication. Recommended to leave this on default.
+
+
+## Docker Compose
+
+Simple docker compose for local development:
+
+```
+version: "3"
+services:
+  db:
+    image: ghcr.io/tursodatabase/libsql-server:main
+    platform: linux/amd64
+    ports:
+      - "8080:8080"
+      - "5001:5001"
+    # environment:
+    #   - SQLD_NODE=primary
+    volumes:
+      - ./data/libsql:/var/lib/sqld
+```


### PR DESCRIPTION
**Summary of changes:**

* Updated `DOCKER.md` with new repository location
* Added link from README to DOCKER.md for Docker instructions
* Added Apple Silicon instructions (with caveat about tags)
* Added instructions for database persistence for dockerized instances
* Added sample docker compose file for non-production environments
* Added additional detail on environment variables used by dockerized version
* Fixed replica run command (see note below)

**Rationale:**

Spent the morning trying to figure out how to get Docker working in deterministic dev environments and ci pipelines. Required digging through source code and issues to realize the docker repo had moved, tags and arch were not the same as other dockerized DBs, and docker persistence documentation was hiding under the build instructions. 

This additional documentation should help prevent others from experiencing the same consternation and hopefully reduce friction for adoption in more formal application development settings.

_Additional Notes:_

**Replicas:** Replica instructions were based on the original version of the doc and corrected for a typo in the environment variable flag; however I was not able to get the replica to handshake with the primary node. I'll open a separate issue with details on how to recreate.

**Arm/Apple Silicon:** Since, I assume, the dockerized version is provided out of convenience, but not officially supported by any formal effort, the `arm64` is even less supported. As such, for now I've updated the instructions to recommend using Rosetta if on Apple Silicon, which will comprise the lionshare of the `arm64` use-cases, and as release/stable versions only seem to be available in `amd64`.