### PR TITLE
Add query percentile support to stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,7 @@ checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
  "base64",
  "byteorder",
+ "crossbeam-channel",
  "flate2",
  "nom",
  "num-traits",
@@ -2794,6 +2795,7 @@ dependencies = [
  "futures",
  "futures-core",
  "hashbrown 0.14.3",
+ "hdrhistogram",
  "hmac",
  "http-body",
  "hyper",

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -81,6 +81,7 @@ aes = { version = "0.8.3", optional = true }
 cbc = { version = "0.1.2", optional = true }
 zerocopy = { version = "0.7.28", features = ["derive", "alloc"] }
 hashbrown = { version = "0.14.3", features = ["serde"] }
+hdrhistogram = "7.5.4"
 
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive_arbitrary"] }

--- a/libsql-server/src/http/admin/stats.rs
+++ b/libsql-server/src/http/admin/stats.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use hdrhistogram::Histogram;
 use itertools::Itertools;
@@ -27,7 +28,7 @@ pub struct StatsResponse {
     pub embedded_replica_frames_replicated: u64,
     pub query_count: u64,
     pub elapsed_ms: u64,
-    pub queries: QueriesStatsResponse,
+    pub queries: Option<QueriesStatsResponse>,
 }
 
 impl From<&Stats> for StatsResponse {
@@ -67,8 +68,9 @@ impl From<Stats> for StatsResponse {
     }
 }
 
-#[derive(Serialize)]
-pub struct QueriesStatsPercentiles {
+#[derive(Serialize, Default)]
+pub struct QueriesLatencyStats {
+    pub sum: u64,
     pub p50: u64,
     pub p75: u64,
     pub p90: u64,
@@ -77,9 +79,10 @@ pub struct QueriesStatsPercentiles {
     pub p999: u64,
 }
 
-impl From<&Histogram<u32>> for QueriesStatsPercentiles {
-    fn from(hist: &Histogram<u32>) -> Self {
-        QueriesStatsPercentiles {
+impl QueriesLatencyStats {
+    fn from(hist: &Histogram<u32>, sum: &Duration) -> Self {
+        QueriesLatencyStats {
+            sum: sum.as_millis() as u64,
             p50: hist.value_at_percentile(50.0),
             p75: hist.value_at_percentile(75.0),
             p90: hist.value_at_percentile(90.0),
@@ -90,28 +93,37 @@ impl From<&Histogram<u32>> for QueriesStatsPercentiles {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Default)]
 pub struct QueriesStatsResponse {
-    pub id: Option<Uuid>,
+    pub id: Uuid,
+    pub created_at: u64,
+    pub count: u64,
     pub stats: Vec<QueryAndStats>,
-    pub quantiles: Option<QueriesStatsPercentiles>,
+    pub elapsed: QueriesLatencyStats,
 }
 
-impl From<&Stats> for QueriesStatsResponse {
+impl From<&Stats> for Option<QueriesStatsResponse> {
     fn from(stats: &Stats) -> Self {
         let queries = stats.get_queries().read().unwrap();
-        Self {
-            id: queries.id(),
-            quantiles: queries.hist().as_ref().map(|h| h.into()),
-            stats: queries
-                .stats()
-                .iter()
-                .map(|(k, v)| QueryAndStats {
-                    query: k.clone(),
-                    elapsed_ms: v.elapsed.as_millis() as u64,
-                    stat: v.clone(),
-                })
-                .collect_vec(),
+        if queries.as_ref().map_or(true, |q| q.expired()) {
+            Self::default()
+        } else {
+            let queries = queries.as_ref().unwrap();
+            Some(QueriesStatsResponse {
+                id: queries.id(),
+                created_at: queries.created_at().timestamp() as u64,
+                count: queries.count(),
+                elapsed: QueriesLatencyStats::from(queries.hist(), &queries.elapsed()),
+                stats: queries
+                    .stats()
+                    .iter()
+                    .map(|(k, v)| QueryAndStats {
+                        query: k.clone(),
+                        elapsed_ms: v.elapsed.as_millis() as u64,
+                        stat: v.clone(),
+                    })
+                    .collect_vec(),
+            })
         }
     }
 }

--- a/libsql-server/src/http/admin/stats.rs
+++ b/libsql-server/src/http/admin/stats.rs
@@ -67,9 +67,20 @@ impl From<Stats> for StatsResponse {
 }
 
 #[derive(Serialize)]
+pub struct QueriesStatsPercentiles {
+    pub p50: u64,
+    pub p75: u64,
+    pub p90: u64,
+    pub p95: u64,
+    pub p99: u64,
+    pub p999: u64,
+}
+
+#[derive(Serialize)]
 pub struct QueriesStatsResponse {
     pub id: Option<Uuid>,
     pub stats: Vec<QueryAndStats>,
+    pub quantiles: Option<QueriesStatsPercentiles>,
 }
 
 impl From<&Stats> for QueriesStatsResponse {
@@ -86,6 +97,16 @@ impl From<&Stats> for QueriesStatsResponse {
                     stat: v.clone(),
                 })
                 .collect_vec(),
+            quantiles: queries.hist().as_ref().map_or(None, |hist| {
+                Some(QueriesStatsPercentiles {
+                    p50: hist.value_at_percentile(50.0),
+                    p75: hist.value_at_percentile(75.0),
+                    p90: hist.value_at_percentile(90.0),
+                    p95: hist.value_at_percentile(95.0),
+                    p99: hist.value_at_percentile(99.0),
+                    p999: hist.value_at_percentile(99.9),
+                })
+            }),
         }
     }
 }

--- a/libsql-server/src/stats.rs
+++ b/libsql-server/src/stats.rs
@@ -158,6 +158,10 @@ impl QueriesStats {
     pub(crate) fn stats(&self) -> &HashMap<String, QueryStats> {
         &self.stats
     }
+
+    pub(crate) fn hist(&self) -> &Option<Histogram<u32>> {
+        &self.hist
+    }
 }
 
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
This uses `hdrhistogram` to record `p50`, `p75`, `p90`, `p95`, `p99`, and `p99.9` of query latency.

If it works well, we may decide to add it per query too.


---

`hdrhistogram` uses constant memory given its range and `sigfig` parameter.
So usage does not go up as we add more records.

I've decided not to use the bounded version of the histogram because even though our latency should be below hundreds of thousands of milliseconds, I didn't want to risk an error or panic.


Some benchmarks around memory usage:

```
memory footprint with sigfig 2 and no records: ~1024
memory footprint with sigfig 2 and records between 0 and 1000: ~2048
memory footprint with sigfig 2 and records between 0 and 5000: ~3584
memory footprint with sigfig 2 and records between 0 and 100000: ~4096
memory footprint with sigfig 2 and records between 0 and 200000: ~4608

memory footprint with sigfig 3 and no records: ~8192
memory footprint with sigfig 3 and records between 0 and 1000: ~8192
memory footprint with sigfig 3 and records between 0 and 5000: ~16384
memory footprint with sigfig 3 and records between 0 and 100000: ~20480
memory footprint with sigfig 3 and records between 0 and 200000: ~24576
```

We should see an 8~16kb overhead per namespace in most cases.
I think that is acceptable, but let me know if it isn't. 