### PR TITLE
Reset query stats every hour and smaller improvements

### DIFF
--- a/libsql-server/src/http/admin/stats.rs
+++ b/libsql-server/src/http/admin/stats.rs
@@ -93,6 +93,8 @@ impl From<&Histogram<u32>> for QueriesStatsPercentiles {
 #[derive(Serialize)]
 pub struct QueriesStatsResponse {
     pub id: Option<Uuid>,
+    pub count: Option<u64>,
+    pub elapsed_ms: u64,
     pub stats: Vec<QueryAndStats>,
     pub quantiles: Option<QueriesStatsPercentiles>,
 }
@@ -103,6 +105,8 @@ impl From<&Stats> for QueriesStatsResponse {
         Self {
             id: queries.id(),
             quantiles: queries.hist().as_ref().map(|h| h.into()),
+            count: queries.count(),
+            elapsed_ms: queries.elapsed().as_millis() as u64,
             stats: queries
                 .stats()
                 .iter()

--- a/libsql-server/src/stats.rs
+++ b/libsql-server/src/stats.rs
@@ -91,6 +91,8 @@ pub struct QueriesStats {
     #[serde(default)]
     stats: HashMap<String, QueryStats>,
     #[serde(skip)]
+    elapsed: Duration,
+    #[serde(skip)]
     stats_threshold: u64,
     #[serde(skip)]
     hist: Option<Histogram<u32>>,
@@ -108,6 +110,8 @@ impl QueriesStats {
     }
 
     fn register_query(&mut self, sql: &String, stat: QueryStats) {
+        self.elapsed += stat.elapsed;
+
         if let Some(hist) = self.hist.as_mut() {
             let _ = hist.record(stat.elapsed.as_millis() as u64);
         }
@@ -168,6 +172,14 @@ impl QueriesStats {
 
     pub(crate) fn start(&self) -> &DateTime<Utc> {
         &self.start
+    }
+
+    pub(crate) fn elapsed(&self) -> &Duration {
+        &self.elapsed
+    }
+
+    pub(crate) fn count(&self) -> Option<u64> {
+        self.hist.as_ref().map(|h| h.len() as u64)
     }
 }
 

--- a/libsql-server/src/stats.rs
+++ b/libsql-server/src/stats.rs
@@ -89,9 +89,9 @@ pub struct QueriesStats {
     #[serde(default)]
     id: Option<Uuid>,
     #[serde(default)]
-    stats_threshold: AtomicU64,
-    #[serde(default)]
     stats: HashMap<String, QueryStats>,
+    #[serde(skip)]
+    stats_threshold: u64,
     #[serde(skip)]
     hist: Option<Histogram<u32>>,
     #[serde(skip)]
@@ -118,7 +118,7 @@ impl QueriesStats {
         };
 
         debug!("query: {}, elapsed: {:?}", sql, aggregated.elapsed);
-        if (aggregated.elapsed.as_micros() as u64) < self.stats_threshold.load(Ordering::Relaxed) {
+        if (aggregated.elapsed.as_micros() as u64) < self.stats_threshold {
             return;
         }
 
@@ -143,8 +143,7 @@ impl QueriesStats {
 
     fn update_threshold(&mut self) {
         if let Some((_, v)) = self.min() {
-            self.stats_threshold
-                .store(v.elapsed.as_micros() as u64, Ordering::Relaxed);
+            self.stats_threshold = v.elapsed.as_micros() as u64;
         }
     }
 


### PR DESCRIPTION
On the same thread that updates stats, we check if we need to reset
the query stats every minute. We could check at every `stats.update` call, 
but that would require a syscall to get the current time.

To decide if we should reset the stats, we get the current time and
truncate it to the current hour and compare it to the truncated hour
stored in the queries stats struct. That gives us the benefit of
always resetting query stats at the beginning of the hour, which
makes aggregating statistics with an hourly granularity easier.
