### PR TITLE
Reset query stats at the beginning of every hour

### DIFF
--- a/libsql-server/src/http/admin/stats.rs
+++ b/libsql-server/src/http/admin/stats.rs
@@ -96,6 +96,7 @@ impl QueriesLatencyStats {
 #[derive(Serialize, Default)]
 pub struct QueriesStatsResponse {
     pub id: Uuid,
+    pub created_at: u64,
     pub count: u64,
     pub stats: Vec<QueryAndStats>,
     pub elapsed: QueriesLatencyStats,
@@ -110,6 +111,7 @@ impl From<&Stats> for Option<QueriesStatsResponse> {
         let queries = queries.as_ref().unwrap();
         Some(QueriesStatsResponse {
             id: queries.id(),
+            created_at: queries.created_at().timestamp() as u64,
             count: queries.count(),
             elapsed: QueriesLatencyStats::from(queries.hist(), &queries.elapsed()),
             stats: queries

--- a/libsql-server/src/stats.rs
+++ b/libsql-server/src/stats.rs
@@ -256,9 +256,6 @@ impl Stats {
 
         let (update_sender, update_receiver) = mpsc::channel(256);
 
-        this.queries = Arc::new(RwLock::new(Some(
-            QueriesStats::with_expiration(next_hour()),
-        )));
         this.namespace = namespace;
         this.sender = Some(update_sender);
 

--- a/libsql-server/src/stats.rs
+++ b/libsql-server/src/stats.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock, Weak};
 
-use chrono::{DurationRound, Utc};
+use chrono::{DateTime, DurationRound, Utc};
 use hdrhistogram::Histogram;
 use metrics::{counter, gauge, histogram, increment_counter};
 use serde::{Deserialize, Serialize};
@@ -91,6 +91,7 @@ pub struct QueriesStats {
     stats_threshold: u64,
     hist: Histogram<u32>,
     expires_at: Option<Instant>,
+    created_at: DateTime<Utc>,
 }
 
 impl QueriesStats {
@@ -102,6 +103,7 @@ impl QueriesStats {
             stats_threshold: 0,
             hist: Histogram::<u32>::new(3).unwrap(),
             expires_at: None,
+            created_at: Utc::now(),
         }
     }
 
@@ -178,6 +180,10 @@ impl QueriesStats {
 
     pub(crate) fn count(&self) -> u64 {
         self.hist.len() as u64
+    }
+
+    pub(crate) fn created_at(&self) -> &DateTime<Utc> {
+        &self.created_at
     }
 }
 


### PR DESCRIPTION
Replaces https://github.com/tursodatabase/libsql/pull/1116

Example of stats API response:
```json
{
  "id": "9bc71983-6631-49b8-8bf8-ba5e2d8abca0",
  "rows_read_count": 270380571,
  "rows_written_count": 38406,
  "storage_bytes_used": 409600,
  "write_requests_delegated": 0,
  "replication_index": 99,
  "top_queries": [...],
  "slowest_queries": [...],
  "embedded_replica_frames_replicated": 0,
  "query_count": 233,
  "elapsed_ms": 27159,
  "queries": {
    "id": "0268dcf7-d755-494d-8791-e698f6c0e4f9",
    "created_at": 1709311047,
    "count": 44,
    "stats": [
      {
        "query": "SELECT * FROM a LIMIT 10000;",
        "elapsed_ms": 189,
        "count": 18,
        "rows_written": 0,
        "rows_read": 180000
      },
      {
        "query": "SELECT * FROM a LIMIT 1000;",
        "elapsed_ms": 37,
        "count": 23,
        "rows_written": 0,
        "rows_read": 23000
      },
      {
        "query": "SELECT * FROM a LIMIT 1000000;",
        "elapsed_ms": 38,
        "count": 1,
        "rows_written": 0,
        "rows_read": 49158
      },
      {
        "query": "SELECT * FROM a LIMIT 100000;",
        "elapsed_ms": 83,
        "count": 2,
        "rows_written": 0,
        "rows_read": 98316
      }
    ],
    "elapsed": {
      "sum": 349,
      "p50": 2,
      "p75": 10,
      "p90": 13,
      "p95": 38,
      "p99": 43,
      "p999": 43
    }
  }
}
```