### PR TITLE
Embedded replicas encryption test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,6 +130,8 @@ jobs:
       env:
         LIBSQL_EXPERIMENTAL_PAGER: 1000
       run: cargo nextest run
+    - name: embedded replica encryption tests
+      run: cargo test -F test-encryption --package libsql-server --test tests embedded_replica
 
   # test-rust-wasm:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,6 +130,8 @@ jobs:
       env:
         LIBSQL_EXPERIMENTAL_PAGER: 1000
       run: cargo nextest run
+    - name: clean build dir
+      run: rm -rf libsql-ffi/bundled/SQLite3MultipleCiphers/build
     - name: embedded replica encryption tests
       run: cargo test -F test-encryption --package libsql-server --test tests embedded_replica
 

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -90,7 +90,7 @@ aws-sdk-s3 = "0.28"
 env_logger = "0.10"
 hyper = { version = "0.14", features = ["client"] }
 insta = { version = "1.26.0", features = ["json"] }
-libsql = { path = "../libsql/", features = ["encryption"]}
+libsql = { path = "../libsql/"}
 libsql-client = { version = "0.6.5", default-features = false, features = ["reqwest_backend"] }
 proptest = "1.0.0"
 rand = "0.8.5"
@@ -111,3 +111,4 @@ debug-tools = ["console-subscriber", "rusqlite/trace", "tokio/tracing"]
 wasm-udfs = ["rusqlite/libsql-wasm-experimental"]
 unix-excl-vfs = ["libsql-sys/unix-excl-vfs"]
 encryption = ["dep:aes", "dep:cbc", "libsql-sys/encryption", "libsql_replication/encryption", "bottomless/encryption"]
+test-encryption = ["libsql/encryption"]

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -90,7 +90,7 @@ aws-sdk-s3 = "0.28"
 env_logger = "0.10"
 hyper = { version = "0.14", features = ["client"] }
 insta = { version = "1.26.0", features = ["json"] }
-libsql = { path = "../libsql/" }
+libsql = { path = "../libsql/", features = ["encryption"]}
 libsql-client = { version = "0.6.5", default-features = false, features = ["reqwest_backend"] }
 proptest = "1.0.0"
 rand = "0.8.5"


### PR DESCRIPTION
When run with:
```
cargo test -F encryption --package libsql-server --test tests embedded_replica::embedded_replica_with_encryption
```

Fails with:
```
running 1 test
2024-03-04T13:28:35.019664Z ERROR tests::embedded_replica: sqlite error 21: API call with invalid database connection pointer
2024-03-04T13:28:35.019716Z ERROR tests::embedded_replica: sqlite error 21: misuse at line 180340 of [17129ba1ff]
2024-03-04T13:28:35.599894Z ERROR tests::embedded_replica: sqlite error 1555: abort at 15 in [INSERT INTO user (id) VALUES (1), (1);]: UNIQUE constraint failed: user.id
2024-03-04T13:28:35.604323Z ERROR tests::embedded_replica: sqlite error 21: API call with invalid database connection pointer
2024-03-04T13:28:35.604336Z ERROR tests::embedded_replica: sqlite error 21: misuse at line 180340 of [17129ba1ff]
2024-03-04T13:28:35.762028Z ERROR tests::embedded_replica: sqlite error 11: database corruption at line 96148 of [17129ba1ff]
2024-03-04T13:28:35.762057Z ERROR tests::embedded_replica: sqlite error 11: statement aborts at 4: [] database disk image is malformed
2024-03-04T13:28:35.762071Z ERROR tests::embedded_replica: sqlite error 11: database disk image is malformed in "PRAGMA journal_mode='WAL'"
2024-03-04T13:28:35.765014Z ERROR tests::embedded_replica: sqlite error 28: file unlinked while open: /private/var/folders/_y/nj5hcsh93l12tmsszxgx7ntr0000gn/T/.tmp9VBWrV/dbs/foo/data
2024-03-04T13:28:35.766108Z ERROR tests::embedded_replica: sqlite error 28: file unlinked while open: /private/var/folders/_y/nj5hcsh93l12tmsszxgx7ntr0000gn/T/.tmp9VBWrV/dbs/foo/data
2024-03-04T13:28:35.767147Z ERROR tests::embedded_replica: sqlite error 28: file unlinked while open: /private/var/folders/_y/nj5hcsh93l12tmsszxgx7ntr0000gn/T/.tmp9VBWrV/metastore/data
test embedded_replica::embedded_replica_with_encryption ... FAILED

failures:

---- embedded_replica::embedded_replica_with_encryption stdout ----
thread 'embedded_replica::embedded_replica_with_encryption' panicked at libsql-server/tests/embedded_replica/mod.rs:283:15:
called `Result::unwrap()` on an `Err` value: Replication(Injector(Sqlite(SqliteFailure(Error { code: DatabaseCorrupt, extended_code: 11 }, Some("database disk image is malformed")))))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    embedded_replica::embedded_replica_with_encryption

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 52 filtered out; finished in 0.75s

error: test failed, to rerun pass `-p libsql-server --test tests`
```