### PR TITLE
libsql: Rename `periodic_sync` to `sync_interval`

### DIFF
--- a/libsql-server/tests/embedded_replica/mod.rs
+++ b/libsql-server/tests/embedded_replica/mod.rs
@@ -738,7 +738,7 @@ fn freeze() {
 }
 
 #[test]
-fn periodic_sync() {
+fn sync_interval() {
     let mut sim = Builder::new().build();
 
     let tmp_embedded = tempdir().unwrap();
@@ -761,7 +761,7 @@ fn periodic_sync() {
             "".to_string(),
         )
         .connector(TurmoilConnector)
-        .periodic_sync(Duration::from_millis(100))
+        .sync_interval(Duration::from_millis(100))
         .build()
         .await?;
 

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -259,7 +259,7 @@ cfg_replication! {
             version: Option<String>,
             read_your_writes: bool,
             encryption_config: Option<EncryptionConfig>,
-            periodic_sync: Option<std::time::Duration>,
+            sync_interval: Option<std::time::Duration>,
         ) -> Result<Database> {
             let https = connector();
 
@@ -271,7 +271,7 @@ cfg_replication! {
                 version,
                 read_your_writes,
                 encryption_config,
-                periodic_sync
+                sync_interval
             ).await
         }
 
@@ -284,7 +284,7 @@ cfg_replication! {
             version: Option<String>,
             read_your_writes: bool,
             encryption_config: Option<EncryptionConfig>,
-            periodic_sync: Option<std::time::Duration>,
+            sync_interval: Option<std::time::Duration>,
         ) -> Result<Database>
         where
             C: tower::Service<http::Uri> + Send + Clone + Sync + 'static,
@@ -308,7 +308,7 @@ cfg_replication! {
                 version,
                 read_your_writes,
                 encryption_config.clone(),
-                periodic_sync,
+                sync_interval,
                 None
             ).await?;
 

--- a/libsql/src/database/builder.rs
+++ b/libsql/src/database/builder.rs
@@ -53,7 +53,7 @@ impl Builder<()> {
                     },
                     encryption_config: None,
                     read_your_writes: true,
-                    periodic_sync: None,
+                    sync_interval: None,
                     http_request_callback: None
                 },
             }
@@ -157,7 +157,7 @@ cfg_replication! {
         remote: Remote,
         encryption_config: Option<EncryptionConfig>,
         read_your_writes: bool,
-        periodic_sync: Option<std::time::Duration>,
+        sync_interval: Option<std::time::Duration>,
         http_request_callback: Option<crate::util::HttpRequestCallback>,
     }
 
@@ -206,8 +206,8 @@ cfg_replication! {
         /// Set the duration at which the replicator will automatically call `sync` in the
         /// background. The sync will continue for the duration that the resulted `Database`
         /// type is alive for, once it is dropped the background task will get dropped and stop.
-        pub fn periodic_sync(mut self, duration: std::time::Duration) -> Builder<RemoteReplica> {
-            self.inner.periodic_sync = Some(duration);
+        pub fn sync_interval(mut self, duration: std::time::Duration) -> Builder<RemoteReplica> {
+            self.inner.sync_interval = Some(duration);
             self
         }
 
@@ -239,7 +239,7 @@ cfg_replication! {
                     },
                 encryption_config,
                 read_your_writes,
-                periodic_sync,
+                sync_interval,
                 http_request_callback
             } = self.inner;
 
@@ -266,7 +266,7 @@ cfg_replication! {
                 version,
                 read_your_writes,
                 encryption_config.clone(),
-                periodic_sync,
+                sync_interval,
                 http_request_callback
             )
             .await?;

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -53,7 +53,7 @@ impl Database {
         endpoint: String,
         auth_token: String,
         encryption_config: Option<EncryptionConfig>,
-        periodic_sync: Option<std::time::Duration>,
+        sync_interval: Option<std::time::Duration>,
     ) -> Result<Database> {
         Self::open_http_sync_internal(
             connector,
@@ -63,7 +63,7 @@ impl Database {
             None,
             false,
             encryption_config,
-            periodic_sync,
+            sync_interval,
             None,
         )
         .await
@@ -79,7 +79,7 @@ impl Database {
         version: Option<String>,
         read_your_writes: bool,
         encryption_config: Option<EncryptionConfig>,
-        periodic_sync: Option<std::time::Duration>,
+        sync_interval: Option<std::time::Duration>,
         http_request_callback: Option<crate::util::HttpRequestCallback>,
     ) -> Result<Database> {
         use std::path::PathBuf;
@@ -103,7 +103,7 @@ impl Database {
             .map_err(|e| crate::errors::Error::ConnectionFailed(e.to_string()))?;
 
         let replicator =
-            EmbeddedReplicator::with_remote(client, path, 1000, encryption_config, periodic_sync)
+            EmbeddedReplicator::with_remote(client, path, 1000, encryption_config, sync_interval)
                 .await?;
 
         db.replication_ctx = Some(ReplicationContext {

--- a/libsql/src/replication/mod.rs
+++ b/libsql/src/replication/mod.rs
@@ -144,7 +144,7 @@ impl EmbeddedReplicator {
                         tokio::time::sleep(sync_duration).await;
                     }
                 }
-                .instrument(tracing::info_span!("periodic_sync")),
+                .instrument(tracing::info_span!("sync_interval")),
             );
 
             replicator.bg_abort = Some(Arc::new(DropAbort(jh.abort_handle())));


### PR DESCRIPTION
Rename the configuration option for periodic sync to `sync_interval` to align with what we're doing with the rest of the SDKs.