### PR TITLE
handle job retry

### DIFF
--- a/libsql-server/src/schema/snapshots/libsql_server__schema__migration__test__already_performed_task_is_not_reexecuted.snap
+++ b/libsql-server/src/schema/snapshots/libsql_server__schema__migration__test__already_performed_task_is_not_reexecuted.snap
@@ -1,0 +1,9 @@
+---
+source: libsql-server/src/schema/migration.rs
+expression: schema
+---
+[
+    Ok(
+        "{Ok(\"type\"): (Text, \"table\"), Ok(\"name\"): (Text, \"__libsql_migration_tasks\"), Ok(\"tbl_name\"): (Text, \"__libsql_migration_tasks\"), Ok(\"rootpage\"): (Integer, 2), Ok(\"sql\"): (Text, \"CREATE TABLE __libsql_migration_tasks (\\n            job_id INTEGER PRIMARY KEY,\\n            status INTEGER,\\n            migration TEXT NOT NULL,\\n            error TEXT\\n        )\")}",
+    ),
+]

--- a/libsql-server/src/schema/status.rs
+++ b/libsql-server/src/schema/status.rs
@@ -97,7 +97,7 @@ impl MigrationJob {
 }
 
 /// Represents the status of a migration task
-#[derive(Debug, Serialize, Deserialize, Copy, Clone)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
 #[repr(u64)]
 pub enum MigrationTaskStatus {
     /// The task was enqueued, and shoudl perform a dry run
@@ -144,6 +144,14 @@ impl MigrationTaskStatus {
 
         // don't forget to update that!
         6
+    }
+
+    /// Returns `true` if the migration task status is [`Enqueued`].
+    ///
+    /// [`Enqueued`]: MigrationTaskStatus::Enqueued
+    #[must_use]
+    pub fn is_enqueued(&self) -> bool {
+        matches!(self, Self::Enqueued)
     }
 }
 


### PR DESCRIPTION
When a job was already performed on a db, but the scheduler inquires again about its status, return the status immediately, and don't re-perform the operation.
