### PR TITLE
prevent namespace creation/update when there is a pending migration on shared schema

### DIFF
--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -324,6 +324,11 @@ fn try_process(
 
     if let Some(schema) = config.shared_schema_name.as_ref() {
         let tx = inner.conn.transaction()?;
+        if let Some(ref schema) = config.shared_schema_name {
+            if crate::schema::db::has_pending_migration_jobs(&tx, schema)? {
+                return Err(crate::Error::PendingMigrationOnSchema(schema.clone()));
+            }
+        }
         tx.execute(
             "INSERT OR REPLACE INTO namespace_configs (namespace, config) VALUES (?1, ?2)",
             rusqlite::params![namespace.as_str(), config_encoded],

--- a/libsql-server/src/schema/db.rs
+++ b/libsql-server/src/schema/db.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use libsql_replication::rpc::metadata;
 use prost::Message;
 use rusqlite::OptionalExtension;
@@ -23,13 +24,13 @@ pub(super) fn setup_schema(conn: &mut rusqlite::Connection) -> Result<(), Error>
                 schema TEXT NOT NULL,
                 migration TEXT NOT NULL,
                 status INTEGER,
-                finished BOOLEAN GENERATED ALWAYS AS (status = {} OR status = {})
+                finished BOOLEAN GENERATED ALWAYS AS ({})
             )
             ",
-            // TODO: also handle abort when we get there
-            // we use format here, because params are not allowed GENERATED expression
-            MigrationJobStatus::RunSuccess as u64,
-            MigrationJobStatus::RunFailure as u64
+            MigrationJobStatus::finished_states()
+                .into_iter()
+                .map(|s| format!("status = {}", *s as u64))
+                .join(" OR ")
         ),
         (),
     )?;
@@ -70,6 +71,19 @@ pub(super) fn setup_schema(conn: &mut rusqlite::Connection) -> Result<(), Error>
 
     txn.commit()?;
     Ok(())
+}
+
+pub(crate) fn has_pending_migration_jobs(
+    conn: &rusqlite::Connection,
+    schema: &NamespaceName,
+) -> Result<bool, Error> {
+    let has_pending = conn.query_row(
+        "SELECT count(1) FROM migration_jobs WHERE schema = ? AND finished = false",
+        [schema.as_str()],
+        |row| Ok(row.get::<_, usize>(0)? != 0),
+    )?;
+
+    Ok(has_pending)
 }
 
 /// Create a migration job, and returns the job_id
@@ -303,7 +317,11 @@ mod test {
             .unwrap();
     }
 
-    async fn register_shared(meta_store: &MetaStore, name: &'static str, schema: &'static str) {
+    async fn register_shared(
+        meta_store: &MetaStore,
+        name: &'static str,
+        schema: &'static str,
+    ) -> crate::Result<()> {
         meta_store
             .handle(name.into())
             .store(DatabaseConfig {
@@ -311,7 +329,6 @@ mod test {
                 ..Default::default()
             })
             .await
-            .unwrap();
     }
 
     #[tokio::test]
@@ -322,17 +339,24 @@ mod test {
         let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
             .await
             .unwrap();
+        let mut conn = maker().unwrap();
+        setup_schema(&mut conn).unwrap();
+
         // create 2 shared schema tables
         register_schema(&meta_store, "schema1").await;
         register_schema(&meta_store, "schema2").await;
 
         // create namespaces
-        register_shared(&meta_store, "ns1", "schema1").await;
-        register_shared(&meta_store, "ns2", "schema2").await;
-        register_shared(&meta_store, "ns3", "schema1").await;
+        register_shared(&meta_store, "ns1", "schema1")
+            .await
+            .unwrap();
+        register_shared(&meta_store, "ns2", "schema2")
+            .await
+            .unwrap();
+        register_shared(&meta_store, "ns3", "schema1")
+            .await
+            .unwrap();
 
-        let mut conn = maker().unwrap();
-        setup_schema(&mut conn).unwrap();
         register_schema_migration_job(
             &mut conn,
             &"schema1".into(),
@@ -382,14 +406,19 @@ mod test {
         let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
             .await
             .unwrap();
-
-        register_schema(&meta_store, "schema1").await;
-        register_shared(&meta_store, "ns1", "schema1").await;
-        register_shared(&meta_store, "ns2", "schema1").await;
-        register_shared(&meta_store, "ns3", "schema1").await;
-
         let mut conn = maker().unwrap();
         setup_schema(&mut conn).unwrap();
+
+        register_schema(&meta_store, "schema1").await;
+        register_shared(&meta_store, "ns1", "schema1")
+            .await
+            .unwrap();
+        register_shared(&meta_store, "ns2", "schema1")
+            .await
+            .unwrap();
+        register_shared(&meta_store, "ns3", "schema1")
+            .await
+            .unwrap();
 
         let job_id = register_schema_migration_job(
             &mut conn,
@@ -424,14 +453,20 @@ mod test {
         let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
             .await
             .unwrap();
-
-        register_schema(&meta_store, "schema1").await;
-        register_shared(&meta_store, "ns1", "schema1").await;
-        register_shared(&meta_store, "ns2", "schema1").await;
-        register_shared(&meta_store, "ns3", "schema1").await;
-
         let mut conn = maker().unwrap();
         setup_schema(&mut conn).unwrap();
+
+        register_schema(&meta_store, "schema1").await;
+        register_shared(&meta_store, "ns1", "schema1")
+            .await
+            .unwrap();
+        register_shared(&meta_store, "ns2", "schema1")
+            .await
+            .unwrap();
+        register_shared(&meta_store, "ns3", "schema1")
+            .await
+            .unwrap();
+
         register_schema_migration_job(
             &mut conn,
             &"schema1".into(),
@@ -469,12 +504,11 @@ mod test {
         let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
             .await
             .unwrap();
+        let mut conn = maker().unwrap();
+        setup_schema(&mut conn).unwrap();
 
         register_schema(&meta_store, "schema1").await;
         register_schema(&meta_store, "schema2").await;
-
-        let mut conn = maker().unwrap();
-        setup_schema(&mut conn).unwrap();
 
         let job_id = register_schema_migration_job(
             &mut conn,
@@ -511,5 +545,60 @@ mod test {
             &Program::seq(&["create table test (x)"]).into(),
         )
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn has_pending_migration() {
+        let tmp = tempdir().unwrap();
+        let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
+        let conn = maker().unwrap();
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+            .await
+            .unwrap();
+        let mut conn = maker().unwrap();
+        setup_schema(&mut conn).unwrap();
+
+        register_schema(&meta_store, "schema").await;
+
+        let job_id = register_schema_migration_job(
+            &mut conn,
+            &"schema".into(),
+            &Program::seq(&["create table test (c)"]),
+        )
+        .unwrap();
+
+        assert!(super::has_pending_migration_jobs(&conn, &"schema".into()).unwrap());
+
+        update_job_status(&mut conn, job_id, MigrationJobStatus::RunSuccess).unwrap();
+        assert!(!super::has_pending_migration_jobs(&conn, &"schema".into()).unwrap());
+    }
+
+    #[tokio::test]
+    async fn attempt_to_create_db_during_migration() {
+        let tmp = tempdir().unwrap();
+        let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
+        let conn = maker().unwrap();
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+            .await
+            .unwrap();
+        let mut conn = maker().unwrap();
+        setup_schema(&mut conn).unwrap();
+
+        register_schema(&meta_store, "schema").await;
+
+        let job_id = register_schema_migration_job(
+            &mut conn,
+            &"schema".into(),
+            &Program::seq(&["create table test (c)"]),
+        )
+        .unwrap();
+
+        assert_debug_snapshot!(register_shared(&meta_store, "ns", "schema")
+            .await
+            .unwrap_err());
+
+        update_job_status(&mut conn, job_id, MigrationJobStatus::RunSuccess).unwrap();
+
+        assert!(register_shared(&meta_store, "ns", "schema").await.is_ok());
     }
 }

--- a/libsql-server/src/schema/mod.rs
+++ b/libsql-server/src/schema/mod.rs
@@ -29,7 +29,7 @@
 //! manner as the dry-run, except for the fact that the migration is actually committed.
 //! - If all tasks are successfull, then the scheduler performs the migration on the schema, and
 //! update the job's state to it's final state, `RunSuccess`.
-mod db;
+pub(crate) mod db;
 mod error;
 mod handle;
 mod message;

--- a/libsql-server/src/schema/snapshots/libsql_server__schema__db__test__attempt_to_create_db_during_migration.snap
+++ b/libsql-server/src/schema/snapshots/libsql_server__schema__db__test__attempt_to_create_db_during_migration.snap
@@ -1,0 +1,7 @@
+---
+source: libsql-server/src/schema/db.rs
+expression: "register_shared(&meta_store, \"ns\", \"schema\").await.unwrap_err()"
+---
+PendingMigrationOnSchema(
+    schema,
+)

--- a/libsql-server/src/schema/status.rs
+++ b/libsql-server/src/schema/status.rs
@@ -168,7 +168,7 @@ pub enum MigrationJobStatus {
 }
 
 impl MigrationJobStatus {
-    pub fn from_int(i: u64) -> Self {
+    pub(crate) fn from_int(i: u64) -> Self {
         match i {
             0 => Self::WaitingDryRun,
             1 => Self::DryRunSuccess,
@@ -179,6 +179,11 @@ impl MigrationJobStatus {
             6 => Self::WaitingSchemaUpdate,
             _ => panic!(),
         }
+    }
+
+    /// Returns a list of MigrationJobStatus considered finished states.
+    pub(crate) fn finished_states() -> &'static [Self] {
+        &[Self::RunSuccess, Self::RunFailure]
     }
 
     /// Returns `true` if the migration job status is [`WaitingRun`].


### PR DESCRIPTION
prevent updating/creating namespaces refering to a shared schema when there are pending migration on the schema
