### PR TITLE
bindings/go: Rename WithAutoSync to WithSyncInterval

### DIFF
--- a/bindings/go/libsql.go
+++ b/bindings/go/libsql.go
@@ -87,10 +87,10 @@ func WithEncryption(key string) Option {
 	})
 }
 
-func WithAutoSync(interval time.Duration) Option {
+func WithSyncInterval(interval time.Duration) Option {
 	return option(func(o *config) error {
 		if o.syncInterval != nil {
-			return fmt.Errorf("auto sync already set")
+			return fmt.Errorf("sync interval already set")
 		}
 		o.syncInterval = &interval
 		return nil

--- a/bindings/go/libsql_test.go
+++ b/bindings/go/libsql_test.go
@@ -459,7 +459,7 @@ func testSync(t *testing.T, connect func(dbPath, primaryUrl, authToken string) *
 func TestAutoSync(t *testing.T) {
 	syncInterval := 1 * time.Second
 	testSync(t, func(dbPath, primaryUrl, authToken string) *Connector {
-		options := []Option{WithReadYourWrites(false), WithAutoSync(syncInterval)}
+		options := []Option{WithReadYourWrites(false), WithSyncInterval(syncInterval)}
 		if authToken != "" {
 			options = append(options, WithAuthToken(authToken))
 		}


### PR DESCRIPTION
This aligns the API with the other SDKs.