### PR TITLE
use custom query builder to collect migration error

### DIFF
--- a/libsql-server/src/database/schema.rs
+++ b/libsql-server/src/database/schema.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use crate::connection::program::Program;
 use crate::connection::{MakeConnection, RequestContext};
 use crate::namespace::NamespaceName;
+use crate::query_result_builder::QueryBuilderConfig;
 use crate::schema::{perform_migration, SchedulerHandle};
 
 use super::primary::PrimaryConnectionMaker;
@@ -39,26 +40,33 @@ impl crate::connection::Connection for SchemaConnection {
             let connection = self.connection.clone();
             let pgm = Arc::new(pgm);
             let pgm_clone = pgm.clone();
-            let ret = tokio::task::spawn_blocking(move || {
-                connection.with_raw(|conn| -> crate::Result<B> {
+            let builder = tokio::task::spawn_blocking(move || {
+                connection.with_raw(|conn| -> crate::Result<_> {
                     let mut txn = conn
                         .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
                         .unwrap();
-                    let (ret, _) = perform_migration(&mut txn, &pgm_clone, true, builder);
+                    // TODO: pass proper config
+                    let (ret, _) = perform_migration(
+                        &mut txn,
+                        &pgm_clone,
+                        true,
+                        builder,
+                        &QueryBuilderConfig::default(),
+                    );
                     txn.rollback().unwrap();
                     Ok(ret?)
                 })
             })
             .await
-            .unwrap();
+            .unwrap()?;
+
             // if dry run is successfull, enqueue
             self.migration_scheduler
                 .register_migration_task(self.schema.clone(), pgm)
                 .await?;
-
             // TODO here wait for dry run to be executed on all dbs
 
-            ret
+            Ok(builder)
         }
     }
 

--- a/libsql-server/src/error.rs
+++ b/libsql-server/src/error.rs
@@ -112,6 +112,8 @@ pub enum Error {
     Migration(#[from] crate::schema::Error),
     #[error("cannot create/update database config while there are pending migration on the shared schema `{0}`")]
     PendingMigrationOnSchema(NamespaceName),
+    #[error("couldn't find requested migration job")]
+    MigrationJobNotFound,
 }
 
 impl AsRef<Self> for Error {
@@ -192,6 +194,7 @@ impl IntoResponse for &Error {
             SharedSchemaCreationError(_) => self.format_err(StatusCode::BAD_REQUEST),
             Migration(e) => e.into_response(),
             PendingMigrationOnSchema(_) => self.format_err(StatusCode::BAD_REQUEST),
+            MigrationJobNotFound => self.format_err(StatusCode::NOT_FOUND),
         }
     }
 }

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -454,7 +454,9 @@ async fn handle_get_migration_details<C: Connector>(
     }
 
     let meta_store = app_state.namespaces.meta_store();
-    let summary = meta_store.get_migration_details(schema, job_id).await?;
-
-    Ok(Json(summary))
+    let details = meta_store.get_migration_details(schema, job_id).await?;
+    match details {
+        Some(details) => Ok(Json(details)),
+        None => Err(crate::Error::MigrationJobNotFound),
+    }
 }

--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -476,15 +476,15 @@ impl MetaStore {
         &self,
         schema: NamespaceName,
         job_id: u64,
-    ) -> crate::Result<MigrationDetails> {
+    ) -> crate::Result<Option<MigrationDetails>> {
         let inner = self.inner.clone();
-        let summary = tokio::task::spawn_blocking(move || {
+        let details = tokio::task::spawn_blocking(move || {
             let mut lock = inner.lock();
             crate::schema::get_migration_details(&mut lock.conn, schema, job_id)
         })
         .await
         .unwrap()?;
-        Ok(summary)
+        Ok(details)
     }
 }
 

--- a/libsql-server/src/query_result_builder.rs
+++ b/libsql-server/src/query_result_builder.rs
@@ -87,6 +87,7 @@ impl<'a> From<&'a rusqlite::Column<'a>> for Column<'a> {
 pub struct QueryBuilderConfig {
     pub max_size: Option<u64>,
     pub max_total_size: Option<u64>,
+    // FIXME: this has absolutely nothing to do here.
     pub auto_checkpoint: u32,
     pub encryption_config: Option<EncryptionConfig>,
 }

--- a/libsql-server/src/schema/error.rs
+++ b/libsql-server/src/schema/error.rs
@@ -19,12 +19,18 @@ pub enum Error {
     SchemaDoesntExist(NamespaceName),
     #[error("A migration job is already in progress for `{0}`")]
     MigrationJobAlreadyInProgress(NamespaceName),
+    #[error("An error occured executing the migration at step {0}: {1}")]
+    MigrationError(usize, String),
 }
 
 impl ResponseError for Error {}
 
 impl IntoResponse for &Error {
     fn into_response(self) -> axum::response::Response {
-        self.format_err(StatusCode::INTERNAL_SERVER_ERROR)
+        match self {
+            // should that really be a bad request?
+            Error::MigrationError { .. } => self.format_err(StatusCode::BAD_REQUEST),
+            _ => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
+        }
     }
 }

--- a/libsql-server/src/schema/mod.rs
+++ b/libsql-server/src/schema/mod.rs
@@ -34,6 +34,7 @@ mod error;
 mod handle;
 mod message;
 mod migration;
+mod result_builder;
 mod scheduler;
 mod status;
 

--- a/libsql-server/src/schema/result_builder.rs
+++ b/libsql-server/src/schema/result_builder.rs
@@ -1,0 +1,106 @@
+use crate::query_result_builder::QueryResultBuilder;
+
+pub struct SchemaMigrationResultBuilder<B> {
+    inner: B,
+    step: usize,
+    errors: Vec<(usize, String)>,
+}
+
+impl<B> SchemaMigrationResultBuilder<B> {
+    pub(crate) fn new(inner: B) -> Self {
+        Self {
+            inner,
+            step: 0,
+            errors: Vec::new(),
+        }
+    }
+
+    pub(crate) fn into_inner(self) -> B {
+        self.inner
+    }
+
+    pub(crate) fn is_success(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    pub(crate) fn into_error(self) -> (usize, String) {
+        assert!(!self.errors.is_empty());
+        self.errors.into_iter().next().unwrap()
+    }
+}
+
+impl<B: QueryResultBuilder> QueryResultBuilder for SchemaMigrationResultBuilder<B> {
+    type Ret = B::Ret;
+
+    fn init(
+        &mut self,
+        config: &crate::query_result_builder::QueryBuilderConfig,
+    ) -> Result<(), crate::query_result_builder::QueryResultBuilderError> {
+        self.step = 0;
+        self.inner.init(config)
+    }
+
+    fn begin_step(&mut self) -> Result<(), crate::query_result_builder::QueryResultBuilderError> {
+        self.step += 1;
+        self.inner.begin_step()
+    }
+
+    fn finish_step(
+        &mut self,
+        affected_row_count: u64,
+        last_insert_rowid: Option<i64>,
+    ) -> Result<(), crate::query_result_builder::QueryResultBuilderError> {
+        self.inner
+            .finish_step(affected_row_count, last_insert_rowid)
+    }
+
+    fn step_error(
+        &mut self,
+        error: crate::error::Error,
+    ) -> Result<(), crate::query_result_builder::QueryResultBuilderError> {
+        self.errors.push((self.step, error.to_string()));
+        self.inner.step_error(error)
+    }
+
+    fn cols_description<'a>(
+        &mut self,
+        cols: impl IntoIterator<Item = impl Into<crate::query_result_builder::Column<'a>>>,
+    ) -> Result<(), crate::query_result_builder::QueryResultBuilderError> {
+        self.inner.cols_description(cols)
+    }
+
+    fn begin_rows(&mut self) -> Result<(), crate::query_result_builder::QueryResultBuilderError> {
+        self.inner.begin_rows()
+    }
+
+    fn begin_row(&mut self) -> Result<(), crate::query_result_builder::QueryResultBuilderError> {
+        self.inner.begin_row()
+    }
+
+    fn add_row_value(
+        &mut self,
+        v: rusqlite::types::ValueRef,
+    ) -> Result<(), crate::query_result_builder::QueryResultBuilderError> {
+        self.inner.add_row_value(v)
+    }
+
+    fn finish_row(&mut self) -> Result<(), crate::query_result_builder::QueryResultBuilderError> {
+        self.inner.finish_row()
+    }
+
+    fn finish_rows(&mut self) -> Result<(), crate::query_result_builder::QueryResultBuilderError> {
+        self.inner.finish_rows()
+    }
+
+    fn finish(
+        &mut self,
+        last_frame_no: Option<crate::replication::FrameNo>,
+        is_auto_commit: bool,
+    ) -> Result<(), crate::query_result_builder::QueryResultBuilderError> {
+        self.inner.finish(last_frame_no, is_auto_commit)
+    }
+
+    fn into_ret(self) -> Self::Ret {
+        self.inner.into_ret()
+    }
+}

--- a/libsql-server/src/schema/scheduler.rs
+++ b/libsql-server/src/schema/scheduler.rs
@@ -8,7 +8,7 @@ use crate::connection::program::Program;
 use crate::connection::MakeConnection;
 use crate::namespace::meta_store::MetaStoreConnection;
 use crate::namespace::{NamespaceName, NamespaceStore};
-use crate::query_result_builder::IgnoreResult;
+use crate::query_result_builder::{IgnoreResult, QueryBuilderConfig};
 use crate::schema::db::{update_job_status, update_meta_task_status};
 use crate::schema::{step_migration_task_run, MigrationJobStatus};
 
@@ -231,8 +231,13 @@ impl Scheduler {
 
                             if schema_version != job_id {
                                 // todo: use proper builder and collect errors
-                                let (ret, _status) =
-                                    perform_migration(&mut txn, &migration, false, IgnoreResult);
+                                let (ret, _status) = perform_migration(
+                                    &mut txn,
+                                    &migration,
+                                    false,
+                                    IgnoreResult,
+                                    &QueryBuilderConfig::default(),
+                                );
                                 let _error = ret.err().map(|e| e.to_string());
                                 txn.pragma_update(None, "schema_version", job_id).unwrap();
                                 // update schema version to job_id?

--- a/libsql-server/tests/namespaces/shared_schema.rs
+++ b/libsql-server/tests/namespaces/shared_schema.rs
@@ -1,3 +1,4 @@
+use hyper::StatusCode;
 use insta::assert_debug_snapshot;
 use libsql::{Connection, Database};
 use serde_json::json;
@@ -98,6 +99,49 @@ fn perform_schema_migration() {
 
         let resp = http_get("http://primary:9090/v1/namespaces/schema/migrations/1").await;
         assert_eq!(resp, r#"{"job_id":1,"status":"RunSuccess","progress":[{"namespace":"ns1","status":"RunSuccess","error":null},{"namespace":"ns2","status":"RunSuccess","error":null}]}"#);
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}
+
+#[test]
+fn no_job_created_when_migration_job_is_invalid() {
+    let mut sim = Builder::new()
+        .simulation_duration(Duration::from_secs(100000))
+        .build();
+    let tmp = tempdir().unwrap();
+    make_primary(&mut sim, tmp.path().to_path_buf());
+
+    sim.client("client", async {
+        let client = Client::new();
+        client
+            .post(
+                "http://primary:9090/v1/namespaces/schema/create",
+                json!({"shared_schema": true }),
+            )
+            .await
+            .unwrap();
+
+        let schema_db = Database::open_remote_with_connector(
+            "http://schema.primary:8080",
+            String::new(),
+            TurmoilConnector,
+        )
+        .unwrap();
+        let schema_conn = schema_db.connect().unwrap();
+        assert_debug_snapshot!(schema_conn
+            .execute_batch("create table test (c); create table test (c)")
+            .await
+            .unwrap_err());
+
+        let resp = client
+            .get("http://primary:9090/v1/namespaces/schema/migrations/1")
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_debug_snapshot!(resp.json_value().await.unwrap());
 
         Ok(())
     });

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__no_job_created_when_migration_job_is_invalid-2.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__no_job_created_when_migration_job_is_invalid-2.snap
@@ -1,0 +1,7 @@
+---
+source: libsql-server/tests/namespaces/shared_schema.rs
+expression: resp.json_value().await.unwrap()
+---
+Object {
+    "error": String("couldn't find requested migration job"),
+}

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__no_job_created_when_migration_job_is_invalid.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__no_job_created_when_migration_job_is_invalid.snap
@@ -1,0 +1,9 @@
+---
+source: libsql-server/tests/namespaces/shared_schema.rs
+expression: "schema_conn.execute_batch(\"create table test (c); create table test (c)\").await.unwrap_err()"
+---
+Hrana(
+    Api(
+        "{\"error\":\"Internal Error: `migration error: An error occured executing the migration at step 2: table test already exists in CREATE TABLE test (c); at offset 13`\"}",
+    ),
+)


### PR DESCRIPTION
Use `SchemaMigrationQueryBuilder` to collect migration error, and check migration task status
