### PR TITLE
bindings/go: Redirect people to Go SDK repository

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,0 +1,3 @@
+# Go SDK for libSQL
+
+You can find the Go SDK at https://github.com/tursodatabase/go-libsql


### PR DESCRIPTION
The Go SDK code lives in two places, but people are supposed to consume the one in the other repository. Let's add a small hint in this repository for people to find the right one.