### PR TITLE
Add optional flush param when storing in MetaStore

### DIFF
--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -364,18 +364,14 @@ async fn handle_fork_namespace<C>(
     let timestamp = req.map(|v| v.timestamp);
     let from = NamespaceName::from_string(from)?;
     let to = NamespaceName::from_string(to)?;
+    let from_store = app_state.namespaces.config_store(from.clone()).await?;
+    let from_config = from_store.get();
+    let to_config = (*from_config).clone();
     app_state
         .namespaces
-        .fork(from.clone(), to.clone(), timestamp)
+        .fork(from, to, to_config, timestamp)
         .await?;
-    let from_store = app_state.namespaces.config_store(from).await?;
-    let from_config = from_store.get();
-    let to_store = app_state.namespaces.config_store(to).await?;
-    let mut to_config = (*to_store.get()).clone();
-    to_config.max_db_pages = from_config.max_db_pages;
-    to_config.heartbeat_url = from_config.heartbeat_url.clone();
-    to_config.shared_schema_name = from_config.shared_schema_name.clone();
-    to_store.store(to_config).await?;
+
     Ok(())
 }
 

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -573,10 +573,6 @@ impl Namespace {
                 } else {
                     None
                 };
-
-                // fork share config with original db
-                to_config.store(from_config).await?;
-
                 let fork_task = ForkTask {
                     base_path: ns_config.base_path.clone(),
                     to_namespace: to_ns,


### PR DESCRIPTION
Added a new method `store_and_maybe_flush` in MetaStore, which gives you an option to flush the config changes to disk.

The previous `store` method behaviour is not changed. It internally calls `store_and_maybe_flush` method, stores the config and flushes to disk.

This patch fixes a bug in fork. Earlier, we were flushing the target config before actually creating a fork. If the fork failed, MetaStore would have invalid data. Now, we store the config, without flush, create the fork. Iff successful, flush the target config to disk.