### PR TITLE
Fixed function `make_amalgamation` naming typo

### DIFF
--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -29,7 +29,7 @@ fn main() {
     }
 
     if std::env::var("LIBSQL_DEV").is_ok() {
-        make_amalgation();
+        make_amalgamation();
         build_multiple_ciphers(&out_path);
     }
 
@@ -56,7 +56,7 @@ fn main() {
     build_bundled(&out_dir, &out_path);
 }
 
-fn make_amalgation() {
+fn make_amalgamation() {
     let flags = ["-DSQLITE_ENABLE_COLUMN_METADATA=1"];
 
     Command::new("make")


### PR DESCRIPTION
Use `amalgamation` instead of `amalgation`.

Ref: https://www.merriam-webster.com/dictionary/amalgamation

Also in comments of `amalgamated` file 

<img width="632" alt="Screenshot 2024-03-08 at 00 35 37" src="https://github.com/tursodatabase/libsql/assets/6627334/cf4a03d7-3f75-4b9a-8ec0-8f726a290c13">
