### PR TITLE
Add tests for data migration in schema dbs

### DIFF
--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__conflicting_data_migration-2.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__conflicting_data_migration-2.snap
@@ -1,0 +1,7 @@
+---
+source: libsql-server/tests/namespaces/shared_schema.rs
+expression: "check_data(\"schema\").await"
+---
+[
+    "Row { cols: [Col { name: Some(\"c\"), decltype: None }], inner: [Integer { value: 42 }] }",
+]

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__conflicting_data_migration-3.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__conflicting_data_migration-3.snap
@@ -1,0 +1,16 @@
+---
+source: libsql-server/tests/namespaces/shared_schema.rs
+expression: resp
+---
+{
+  "job_id": 3,
+  "status": "RunFailure",
+  "error": "task 3 for namespace `ns1` failed with error: An error occured executing the migration at step 1: UNIQUE constraint failed: test.c",
+  "progress": [
+    {
+      "namespace": "ns1",
+      "status": "RunFailure",
+      "error": "aborted"
+    }
+  ]
+}

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__conflicting_data_migration.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__conflicting_data_migration.snap
@@ -1,0 +1,7 @@
+---
+source: libsql-server/tests/namespaces/shared_schema.rs
+expression: "check_data(\"ns1\").await"
+---
+[
+    "Row { cols: [Col { name: Some(\"c\"), decltype: None }], inner: [Integer { value: 42 }] }",
+]

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__perform_data_migration-2.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__perform_data_migration-2.snap
@@ -1,0 +1,8 @@
+---
+source: libsql-server/tests/namespaces/shared_schema.rs
+expression: "check_data(\"ns2\").await"
+---
+[
+    "Row { cols: [Col { name: Some(\"c\"), decltype: None }], inner: [Integer { value: 42 }] }",
+    "Row { cols: [Col { name: Some(\"c\"), decltype: None }], inner: [Integer { value: 43 }] }",
+]

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__perform_data_migration-3.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__perform_data_migration-3.snap
@@ -1,0 +1,8 @@
+---
+source: libsql-server/tests/namespaces/shared_schema.rs
+expression: "check_data(\"ns3\").await"
+---
+[
+    "Row { cols: [Col { name: Some(\"c\"), decltype: None }], inner: [Integer { value: 42 }] }",
+    "Row { cols: [Col { name: Some(\"c\"), decltype: None }], inner: [Integer { value: 43 }] }",
+]

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__perform_data_migration-4.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__perform_data_migration-4.snap
@@ -1,0 +1,8 @@
+---
+source: libsql-server/tests/namespaces/shared_schema.rs
+expression: "check_data(\"schema\").await"
+---
+[
+    "Row { cols: [Col { name: Some(\"c\"), decltype: None }], inner: [Integer { value: 42 }] }",
+    "Row { cols: [Col { name: Some(\"c\"), decltype: None }], inner: [Integer { value: 43 }] }",
+]

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__perform_data_migration.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__perform_data_migration.snap
@@ -1,0 +1,8 @@
+---
+source: libsql-server/tests/namespaces/shared_schema.rs
+expression: "check_data(\"ns1\").await"
+---
+[
+    "Row { cols: [Col { name: Some(\"c\"), decltype: None }], inner: [Integer { value: 42 }] }",
+    "Row { cols: [Col { name: Some(\"c\"), decltype: None }], inner: [Integer { value: 43 }] }",
+]


### PR DESCRIPTION
- Added a test which performs data migration including inserts, updates and deletes
- Added a test which shows that schema migration fails if there is any conflicting data in the linked dbs