### PR TITLE
libsql: bump 0.3.1 and remove all features for doc

### DIFF
--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "libSQL library: the main gateway for interacting with the database"
 repository = "https://github.com/tursodatabase/libsql"
@@ -127,5 +127,4 @@ name = "benchmark"
 harness = false
 
 [package.metadata.docs.rs]
-all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Related to build issues on the docs.rs site due to ffi writing to the file system instead of the out dir.