### PR TITLE
Hrana: don't close the stream at the end of prepared statement execution

### DIFF
--- a/libsql-server/tests/standalone/mod.rs
+++ b/libsql-server/tests/standalone/mod.rs
@@ -165,7 +165,7 @@ fn primary_serializability() {
 #[test]
 fn execute_transaction() {
     let mut sim = turmoil::Builder::new()
-        .simulation_duration(Duration::from_secs(1000))
+        .simulation_duration(Duration::from_secs(u64::MAX))
         .build();
 
     sim.host("primary", make_standalone_server);

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -89,7 +89,7 @@ impl HttpSend for HttpSender {
         if let Ok(rt) = tokio::runtime::Handle::try_current() {
             rt.spawn(self.send(url, auth, body));
         } else {
-            log::warn!("tried to send request to `{url}` while no runtime was available");
+            tracing::warn!("tried to send request to `{url}` while no runtime was available");
         }
     }
 }

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -16,6 +16,7 @@ use http::{HeaderValue, StatusCode};
 use hyper::body::HttpBody;
 use std::io::ErrorKind;
 use std::sync::Arc;
+use tracing::log;
 
 pub type ByteStream = Box<dyn Stream<Item = std::io::Result<Bytes>> + Send + Sync + Unpin>;
 
@@ -85,7 +86,11 @@ impl HttpSend for HttpSender {
     }
 
     fn oneshot(self, url: Arc<str>, auth: Arc<str>, body: String) {
-        tokio::spawn(self.send(url, auth, body));
+        if let Ok(rt) = tokio::runtime::Handle::try_current() {
+            rt.spawn(self.send(url, auth, body));
+        } else {
+            log::warn!("tried to send request to `{url}` while no runtime was available");
+        }
     }
 }
 
@@ -141,7 +146,13 @@ impl Conn for HttpConnection<HttpSender> {
             close: Some(Box::new(|| {
                 // make sure that Hrana connection is closed and all uncommitted changes
                 // are rolled back when we're about to drop the transaction
-                drop(tokio::task::spawn(async move { tx.rollback().await }));
+                if let Ok(rt) = tokio::runtime::Handle::try_current() {
+                    // transaction will rollback automatically after timeout on the server side
+                    // this is gracefull rollback on best-effort basis
+                    rt.spawn(async move {
+                        let _ = tx.rollback().await;
+                    });
+                }
             })),
         })
     }

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -16,7 +16,6 @@ use http::{HeaderValue, StatusCode};
 use hyper::body::HttpBody;
 use std::io::ErrorKind;
 use std::sync::Arc;
-use tracing::log;
 
 pub type ByteStream = Box<dyn Stream<Item = std::io::Result<Bytes>> + Send + Sync + Unpin>;
 

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -134,8 +134,11 @@ where
             )),
             Some(Err(e)) => Err(e),
             Some(Ok(stmt)) => {
+                // if we're already in transaction scope (non-autocommit) or we're starting
+                // a transaction, we DON'T want to close the stream
                 let in_tx_scope = !stream.is_autocommit()
                     || matches!(stmt.kind, StmtKind::TxnBegin | StmtKind::TxnBeginReadOnly);
+                // if we're at COMMIT/ROLLBACK statement, we DO want to close the stream
                 let close_stream = !in_tx_scope || matches!(stmt.kind, StmtKind::TxnEnd);
                 let inner = Stmt::new(stmt.stmt, want_rows);
                 Ok(Statement {

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -134,7 +134,9 @@ where
             )),
             Some(Err(e)) => Err(e),
             Some(Ok(stmt)) => {
-                let close_stream = !matches!(stmt.kind, StmtKind::TxnBegin | StmtKind::TxnBeginReadOnly);
+                let in_tx_scope = !stream.is_autocommit()
+                    || matches!(stmt.kind, StmtKind::TxnBegin | StmtKind::TxnBeginReadOnly);
+                let close_stream = !in_tx_scope || matches!(stmt.kind, StmtKind::TxnEnd);
                 let inner = Stmt::new(stmt.stmt, want_rows);
                 Ok(Statement {
                     stream,
@@ -370,7 +372,8 @@ fn into_value2(value: proto::Value) -> crate::Value {
 }
 
 pub(crate) fn unwrap_err(batch_res: BatchResult) -> crate::Result<()> {
-    batch_res.step_errors
+    batch_res
+        .step_errors
         .into_iter()
         .find_map(|e| e)
         .map(|e| Err(crate::Error::Hrana(Box::new(HranaError::Api(e.message)))))


### PR DESCRIPTION
This PR fixes the issue @haaawk and me originally noticed in libsql Go tests. It turns out, that the prepared statements - when calling `stmt.execute` - were always closing the stream, even if there was a transaction pending (created before prepare stmt).

I've also added standalone test that confirms the original issue.