### PR TITLE
ignore legacy auth when new auth is present

### DIFF
--- a/libsql-server/src/auth/authenticated.rs
+++ b/libsql-server/src/auth/authenticated.rs
@@ -13,7 +13,14 @@ use super::Permission;
 pub enum Authenticated {
     Anonymous,
     Authorized(Arc<Authorized>),
+    Legacy(LegacyAuth),
     FullAccess,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct LegacyAuth {
+    pub(crate) namespace: Option<NamespaceName>,
+    pub(crate) perm: Permission,
 }
 
 impl Authenticated {
@@ -48,6 +55,9 @@ impl Authenticated {
                 auth.has_right(Scope::Namespace(namespace.clone()), Permission::Read)
             }
             Authenticated::FullAccess => true,
+            Authenticated::Legacy(auth) => {
+                auth.namespace.is_none() || auth.namespace.iter().any(|ns| ns == namespace)
+            }
         }
     }
 
@@ -69,6 +79,15 @@ impl Authenticated {
                 }
             }
             Authenticated::FullAccess => Ok(()),
+            Authenticated::Legacy(auth) => {
+                if self.is_namespace_authorized(namespace) && Permission::has_right(auth.perm, perm)
+                {
+                    Ok(())
+                } else {
+                    Err(crate::Error::NotAuthorized(format!(
+                                "Current session doesn't not have {perm:?} permission to namespace {namespace}")))
+                }
+            }
         }
     }
 

--- a/libsql-server/src/auth/authorized.rs
+++ b/libsql-server/src/auth/authorized.rs
@@ -104,6 +104,13 @@ impl Authorized {
             }
         }
 
+        // ddl override implies write
+        if let Some(ref scope) = self.ddl_override {
+            if scope.contains(name) {
+                return true;
+            }
+        }
+
         false
     }
 

--- a/libsql-server/src/auth/permission.rs
+++ b/libsql-server/src/auth/permission.rs
@@ -8,3 +8,19 @@ pub enum Permission {
     #[serde(rename = "roa")]
     AttachRead,
 }
+
+impl Permission {
+    pub(crate) fn has_right(perm: Self, requested: Self) -> bool {
+        match (perm, requested) {
+            (Permission::Read, Permission::Read) => true,
+            (Permission::AttachRead, Permission::AttachRead) => true,
+            (Permission::Write, Permission::Write) => true,
+            (Permission::Read, Permission::Write) => false,
+            (Permission::Read, Permission::AttachRead) => false,
+            (Permission::Write, Permission::Read) => true,
+            (Permission::Write, Permission::AttachRead) => false,
+            (Permission::AttachRead, Permission::Read) => true,
+            (Permission::AttachRead, Permission::Write) => false,
+        }
+    }
+}

--- a/libsql-server/tests/standalone/attach.rs
+++ b/libsql-server/tests/standalone/attach.rs
@@ -189,8 +189,10 @@ fn attach_auth() {
 
         // mixed claims
         let claims = serde_json::json!({
-            "id": "foo",
             "p": {
+                "rw": {
+                    "ns": ["foo"]
+                },
                 "roa": {
                     "ns": ["bar"]
                 }


### PR DESCRIPTION
We don't try to merge legacy auth with new auth anymore. Legacy auth fields are ignored is new auth is present.
