### PR TITLE
Namespace::destroy: add parameter to perform soft delete (preserve backup)

### DIFF
--- a/bottomless/src/completion_progress.rs
+++ b/bottomless/src/completion_progress.rs
@@ -60,10 +60,16 @@ impl SavepointTracker {
         let last_frame_no = self.next_frame_no.load(Ordering::SeqCst) - 1;
         let frame_no = *self.receiver.wait_for(|fno| *fno >= last_frame_no).await?;
         let generation = self.confirm_snapshotted().await?;
-        Ok(BackupThreshold {
+        let t = BackupThreshold {
             generation: generation.as_ref().map(Uuid::to_string),
             frame_no,
-        })
+        };
+        tracing::debug!(
+            "confirmed backup savepoint for generation `{:?}`, frame no.: {}",
+            t.generation,
+            t.frame_no
+        );
+        Ok(t)
     }
 }
 

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -489,7 +489,10 @@ impl Replicator {
         tracing::debug!(
             "calling for backup savepoint for `{}` on generation `{}`, frame no.: {}",
             self.db_name,
-            self.generation().unwrap(),
+            match self.generation() {
+                Ok(gen) => gen.to_string(),
+                _ => "".to_string(),
+            },
             self.next_frame_no() - 1
         );
         if let Some(tx) = &self.flush_trigger {

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -486,6 +486,12 @@ impl Replicator {
     }
 
     pub fn savepoint(&self) -> SavepointTracker {
+        tracing::debug!(
+            "calling for backup savepoint for `{}` on generation `{}`, frame no.: {}",
+            self.db_name,
+            self.generation().unwrap(),
+            self.next_frame_no() - 1
+        );
         if let Some(tx) = &self.flush_trigger {
             let _ = tx.send(());
         }

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -403,13 +403,20 @@ where
     }
 }
 
+#[derive(Deserialize, Default)]
+struct DeleteNamespaceReq {
+    #[serde(default)]
+    pub keep_backup: bool,
+}
+
 async fn handle_delete_namespace<C>(
     State(app_state): State<Arc<AppState<C>>>,
     Path(namespace): Path<String>,
+    Json(req): Json<DeleteNamespaceReq>,
 ) -> crate::Result<()> {
     app_state
         .namespaces
-        .destroy(NamespaceName::from_string(namespace)?)
+        .destroy(NamespaceName::from_string(namespace)?, !req.keep_backup)
         .await?;
     Ok(())
 }

--- a/libsql-server/src/namespace/store.rs
+++ b/libsql-server/src/namespace/store.rs
@@ -91,7 +91,7 @@ impl NamespaceStore {
         self.inner.metadata.exists(namespace)
     }
 
-    pub async fn destroy(&self, namespace: NamespaceName) -> crate::Result<()> {
+    pub async fn destroy(&self, namespace: NamespaceName, prune_all: bool) -> crate::Result<()> {
         if self.inner.has_shutdown.load(Ordering::Relaxed) {
             return Err(Error::NamespaceStoreShutdown);
         }
@@ -117,7 +117,7 @@ impl NamespaceStore {
             &self.inner.config,
             &namespace,
             &db_config,
-            true,
+            prune_all,
             bottomless_db_id_init,
         )
         .await?;
@@ -185,7 +185,7 @@ impl NamespaceStore {
                         }
                     }
                     ResetOp::Destroy(ns) => {
-                        if let Err(e) = this.destroy(ns.clone()).await {
+                        if let Err(e) = this.destroy(ns.clone(), false).await {
                             tracing::error!("error destroying namesace `{ns}`: {e}",);
                         }
                     }

--- a/libsql-server/src/schema/scheduler.rs
+++ b/libsql-server/src/schema/scheduler.rs
@@ -1039,7 +1039,7 @@ mod test {
             scheduler.step(&mut receiver).await.unwrap();
         }
 
-        assert_debug_snapshot!(store.destroy("ns".into()).await.unwrap_err());
+        assert_debug_snapshot!(store.destroy("ns".into(), true).await.unwrap_err());
 
         while super::super::db::has_pending_migration_jobs(
             &scheduler.migration_db.lock(),
@@ -1050,7 +1050,7 @@ mod test {
             scheduler.step(&mut receiver).await.unwrap();
         }
 
-        store.destroy("ns".into()).await.unwrap();
+        store.destroy("ns".into(), true).await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
Accordingly to @haaawk request: this PR extends DELETE `v1/namespace/:ns` API with optional `{"keep_backup": bool}` option. If it's set, the database will be deleted locally, but we make sure that its state is preserved in the backup.

~~Question: _while we don't delete the backup, we still have pretty much no out-of-the-box way of restoring the db using it (other than using bottomless-cli which will be troublesome) after it was deleted this way._~~