### PR TITLE
fix parser error

### DIFF
--- a/vendored/sqlite3-parser/src/parser/ast/mod.rs
+++ b/vendored/sqlite3-parser/src/parser/ast/mod.rs
@@ -1449,7 +1449,11 @@ impl FromClause {
         }
     }
 
-    pub(crate) fn push(&mut self, table: SelectTable, jc: Option<JoinConstraint>) {
+    pub(crate) fn push(
+        &mut self,
+        table: SelectTable,
+        jc: Option<JoinConstraint>,
+    ) -> Result<(), ParserError> {
         let op = self.op.take();
         if let Some(op) = op {
             let jst = JoinedSelectTable {
@@ -1463,11 +1467,17 @@ impl FromClause {
                 self.joins = Some(vec![jst]);
             }
         } else {
-            debug_assert!(jc.is_none());
+            if jc.is_some() {
+                return Err(ParserError::Custom(
+                    "a JOIN clause is required before ON".to_string(),
+                ));
+            }
             debug_assert!(self.select.is_none());
             debug_assert!(self.joins.is_none());
             self.select = Some(Box::new(table));
         }
+
+        Ok(())
     }
 
     pub(crate) fn push_op(&mut self, op: JoinOperator) {

--- a/vendored/sqlite3-parser/src/parser/parse.y
+++ b/vendored/sqlite3-parser/src/parser/parse.y
@@ -622,26 +622,26 @@ seltablist(A) ::= stl_prefix(A) fullname(Y) as(Z) indexed_opt(I)
                   on_using(N). {
     let st = SelectTable::Table(Y, Z, I);
     let jc = N;
-    A.push(st, jc);
+    A.push(st, jc)?;
 }
 seltablist(A) ::= stl_prefix(A) fullname(Y) LP exprlist(E) RP as(Z)
                   on_using(N). {
     let st = SelectTable::TableCall(Y, E, Z);
     let jc = N;
-    A.push(st, jc);
+    A.push(st, jc)?;
 }
 %ifndef SQLITE_OMIT_SUBQUERY
   seltablist(A) ::= stl_prefix(A) LP select(S) RP
                     as(Z) on_using(N). {
     let st = SelectTable::Select(S, Z);
     let jc = N;
-    A.push(st, jc);
+    A.push(st, jc)?;
   }
   seltablist(A) ::= stl_prefix(A) LP seltablist(F) RP
                     as(Z) on_using(N). {
     let st = SelectTable::Sub(F, Z);
     let jc = N;
-    A.push(st, jc);
+    A.push(st, jc)?;
   }
 %endif  SQLITE_OMIT_SUBQUERY
 


### PR DESCRIPTION
This PR fixes a bug in the parser found by the fuzzer. A minimal example that would trigger it is:

```
SELECT
0
FROM
T
on''
```
