### PR TITLE
use uuid v7 for log id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5358,6 +5364,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
+ "atomic",
  "getrandom",
  "serde",
 ]

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -76,7 +76,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 http-body = "0.4"
 url = { version = "2.3", features = ["serde"] }
-uuid = { version = "1.3", features = ["v4", "serde"] }
+uuid = { version = "1.3", features = ["v4", "serde", "v7"] }
 aes = { version = "0.8.3", optional = true }
 cbc = { version = "0.1.2", optional = true }
 zerocopy = { version = "0.7.28", features = ["derive", "alloc"] }

--- a/libsql-server/src/replication/snapshot.rs
+++ b/libsql-server/src/replication/snapshot.rs
@@ -596,7 +596,7 @@ mod test {
     #[tokio::test]
     async fn process_pending_logs_on_startup() {
         let tmp = tempdir().unwrap();
-        let log_id = Uuid::new_v4();
+        let log_id = Uuid::now_v7();
         let to_compact_path = tmp.path().join("to_compact");
         tokio::fs::create_dir_all(&to_compact_path).await.unwrap();
         let mut current_fno = 0;
@@ -714,7 +714,7 @@ mod test {
     #[tokio::test]
     async fn compact_many() {
         let tmp = tempdir().unwrap();
-        let log_id = Uuid::new_v4();
+        let log_id = Uuid::now_v7();
         let to_compact_path = tmp.path().join("to_compact");
         tokio::fs::create_dir_all(&to_compact_path).await.unwrap();
         let mut current_fno = 0;


### PR DESCRIPTION
use uuid v7 for log ids so that log ids can be ordered.
