### PR TITLE
server: allow explain queries without bind parameters

### DIFF
--- a/libsql-server/src/query.rs
+++ b/libsql-server/src/query.rs
@@ -142,9 +142,17 @@ impl Params {
                 if let Some(value) = maybe_value {
                     stmt.raw_bind_parameter(index, value)?;
                 } else if let Some(name) = param_name {
-                    return Err(anyhow!("value for parameter {} not found", name));
+                    if stmt.is_explain() > 0 {
+                        return Ok(());
+                    } else {
+                        return Err(anyhow!("value for parameter {} not found", name));
+                    }
                 } else {
-                    return Err(anyhow!("value for parameter {} not found", index));
+                    if stmt.is_explain() > 0 {
+                        return Ok(());
+                    } else {
+                        return Err(anyhow!("value for parameter {} not found", index));
+                    }
                 }
             }
         }


### PR DESCRIPTION
In SQLite, it is invalid to pass a query with a ? or named parameter without a bind variable, unless you are just trying to explain the command.

We always fail those queries, but we shouldn't.