### PR TITLE
Add more logging in case snapshots fail

### DIFF
--- a/libsql-server/src/replication/primary/logger.rs
+++ b/libsql-server/src/replication/primary/logger.rs
@@ -445,14 +445,16 @@ fn atomic_rename(p1: impl AsRef<Path>, p2: impl AsRef<Path>) -> anyhow::Result<(
     use nix::libc::renamex_np;
     use nix::libc::RENAME_SWAP;
 
-    let p1 = CString::new(p1.as_ref().as_os_str().as_bytes())?;
-    let p2 = CString::new(p2.as_ref().as_os_str().as_bytes())?;
+    let cp1 = CString::new(p1.as_ref().as_os_str().as_bytes())?;
+    let cp2 = CString::new(p2.as_ref().as_os_str().as_bytes())?;
     unsafe {
-        let ret = renamex_np(p1.as_ptr(), p2.as_ptr(), RENAME_SWAP);
+        let ret = renamex_np(cp1.as_ptr(), cp2.as_ptr(), RENAME_SWAP);
 
         if ret != 0 {
             bail!(
-                "failed to perform snapshot file swap: {ret}, errno: {}",
+                "failed to perform snapshot file swap {} -> {}: {ret}, errno: {}",
+                p1.as_ref().display(),
+                p2.as_ref().display(),
                 std::io::Error::last_os_error()
             );
         }
@@ -473,7 +475,13 @@ fn atomic_rename(p1: impl AsRef<Path>, p2: impl AsRef<Path>) -> anyhow::Result<(
         p2.as_ref(),
         RenameFlags::RENAME_EXCHANGE,
     )
-    .context("failed to perform snapshot file swap")?;
+    .with_context(|| {
+        format!(
+            "failed to perform snapshot file swap {} -> {}",
+            p1.as_ref().display(),
+            p2.as_ref().display()
+        )
+    })?;
 
     Ok(())
 }


### PR DESCRIPTION
We have a user with a failing snapshot, but we don't know why. We know rename returns EINVAL, which could happen for a variety of reasons, all of them related to the paths themselves.

By printing the path, we will be able to figure out the actual reason. Right now we're shooting in the dark.