### PR TITLE
Revert "add debug info to release build (#1297)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ exclude = [
 [profile.release]
 codegen-units = 1
 panic = "unwind"
-debug = true
 
 [workspace.dependencies]
 rusqlite = { package = "libsql-rusqlite", path = "vendored/rusqlite", version = "0.30", default-features = false, features = [


### PR DESCRIPTION
This reverts commit 342e4c368bce0b988500e619df27cf582914793a.

~CI is broken, let's get it to a healthy state and then we see how we go about this.~
CI was fixed by https://github.com/tursodatabase/libsql/pull/1301.

But the Docker image size increased ~4x from `142MB` to `571MB`.
Even though debug symbols can help us troubleshoot that difference is significant.
We should consider having a different registry/tag for debug builds, not replacing the main one with it. 