### PR TITLE
Fix sync

### DIFF
--- a/libsql-server/tests/embedded_replica/mod.rs
+++ b/libsql-server/tests/embedded_replica/mod.rs
@@ -126,13 +126,13 @@ fn embedded_replica() {
             if key.kind() == metrics_util::MetricKind::Counter
                 && key.key().name() == "libsql_client_version"
             {
-                assert_eq!(val, &metrics_util::debugging::DebugValue::Counter(8));
+                assert_eq!(val, &metrics_util::debugging::DebugValue::Counter(6));
                 let label = key.key().labels().next().unwrap();
                 assert!(label.value().starts_with("libsql-rpc-"));
             }
         }
 
-        snapshot.assert_counter("libsql_server_user_http_response", 8);
+        snapshot.assert_counter("libsql_server_user_http_response", 6);
 
         Ok(())
     });
@@ -258,13 +258,13 @@ fn embedded_replica_with_encryption() {
             if key.kind() == metrics_util::MetricKind::Counter
                 && key.key().name() == "libsql_client_version"
             {
-                assert_eq!(val, &metrics_util::debugging::DebugValue::Counter(8));
+                assert_eq!(val, &metrics_util::debugging::DebugValue::Counter(6));
                 let label = key.key().labels().next().unwrap();
                 assert!(label.value().starts_with("libsql-rpc-"));
             }
         }
 
-        snapshot.assert_counter("libsql_server_user_http_response", 8);
+        snapshot.assert_counter("libsql_server_user_http_response", 6);
 
         conn.execute("INSERT INTO user(id) VALUES (1)", ())
             .await

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -257,20 +257,9 @@ impl Database {
     }
 
     #[cfg(feature = "replication")]
-    /// Sync until caught up with primary
-    // FIXME: there is no guarantee this ever returns!
+    /// Sync with primary
     pub async fn sync(&self) -> Result<Option<FrameNo>> {
-        let mut previous_fno = None;
-        loop {
-            let new_fno = self.sync_oneshot().await?;
-            tracing::trace!("New commited fno: {new_fno:?}");
-            if new_fno == previous_fno {
-                break;
-            } else {
-                previous_fno = new_fno;
-            }
-        }
-        Ok(previous_fno)
+        Ok(self.sync_oneshot().await?)
     }
 
     #[cfg(feature = "replication")]


### PR DESCRIPTION
Old implementation could never finish if the write is faster than time needed to do two round-trips to primary.

For example it's enough to have a write every 200ms to make sync never finish if it's done in embedded replica in Sydney if the primary and the writer are in the US.

Fixes https://github.com/tursodatabase/libsql/issues/1315