### PR TITLE
use user query string for queries rather than generated

### DIFF
--- a/libsql-server/src/query_analysis.rs
+++ b/libsql-server/src/query_analysis.rs
@@ -288,6 +288,7 @@ impl Statement {
             stmt_count: u64,
             has_more_stmts: bool,
             c: Cmd,
+            stmt_orig: &str,
         ) -> Result<Statement> {
             let kind = StmtKind::kind(&c)
                 .ok_or_else(|| anyhow::anyhow!("unsupported statement: {original}"))?;
@@ -319,8 +320,9 @@ impl Statement {
                 }) => Some((expr.clone(), name.clone())),
                 _ => None,
             };
+
             Ok(Statement {
-                stmt: c.to_string(),
+                stmt: stmt_orig.to_string(),
                 kind,
                 is_iud,
                 is_insert,
@@ -332,7 +334,19 @@ impl Statement {
         // on the heap:
         // - https://github.com/gwenn/lemon-rs/issues/8
         // - https://github.com/gwenn/lemon-rs/pull/19
-        let mut parser = Some(Box::new(Parser::new(s.as_bytes()).peekable()));
+
+        let mut parser = Box::new(Parser::new(s.as_bytes()));
+        let parser_iter = fallible_iterator::from_fn(move || {
+            let offset = parser.offset();
+            match parser.next()? {
+                Some(cmd) => {
+                    let new_offset = parser.offset();
+                    Ok(Some((cmd, &s[offset..new_offset])))
+                }
+                None => Ok(None),
+            }
+        });
+        let mut parser = Some(parser_iter.peekable());
         let mut stmt_count = 0;
         std::iter::from_fn(move || {
             // temporary macro to catch panic from the parser, until we fix it.
@@ -343,7 +357,7 @@ impl Statement {
                     };
                     match std::panic::catch_unwind(|| {
                         let ret = {
-                            let $arg = &mut p.as_mut();
+                            let $arg = &mut p;
                             $b
                         };
                         (ret, p)
@@ -363,11 +377,12 @@ impl Statement {
             let next = parse!(parser, |p| { p.next() });
 
             match next {
-                Ok(Some(cmd)) => Some(parse_inner(
+                Ok(Some((cmd, stmt_orig))) => Some(parse_inner(
                     s,
                     stmt_count,
                     parse!(parser, |p| { p.peek().map_or(true, |o| o.is_some()) }),
                     cmd,
+                    stmt_orig,
                 )),
                 Ok(None) => None,
                 Err(sqlite3_parser::lexer::sql::Error::ParserError(

--- a/libsql-server/src/schema/snapshots/libsql_server__schema__db__test__enqueue_migration_job.snap
+++ b/libsql-server/src/schema/snapshots/libsql_server__schema__db__test__enqueue_migration_job.snap
@@ -19,7 +19,7 @@ expression: stmt.query(()).unwrap().next().unwrap().unwrap()
         "migration",
     ): (
         Text,
-        "{\"steps\":[{\"cond\":null,\"query\":{\"stmt\":{\"stmt\":\"SELECT * FROM test;\",\"kind\":\"Read\",\"is_iud\":false,\"is_insert\":false,\"attach_info\":null},\"params\":{\"Positional\":[]},\"want_rows\":true}}]}",
+        "{\"steps\":[{\"cond\":null,\"query\":{\"stmt\":{\"stmt\":\"select * from test\",\"kind\":\"Read\",\"is_iud\":false,\"is_insert\":false,\"attach_info\":null},\"params\":{\"Positional\":[]},\"want_rows\":true}}]}",
     ),
     Ok(
         "status",

--- a/vendored/sqlite3-parser/src/lexer/scan.rs
+++ b/vendored/sqlite3-parser/src/lexer/scan.rs
@@ -92,6 +92,10 @@ impl<S: Splitter> Scanner<S> {
         self.line = 1;
         self.column = 1;
     }
+
+    pub(crate) fn offset(&self) -> usize {
+        self.offset
+    }
 }
 
 type ScanResult<'input, TokenType, Error> =

--- a/vendored/sqlite3-parser/src/lexer/sql/mod.rs
+++ b/vendored/sqlite3-parser/src/lexer/sql/mod.rs
@@ -54,6 +54,9 @@ impl<'input> Parser<'input> {
     pub fn column(&self) -> usize {
         self.scanner.column()
     }
+    pub fn offset(&self) -> usize {
+        self.scanner.offset()
+    }
 }
 
 /*


### PR DESCRIPTION
rather than using a query string reconstructed from the parsed AST, use the user query string.

Fixes https://github.com/tursodatabase/libsql/issues/1329