### PR TITLE
Stop holding lock during query execution

### DIFF
--- a/libsql-server/src/rpc/proxy.rs
+++ b/libsql-server/src/rpc/proxy.rs
@@ -637,20 +637,24 @@ impl Proxy for ProxyService {
                 }
             })?;
 
-        let lock = self.clients.upgradable_read().await;
-        let conn = match lock.get(&client_id) {
-            Some(conn) => conn.clone(),
-            None => {
-                tracing::debug!("connected: {client_id}");
-                match connection_maker.create().await {
-                    Ok(conn) => {
-                        assert!(conn.is_primary());
-                        let conn = Arc::new(TimeoutConnection::new(conn));
-                        let mut lock = RwLockUpgradableReadGuard::upgrade(lock).await;
-                        lock.insert(client_id, conn.clone());
-                        conn
+        let conn = {
+            let lock = self.clients.upgradable_read().await;
+            match lock.get(&client_id) {
+                Some(conn) => conn.clone(),
+                None => {
+                    tracing::debug!("connected: {client_id}");
+                    match connection_maker.create().await {
+                        Ok(conn) => {
+                            assert!(conn.is_primary());
+                            let conn = Arc::new(TimeoutConnection::new(conn));
+                            let mut lock = RwLockUpgradableReadGuard::upgrade(lock).await;
+                            lock.insert(client_id, conn.clone());
+                            conn
+                        }
+                        Err(e) => {
+                            return Err(tonic::Status::new(tonic::Code::Internal, e.to_string()))
+                        }
                     }
-                    Err(e) => return Err(tonic::Status::new(tonic::Code::Internal, e.to_string())),
                 }
             }
         };


### PR DESCRIPTION
Holding a lock during query execution can lead to a deadlock if the transaction holding it is blocked by another transaction and that other transaction can't proceed because it can't get the lock that is held by the first transaction.

Fixes #1290