### PR TITLE
libsql wal init

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "vendored/sqlite3-parser",
 
   "xtask", "libsql-hrana",
+  "libsql-wal"
 ]
 
 exclude = [

--- a/libsql-wal/Cargo.toml
+++ b/libsql-wal/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+nix = { version = "0.28.0", features = ["uio", "fs"] }
 

--- a/libsql-wal/Cargo.toml
+++ b/libsql-wal/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "libsql-wal"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+

--- a/libsql-wal/src/fs/file.rs
+++ b/libsql-wal/src/fs/file.rs
@@ -1,0 +1,123 @@
+use std::fs::File;
+use std::io::{self, ErrorKind, IoSlice, Result, Write};
+
+pub trait FileExt {
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> Result<()>;
+    fn write_at_vectored(&self, bufs: &[IoSlice], offset: u64) -> Result<usize>;
+    fn write_at(&self, buf: &[u8], offset: u64) -> Result<usize>;
+
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> Result<()>;
+
+    fn sync_all(&self) -> Result<()>;
+
+    fn set_len(&self, len: u64) -> Result<()>;
+
+    fn cursor(&self, offset: u64) -> Cursor<Self>
+    where
+        Self: Sized,
+    {
+        Cursor {
+            file: self,
+            offset,
+            count: 0,
+        }
+    }
+}
+
+impl FileExt for File {
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> Result<()> {
+        let mut written = 0;
+
+        while written != buf.len() {
+            written += nix::sys::uio::pwrite(self, &buf[written..], offset as _)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_at_vectored(&self, bufs: &[IoSlice], offset: u64) -> Result<usize> {
+        Ok(nix::sys::uio::pwritev(self, bufs, offset as _)?)
+    }
+
+    fn write_at(&self, buf: &[u8], offset: u64) -> Result<usize> {
+        Ok(nix::sys::uio::pwrite(self, buf, offset as _)?)
+    }
+
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> Result<()> {
+        let mut read = 0;
+
+        while read != buf.len() {
+            let n = nix::sys::uio::pread(self, &mut buf[read..], (offset + read as u64) as _)?;
+            if n == 0 {
+                return Err(io::Error::new(
+                    ErrorKind::UnexpectedEof,
+                    "unexpected end-of-file",
+                ));
+            }
+            read += n;
+        }
+
+        Ok(())
+    }
+
+    fn sync_all(&self) -> Result<()> {
+        std::fs::File::sync_all(self)
+    }
+
+    fn set_len(&self, len: u64) -> Result<()> {
+        std::fs::File::set_len(self, len)
+    }
+}
+
+#[derive(Debug)]
+pub struct Cursor<'a, T> {
+    file: &'a T,
+    offset: u64,
+    count: u64,
+}
+
+impl<T> Cursor<'_, T> {
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+}
+
+impl<T: FileExt> Write for Cursor<'_, T> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let count = self.file.write_at(buf, self.offset + self.count)?;
+        self.count += count as u64;
+        Ok(count)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+pub struct BufCopy<W> {
+    w: W,
+    buf: Vec<u8>,
+}
+
+impl<W> BufCopy<W> {
+    pub fn new(w: W) -> Self {
+        Self { w, buf: Vec::new() }
+    }
+
+    pub fn into_parts(self) -> (W, Vec<u8>) {
+        let Self { w, buf } = self;
+        (w, buf)
+    }
+}
+
+impl<W: Write> Write for BufCopy<W> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        let count = self.w.write(buf)?;
+        self.buf.extend_from_slice(&buf[..count]);
+        Ok(count)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.w.flush()
+    }
+}

--- a/libsql-wal/src/fs/mod.rs
+++ b/libsql-wal/src/fs/mod.rs
@@ -1,0 +1,44 @@
+use std::io;
+use std::path::Path;
+
+use self::file::FileExt;
+
+pub mod file;
+
+pub trait FileSystem {
+    type File: FileExt;
+
+    fn create_dir_all(&self, path: &Path) -> io::Result<()>;
+    fn open(
+        &self,
+        create_new: bool,
+        read: bool,
+        write: bool,
+        path: &Path,
+    ) -> io::Result<Self::File>;
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct StdFs(pub(crate) ());
+
+impl FileSystem for StdFs {
+    type File = std::fs::File;
+
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        std::fs::create_dir_all(path)
+    }
+
+    fn open(
+        &self,
+        create_new: bool,
+        read: bool,
+        write: bool,
+        path: &Path,
+    ) -> io::Result<Self::File> {
+        std::fs::OpenOptions::new()
+            .create_new(create_new)
+            .read(read)
+            .write(write)
+            .open(path)
+    }
+}

--- a/libsql-wal/src/lib.rs
+++ b/libsql-wal/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod fs;


### PR DESCRIPTION
This PR introduces the libsql-wal crate, that will contain the libsql custom wal implementation.

For now it only contains filesystem methods abstraction that the custom wal will use. Abstracting io/fs ops allows us to perform fault injection during testing.
