### PR TITLE
fix rows into stream

### DIFF
--- a/libsql/src/rows.rs
+++ b/libsql/src/rows.rs
@@ -82,7 +82,7 @@ impl Rows {
     #[cfg(feature = "stream")]
     pub fn into_stream(mut self) -> impl futures::Stream<Item = Result<Row>> {
         async_stream::try_stream! {
-            if let Some(row) = self.next().await? {
+            while let Some(row) = self.next().await? {
                 yield row
             }
         }


### PR DESCRIPTION
Into stream currently has a bug which only returns the first row. 

This PR addresses that issue