### PR TITLE
libsql wal shared wal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,12 +3462,14 @@ dependencies = [
  "bytes",
  "crossbeam",
  "fst",
+ "hashbrown 0.14.5",
  "libsql-sys",
  "memoffset 0.9.1",
  "nix 0.28.0",
  "parking_lot",
  "thiserror",
  "tracing",
+ "walkdir",
  "zerocopy",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
  "aws-smithy-types 1.1.8",
  "aws-types 1.2.0",
  "bytes",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "hex",
  "http 0.2.12",
  "hyper",
@@ -461,7 +461,7 @@ dependencies = [
  "aws-smithy-types 1.1.8",
  "aws-types 1.2.0",
  "bytes",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "http 0.2.12",
  "http-body 0.4.6",
  "percent-encoding",
@@ -524,7 +524,7 @@ dependencies = [
  "aws-smithy-xml 0.60.8",
  "aws-types 1.2.0",
  "bytes",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "hex",
  "hmac",
  "http 0.2.12",
@@ -941,7 +941,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types 1.1.8",
  "bytes",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -951,7 +951,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
@@ -1669,9 +1669,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2068,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "debugid"
@@ -2330,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fd-lock"
@@ -2639,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -2654,7 +2654,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2884,7 +2884,7 @@ dependencies = [
  "http 0.2.12",
  "hyper",
  "log",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2900,7 +2900,7 @@ dependencies = [
  "http 0.2.12",
  "hyper",
  "log",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -3006,7 +3006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3363,7 +3363,7 @@ dependencies = [
  "fallible-iterator 0.3.0",
  "futures",
  "futures-core",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hdrhistogram",
  "hmac",
  "http-body 0.4.6",
@@ -3396,7 +3396,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring 0.17.8",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "s3s",
  "s3s-fs",
@@ -3459,6 +3459,8 @@ name = "libsql-wal"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "bytes",
+ "crossbeam",
  "fst",
  "libsql-sys",
  "memoffset 0.9.1",
@@ -3557,7 +3559,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4637,7 +4639,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -4769,9 +4771,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.11"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.8",
@@ -5047,9 +5049,9 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
@@ -5067,9 +5069,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5247,9 +5249,9 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -5425,7 +5427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
@@ -5591,7 +5593,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.11",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -6016,9 +6018,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"

--- a/libsql-wal/Cargo.toml
+++ b/libsql-wal/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 arc-swap = "1.7.1"
+bytes = "1.6.0"
+crossbeam = "0.8.4"
 fst = "0.4.7"
 libsql-sys = { path = "../libsql-sys", features = ["rusqlite"] }
 memoffset = "0.9.1"

--- a/libsql-wal/Cargo.toml
+++ b/libsql-wal/Cargo.toml
@@ -10,10 +10,12 @@ arc-swap = "1.7.1"
 bytes = "1.6.0"
 crossbeam = "0.8.4"
 fst = "0.4.7"
+hashbrown = "0.14.3"
 libsql-sys = { path = "../libsql-sys", features = ["rusqlite"] }
 memoffset = "0.9.1"
 nix = { version = "0.28.0", features = ["uio", "fs"] }
 parking_lot = "0.12.1"
 thiserror = "1.0.58"
 tracing = "0.1.40"
+walkdir = "2.5.0"
 zerocopy = { version = "0.7.32", features = ["derive", "alloc"] }

--- a/libsql-wal/src/lib.rs
+++ b/libsql-wal/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod error;
 pub mod fs;
-pub mod segment;
-pub mod transaction;
-pub mod shared_wal;
-pub mod registry;
 pub mod name;
+pub mod registry;
+pub mod segment;
+pub mod shared_wal;
+pub mod transaction;

--- a/libsql-wal/src/lib.rs
+++ b/libsql-wal/src/lib.rs
@@ -1,3 +1,7 @@
 pub mod error;
 pub mod fs;
 pub mod segment;
+pub mod transaction;
+pub mod shared_wal;
+pub mod registry;
+pub mod name;

--- a/libsql-wal/src/name.rs
+++ b/libsql-wal/src/name.rs
@@ -1,0 +1,51 @@
+use std::fmt;
+
+use bytes::Bytes;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct NamespaceName(Bytes);
+
+impl fmt::Debug for NamespaceName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl Default for NamespaceName {
+    fn default() -> Self {
+        Self(Bytes::from_static(b"default"))
+    }
+}
+
+impl AsRef<str> for NamespaceName {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<&'static str> for NamespaceName {
+    fn from(value: &'static str) -> Self {
+        Self(Bytes::from_static(value.as_bytes()))
+    }
+}
+
+impl NamespaceName {
+    pub fn from_string(s: String) -> Self {
+        Self(Bytes::from(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        // Safety: the namespace is always valid UTF8
+        unsafe { std::str::from_utf8_unchecked(&self.0) }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl fmt::Display for NamespaceName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_str().fmt(f)
+    }
+}

--- a/libsql-wal/src/registry.rs
+++ b/libsql-wal/src/registry.rs
@@ -1,0 +1,212 @@
+use std::num::NonZeroU64;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use hashbrown::HashMap;
+use libsql_sys::ffi::Sqlite3DbHeader;
+use parking_lot::RwLock;
+use zerocopy::{AsBytes, FromZeroes};
+
+use crate::error::Result;
+use crate::fs::file::FileExt;
+use crate::fs::{FileSystem, StdFs};
+use crate::name::NamespaceName;
+use crate::segment::list::SegmentList;
+use crate::segment::{current::CurrentSegment, sealed::SealedSegment};
+use crate::shared_wal::SharedWal;
+use crate::transaction::{Transaction, WriteTransaction};
+
+/// Translates a path to a namespace name
+pub trait NamespaceResolver {
+    fn resolve(&self, path: &Path) -> NamespaceName;
+}
+
+impl<F: Fn(&Path) -> NamespaceName + Send + Sync + 'static> NamespaceResolver for F {
+    fn resolve(&self, path: &Path) -> NamespaceName {
+        (self)(path)
+    }
+}
+
+/// Wal Registry maintains a set of shared Wal, and their respective set of files.
+pub struct WalRegistry<FS: FileSystem> {
+    fs: FS,
+    path: PathBuf,
+    shutdown: AtomicBool,
+    opened: RwLock<HashMap<NamespaceName, Arc<SharedWal<FS>>>>,
+    resolver: Box<dyn NamespaceResolver + Send + Sync + 'static>,
+}
+
+impl WalRegistry<StdFs> {
+    pub fn new(
+        path: PathBuf,
+        resolver: impl NamespaceResolver + Send + Sync + 'static,
+    ) -> Result<Self> {
+        Self::new_with_fs(StdFs(()), path, resolver)
+    }
+}
+
+impl<FS: FileSystem> WalRegistry<FS> {
+    pub fn new_with_fs(
+        fs: FS,
+        path: PathBuf,
+        resolver: impl NamespaceResolver + Send + Sync + 'static,
+    ) -> Result<Self> {
+        fs.create_dir_all(&path)?;
+        Ok(Self {
+            fs,
+            path,
+            opened: Default::default(),
+            shutdown: Default::default(),
+            resolver: Box::new(resolver),
+        })
+    }
+
+    #[tracing::instrument(skip(self, db_path))]
+    pub fn open(self: Arc<Self>, db_path: &Path) -> Result<Arc<SharedWal<FS>>> {
+        if self.shutdown.load(Ordering::SeqCst) {
+            todo!("open after shutdown");
+        }
+
+        let namespace = self.resolver.resolve(db_path);
+        let mut opened = self.opened.upgradable_read();
+        if let Some(entry) = opened.get(&namespace) {
+            return Ok(entry.clone());
+        }
+
+        let path = self.path.join(namespace.as_str());
+        self.fs.create_dir_all(&path)?;
+        let dir = walkdir::WalkDir::new(&path).sort_by_file_name().into_iter();
+
+        let tail = SegmentList::default();
+        for entry in dir {
+            let entry = entry.map_err(|e| e.into_io_error().unwrap())?;
+            if entry
+                .path()
+                .extension()
+                .map(|e| e.to_str().unwrap() != "seg")
+                .unwrap_or(true)
+            {
+                continue;
+            }
+
+            let file = self.fs.open(false, true, true, entry.path())?;
+
+            if let Some(sealed) =
+                SealedSegment::open(file.into(), entry.path().to_path_buf(), Default::default())?
+            {
+                tail.push_log(sealed);
+            }
+        }
+
+        let db_file = self.fs.open(false, true, true, db_path)?;
+
+        // If this is a fresh database, we want to patch the header value for reserved space at the
+        // end of the file to store the replication index
+        let mut header: Sqlite3DbHeader = Sqlite3DbHeader::new_zeroed();
+        db_file.read_exact_at(header.as_bytes_mut(), 0)?;
+
+        let (db_size, next_frame_no) = tail
+            .with_head(|segment| {
+                let header = segment.header();
+                (header.db_size(), header.next_frame_no())
+            })
+            .unwrap_or((
+                header.db_size.get(),
+                NonZeroU64::new(header.replication_index.get() + 1)
+                    .unwrap_or(NonZeroU64::new(1).unwrap()),
+            ));
+
+        let current_path = path.join(format!("{namespace}:{next_frame_no:020}.seg"));
+
+        let segment_file = self.fs.open(true, true, true, &current_path)?;
+
+        let current = arc_swap::ArcSwap::new(Arc::new(CurrentSegment::create(
+            segment_file,
+            current_path,
+            next_frame_no,
+            db_size,
+            tail.into(),
+        )?));
+
+        let shared = Arc::new(SharedWal {
+            current,
+            wal_lock: Default::default(),
+            db_file,
+            registry: self.clone(),
+            namespace: namespace.clone(),
+        });
+
+        opened.with_upgraded(|opened| {
+            opened.insert(namespace.clone(), shared.clone());
+        });
+
+        Ok(shared)
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub fn swap_current(
+        &self,
+        shared: &SharedWal<FS>,
+        tx: &WriteTransaction<FS::File>,
+    ) -> Result<()> {
+        assert!(tx.is_commited());
+        // at this point we must hold a lock to a commited transaction.
+        // First, we'll acquire the lock to the current transaction to make sure no one steals it from us:
+        let lock = shared.wal_lock.tx_id.lock();
+        // Make sure that we still own the transaction:
+        if lock.is_none() || lock.unwrap() != tx.id {
+            return Ok(());
+        }
+
+        let current = shared.current.load();
+        if current.is_empty() {
+            return Ok(());
+        }
+        let start_frame_no = current.next_frame_no();
+        let path = self
+            .path
+            .join(shared.namespace.as_str())
+            .join(format!("{}:{start_frame_no:020}.seg", shared.namespace));
+
+        let segment_file = self.fs.open(true, true, true, &path)?;
+
+        let new = CurrentSegment::create(
+            segment_file,
+            path,
+            start_frame_no,
+            current.db_size(),
+            current.tail().clone(),
+        )?;
+        // sealing must the last fallible operation, because we don't want to end up in a situation
+        // where the current log is sealed and it wasn't swapped.
+        if let Some(sealed) = current.seal()? {
+            new.tail().push_log(sealed);
+        }
+
+        shared.current.swap(Arc::new(new));
+        tracing::debug!("current segment swapped");
+
+        Ok(())
+    }
+
+    // On shutdown, we checkpoint all the WALs. This require sealing the current segment, and when
+    // checkpointing all the segments
+    pub fn shutdown(&self) -> Result<()> {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let mut opened = self.opened.write();
+        for (_, shared) in opened.drain() {
+            let mut tx = Transaction::Read(shared.begin_read(u64::MAX));
+            shared.upgrade(&mut tx)?;
+            tx.commit();
+            self.swap_current(&shared, &mut tx.as_write_mut().unwrap())?;
+            // The current segment will not be used anymore. It's empty, but we still seal it so that
+            // the next startup doesn't find an unsealed segment.
+            shared.current.load().seal()?;
+            drop(tx);
+            shared.current.load().tail().checkpoint(&shared.db_file)?;
+        }
+
+        Ok(())
+    }
+}

--- a/libsql-wal/src/registry.rs
+++ b/libsql-wal/src/registry.rs
@@ -101,8 +101,6 @@ impl<FS: FileSystem> WalRegistry<FS> {
 
         let db_file = self.fs.open(false, true, true, db_path)?;
 
-        // If this is a fresh database, we want to patch the header value for reserved space at the
-        // end of the file to store the replication index
         let mut header: Sqlite3DbHeader = Sqlite3DbHeader::new_zeroed();
         db_file.read_exact_at(header.as_bytes_mut(), 0)?;
 

--- a/libsql-wal/src/segment/mod.rs
+++ b/libsql-wal/src/segment/mod.rs
@@ -1,3 +1,11 @@
+//! Libsql-wal is organized as a linked list of segments. Frames are appended to the head segments,
+//! and eventually, the head segment is swapped for a new empty one. The previous head segment is
+//! sealed and becomes immutable. The head segment is represented by the `CurrentSegment` type, and
+//! the sealed segments by the `SealedSegment` type.
+//!
+//! When a reader starts a transaction, it record the head segment current frame_no. This is the
+//! maximum frame_no that this reader is allowed to read. The reader also keeps a reference to the
+//! head segment at the moment it was created.
 #![allow(dead_code)]
 use std::mem::size_of;
 use std::num::NonZeroU64;
@@ -8,6 +16,7 @@ use zerocopy::AsBytes;
 
 use crate::error::{Error, Result};
 
+pub mod current;
 pub mod list;
 pub mod sealed;
 

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -105,8 +105,8 @@ impl<FS: FileSystem> SharedWal<FS> {
                                 "txn currently held by another connection, registering to wait queue"
                             );
                             let parker = crossbeam::sync::Parker::new();
-                            let unpaker = parker.unparker().clone();
-                            self.wal_lock.waiters.push((unpaker, read_tx.conn_id));
+                            let unparker = parker.unparker().clone();
+                            self.wal_lock.waiters.push((unparker, read_tx.conn_id));
                             drop(lock);
                             parker.park();
                         }

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -19,7 +19,7 @@ use crate::transaction::{ReadTransaction, Savepoint, Transaction, WriteTransacti
 
 #[derive(Default)]
 pub struct WalLock {
-    tx_id: Mutex<Option<u64>>,
+    pub(crate) tx_id: Mutex<Option<u64>>,
     /// When a writer is popped from the write queue, its write transaction may not be reading from the most recent
     /// snapshot. In this case, we return `SQLITE_BUSY_SNAPHSOT` to the caller. If no reads were performed
     /// with that transaction before upgrading, then the caller will call us back immediately after re-acquiring
@@ -27,17 +27,17 @@ pub struct WalLock {
     /// Without the reserved slot, the writer would be re-enqueued, a writer before it would be inserted,
     /// and we'd find ourselves in the initial situation. Instead, we use the reserved slot to bypass the queue when the 
     /// writer tried to re-acquire the write lock.
-    reserved: Mutex<Option<u64>>,
+    pub(crate) reserved: Mutex<Option<u64>>,
     next_tx_id: AtomicU64,
-    waiters: Injector<(Unparker, u64)>,
+    pub(crate) waiters: Injector<(Unparker, u64)>,
 }
 
 pub struct SharedWal<FS: FileSystem> {
-    current: ArcSwap<CurrentSegment<FS::File>>,
-    wal_lock: Arc<WalLock>,
-    db_file: FS::File,
-    namespace: NamespaceName,
-    registry: Arc<WalRegistry<FS>>,
+    pub(crate) current: ArcSwap<CurrentSegment<FS::File>>,
+    pub(crate) wal_lock: Arc<WalLock>,
+    pub(crate) db_file: FS::File,
+    pub(crate) namespace: NamespaceName,
+    pub(crate) registry: Arc<WalRegistry<FS>>,
 }
 
 impl<FS: FileSystem> SharedWal<FS> {
@@ -49,24 +49,19 @@ impl<FS: FileSystem> SharedWal<FS> {
     pub fn begin_read(&self, conn_id: u64) -> ReadTransaction<FS::File> {
         // FIXME: this is not enough to just increment the counter, we must make sure that the segment
         // is not sealed. If the segment is sealed, retry with the current segment
-        loop {
-            let current = self.current.load();
-            if current.is_sealed() {
-                continue;
-            }
-            current.inc_reader_count();
-            let (max_frame_no, db_size) =
-                current.with_header(|header| (header.last_committed(), header.db_size()));
-            let id = self.wal_lock.next_tx_id.fetch_add(1, Ordering::Relaxed);
-            return ReadTransaction {
-                id,
-                max_frame_no,
-                current: current.clone(),
-                db_size,
-                created_at: Instant::now(),
-                conn_id,
-                pages_read: 0,
-            };
+        let current = self.current.load();
+        current.inc_reader_count();
+        let (max_frame_no, db_size) =
+            current.with_header(|header| (header.last_committed(), header.db_size()));
+        let id = self.wal_lock.next_tx_id.fetch_add(1, Ordering::Relaxed);
+        ReadTransaction {
+            id,
+            max_frame_no,
+            current: current.clone(),
+            db_size,
+            created_at: Instant::now(),
+            conn_id,
+            pages_read: 0,
         }
     }
 
@@ -128,7 +123,7 @@ impl<FS: FileSystem> SharedWal<FS> {
         // 2) that transaction held the lock to tx_id (be in a transaction critical section)
         let current = self.current.load();
         let last_commited = current.last_committed();
-        if read_tx.max_frame_no != last_commited {
+        if read_tx.max_frame_no != last_commited  || current.is_sealed() {
             if read_tx.pages_read <= 1 {
                 // this transaction hasn't read anything yet, it will retry to
                 // acquire the lock, reserved the slot so that it can make
@@ -215,5 +210,9 @@ impl<FS: FileSystem> SharedWal<FS> {
     pub fn last_committed_frame_no(&self) -> u64 {
         let current = self.current.load();
         current.last_committed_frame_no()
+    }
+
+    pub fn namespace(&self) -> &NamespaceName {
+        &self.namespace
     }
 }

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -25,7 +25,7 @@ pub struct WalLock {
     /// with that transaction before upgrading, then the caller will call us back immediately after re-acquiring
     /// a read mark.
     /// Without the reserved slot, the writer would be re-enqueued, a writer before it would be inserted,
-    /// and we'd find ourselves in the initial situation. Instead, we use the reserved slot to bypass the queue when the 
+    /// and we'd find ourselves in the initial situation. Instead, we use the reserved slot to bypass the queue when the
     /// writer tried to re-acquire the write lock.
     pub(crate) reserved: Mutex<Option<u64>>,
     next_tx_id: AtomicU64,
@@ -123,7 +123,7 @@ impl<FS: FileSystem> SharedWal<FS> {
         // 2) that transaction held the lock to tx_id (be in a transaction critical section)
         let current = self.current.load();
         let last_commited = current.last_committed();
-        if read_tx.max_frame_no != last_commited  || current.is_sealed() {
+        if read_tx.max_frame_no != last_commited || current.is_sealed() {
             if read_tx.pages_read <= 1 {
                 // this transaction hasn't read anything yet, it will retry to
                 // acquire the lock, reserved the slot so that it can make

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -1,0 +1,221 @@
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use arc_swap::ArcSwap;
+use crossbeam::deque::Injector;
+use crossbeam::sync::Unparker;
+use libsql_sys::wal::PageHeaders;
+use parking_lot::{Mutex, MutexGuard};
+
+use crate::error::{Error, Result};
+use crate::fs::file::FileExt;
+use crate::fs::FileSystem;
+use crate::name::NamespaceName;
+use crate::registry::WalRegistry;
+use crate::segment::current::CurrentSegment;
+use crate::transaction::{ReadTransaction, Savepoint, Transaction, WriteTransaction};
+
+#[derive(Default)]
+pub struct WalLock {
+    pub tx_id: Mutex<Option<u64>>,
+    pub reserved: Mutex<Option<u64>>,
+    pub next_tx_id: AtomicU64,
+    pub waiters: Injector<(Unparker, u64)>,
+}
+
+pub struct SharedWal<FS: FileSystem> {
+    pub current: ArcSwap<CurrentSegment<FS::File>>,
+    pub wal_lock: Arc<WalLock>,
+    /// Current transaction id
+    pub db_file: FS::File,
+    pub namespace: NamespaceName,
+    pub registry: Arc<WalRegistry<FS>>,
+}
+
+impl<FS: FileSystem> SharedWal<FS> {
+    pub fn db_size(&self) -> u32 {
+        self.current.load().db_size()
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub fn begin_read(&self, conn_id: u64) -> ReadTransaction<FS::File> {
+        // FIXME: this is not enough to just increment the counter, we must make sure that the segment
+        // is not sealed. If the segment is sealed, retry with the current segment
+        loop {
+            let current = self.current.load();
+            // FIXME: This function comes up a lot more than in should in profiling. I suspect that
+            // this is caused by those expensive loads here
+            current.inc_reader_count();
+            if current.is_sealed() {
+                continue;
+            }
+            let (max_frame_no, db_size) =
+                current.with_header(|header| (header.last_committed(), header.db_size()));
+            let id = self.wal_lock.next_tx_id.fetch_add(1, Ordering::Relaxed);
+            return ReadTransaction {
+                id,
+                max_frame_no,
+                current: current.clone(),
+                db_size,
+                created_at: Instant::now(),
+                conn_id,
+                pages_read: 0,
+            };
+        }
+    }
+
+    /// Upgrade a read transaction to a write transaction
+    pub fn upgrade(&self, tx: &mut Transaction<FS::File>) -> Result<()> {
+        loop {
+            match tx {
+                Transaction::Write(_) => unreachable!("already in a write transaction"),
+                Transaction::Read(read_tx) => {
+                    {
+                        let mut reserved = self.wal_lock.reserved.lock();
+                        match *reserved {
+                            // we have already reserved the slot, go ahead and try to acquire
+                            Some(id) if id == read_tx.conn_id => {
+                                tracing::trace!("taking reserved slot");
+                                reserved.take();
+                                let lock = self.wal_lock.tx_id.lock();
+                                let write_tx = self.acquire_write(read_tx, lock, reserved)?;
+                                *tx = Transaction::Write(write_tx);
+                                //                                println!("upgraded: {}", before.elapsed().as_micros());1
+                                return Ok(());
+                            }
+                            _ => (),
+                        }
+                    }
+
+                    let lock = self.wal_lock.tx_id.lock();
+                    match *lock {
+                        None if self.wal_lock.waiters.is_empty() => {
+                            let write_tx =
+                                self.acquire_write(read_tx, lock, self.wal_lock.reserved.lock())?;
+                            *tx = Transaction::Write(write_tx);
+                            //                            println!("upgraded: {}", before.elapsed().as_micros());1
+                            return Ok(());
+                        }
+                        Some(_) | None => {
+                            tracing::trace!(
+                                "txn currently held by another connection, registering to wait queue"
+                            );
+                            let parker = crossbeam::sync::Parker::new();
+                            let unpaker = parker.unparker().clone();
+                            self.wal_lock.waiters.push((unpaker, read_tx.conn_id));
+                            drop(lock);
+                            parker.park();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn acquire_write(
+        &self,
+        read_tx: &ReadTransaction<FS::File>,
+        mut tx_id_lock: MutexGuard<Option<u64>>,
+        mut reserved: MutexGuard<Option<u64>>,
+    ) -> Result<WriteTransaction<FS::File>> {
+        // we read two fields in the header. There is no risk that a transaction commit in
+        // between the two reads because this would require that:
+        // 1) there would be a running txn
+        // 2) that transaction held the lock to tx_id (be in a transaction critical section)
+        let current = self.current.load();
+        let last_commited = current.last_committed();
+        if read_tx.max_frame_no != last_commited {
+            if read_tx.pages_read <= 1 {
+                // this transaction hasn't read anything yet, it will retry to
+                // acquire the lock, reserved the slot so that it can make
+                // progress quickly
+                tracing::debug!("reserving tx slot");
+                reserved.replace(read_tx.conn_id);
+            }
+            return Err(Error::BusySnapshot);
+        }
+        let next_offset = current.count_committed() as u32;
+        let next_frame_no = current.next_frame_no().get();
+        *tx_id_lock = Some(read_tx.id);
+
+        Ok(WriteTransaction {
+            wal_lock: self.wal_lock.clone(),
+            savepoints: vec![Savepoint {
+                next_offset,
+                next_frame_no,
+                index: BTreeMap::new(),
+            }],
+            next_frame_no,
+            next_offset,
+            is_commited: false,
+            read_tx: read_tx.clone(),
+        })
+    }
+
+    #[tracing::instrument(skip(self, tx, buffer))]
+    pub fn read_frame(
+        &self,
+        tx: &mut Transaction<FS::File>,
+        page_no: u32,
+        buffer: &mut [u8],
+    ) -> Result<()> {
+        match tx.current.find_frame(page_no, tx) {
+            Some(offset) => tx.current.read_page_offset(offset, buffer)?,
+            None => {
+                // locate in segments
+                if !tx
+                    .current
+                    .tail()
+                    .read_page(page_no, tx.max_frame_no, buffer)?
+                {
+                    // read from db_file
+                    tracing::trace!(page_no, "reading from main file");
+                    self.db_file
+                        .read_exact_at(buffer, (page_no as u64 - 1) * 4096)?;
+                }
+            }
+        }
+
+        tx.pages_read += 1;
+
+        // let frame_no = u64::from_be_bytes(buffer[4096 - 8..].try_into().unwrap());
+        // tracing::trace!(frame_no, tx = tx.max_frame_no, "read page");
+        // assert!(
+        //     dbg!(frame_no) <= dbg!(tx.max_frame_no()),
+        //     "read frame out of transaction boundaries"
+        // );
+        //
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all, fields(tx_id = tx.id))]
+    pub fn insert_frames(
+        &self,
+        tx: &mut WriteTransaction<FS::File>,
+        pages: &mut PageHeaders,
+        size_after: u32,
+    ) -> Result<()> {
+        let current = self.current.load();
+        current.insert_pages(pages.iter(), (size_after != 0).then_some(size_after), tx)?;
+
+        // TODO: use config for max log size
+        if tx.is_commited() && current.count_committed() > 1000 {
+            self.registry.swap_current(self, tx)?;
+        }
+
+        // TODO: remove, stupid strategy for tests
+        // ok, we still hold a write txn
+        if current.tail().len() > 10 {
+            current.tail().checkpoint(&self.db_file)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn last_committed_frame_no(&self) -> u64 {
+        let current = self.current.load();
+        current.last_committed_frame_no()
+    }
+}


### PR DESCRIPTION
Introduce `SharedWal` and `WalRegistry`

The `WalRegistry` manages wal instances and ressources from different databases. In libsql wal, the wal segments are managed by the registry, and so are the database files. All read and writes to the main file go through the wal.

The `SharedWal` brings all the different parts of the wal together.
