### PR TITLE
server: flag to destroy metastore on restore err

### DIFF
--- a/libsql-server/src/config.rs
+++ b/libsql-server/src/config.rs
@@ -180,6 +180,8 @@ pub struct HeartbeatConfig {
 pub struct MetaStoreConfig {
     pub bottomless: Option<BottomlessConfig>,
     pub allow_recover_from_fs: bool,
+    /// Destroy the metastore if there is a restore error
+    pub destroy_on_error: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -227,6 +227,13 @@ struct Cli {
     #[clap(long, env = "SQLD_META_STORE_BUCKET_ENDPOINT")]
     meta_store_bucket_endpoint: Option<String>,
 
+    #[clap(
+        long,
+        env = "SQLD_META_STORE_DESTROY_ON_ERROR",
+        default_value = "false"
+    )]
+    meta_store_destroy_on_error: bool,
+
     /// encryption_key for encryption at rest
     #[clap(long, env = "SQLD_ENCRYPTION_KEY")]
     encryption_key: Option<bytes::Bytes>,
@@ -586,6 +593,7 @@ fn make_meta_store_config(config: &Cli) -> anyhow::Result<MetaStoreConfig> {
     Ok(MetaStoreConfig {
         bottomless,
         allow_recover_from_fs: config.allow_metastore_recovery,
+        destroy_on_error: config.meta_store_destroy_on_error,
     })
 }
 


### PR DESCRIPTION
This adds a new flag that when set to true will destroy the metastore and start with a fresh db file when restore runs into issues. This is a temp fix to for larger metastore restore issues that include disk malformed issues that we have seen.