### PR TITLE
fix readme: go-libsql link

### DIFF
--- a/README-libsql.md
+++ b/README-libsql.md
@@ -16,7 +16,7 @@ This libSQL API is an experimental, batteries-included library built on top of S
 * [Rust](core) 
 * [Python](https://github.com/libsql/libsql-experimental-python)
 * [JavaScript](https://github.com/libsql/libsql-experimental-node)
-* [Go](bindings/go) (wip)
+* [Go](https://github.com/libsql/go-libsql)
 * [C](bindings/c) (wip)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To get started with the libSQL API:
 * [JavaScript](https://github.com/libsql/libsql-experimental-node)
 * [Rust](libsql) 
 * [Python](https://github.com/libsql/libsql-experimental-python) (experimental)
-* [Go](bindings/go) (experimental)
+* [Go](https://github.com/libsql/go-libsql)
 * [C](bindings/c) (experimental)
 
 To build the SQLite-compatible C library and tools, run:


### PR DESCRIPTION
Fixes some broken links to the Go libsql repo.

Original link pointed to `bindings/go`

Link should point to: https://github.com/libsql/go-libsql