### PR TITLE
add session_token for AWS short-term credentials

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -97,6 +97,7 @@ pub struct Options {
     pub aws_endpoint: Option<String>,
     pub access_key_id: Option<String>,
     pub secret_access_key: Option<String>,
+    pub session_token: Option<String>,
     pub region: Option<String>,
     pub db_id: Option<String>,
     /// Bucket directory name where all S3 objects are backed up. General schema is:
@@ -136,13 +137,14 @@ impl Options {
         let secret_access_key = self.secret_access_key.clone().ok_or(anyhow!(
             "LIBSQL_BOTTOMLESS_AWS_SECRET_ACCESS_KEY was not set"
         ))?;
+        let session_token: Option<String> = self.session_token.clone();
         let conf = loader
             .behavior_version(BehaviorVersion::latest())
             .region(Region::new(region))
             .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
                 access_key_id,
                 secret_access_key,
-                None,
+                session_token,
                 None,
                 "Static",
             )))
@@ -188,6 +190,7 @@ impl Options {
         );
         let access_key_id = env_var("LIBSQL_BOTTOMLESS_AWS_ACCESS_KEY_ID").ok();
         let secret_access_key = env_var("LIBSQL_BOTTOMLESS_AWS_SECRET_ACCESS_KEY").ok();
+        let session_token = env_var("LIBSQL_BOTTOMLESS_AWS_SESSION_TOKEN").ok();
         let region = env_var("LIBSQL_BOTTOMLESS_AWS_DEFAULT_REGION").ok();
         let max_frames_per_batch =
             env_var_or("LIBSQL_BOTTOMLESS_BATCH_MAX_FRAMES", 10000).parse::<usize>()?;
@@ -243,6 +246,7 @@ impl Options {
             aws_endpoint,
             access_key_id,
             secret_access_key,
+            session_token,
             region,
             bucket_name,
             s3_max_retries,

--- a/libsql-server/src/config.rs
+++ b/libsql-server/src/config.rs
@@ -184,6 +184,7 @@ pub struct MetaStoreConfig {
 pub struct BottomlessConfig {
     pub access_key_id: String,
     pub secret_access_key: String,
+    pub session_token: Option<String>,
     pub region: String,
     pub backup_id: String,
     pub bucket_name: String,

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -212,6 +212,9 @@ struct Cli {
     /// S3 secret access key for the meta store backup
     #[clap(long, env = "SQLD_META_STORE_SECRET_ACCESS")]
     meta_store_secret_access_key: Option<String>,
+    /// S3 session token for the meta store backup
+    #[clap(long, env = "SQLD_META_STORE_SESSION_TOKEN")]
+    meta_store_session_token: Option<String>,
     /// S3 region for the metastore backup
     #[clap(long, env = "SQLD_META_STORE_REGION")]
     meta_store_region: Option<String>,
@@ -573,6 +576,7 @@ fn make_meta_store_config(config: &Cli) -> anyhow::Result<MetaStoreConfig> {
                 .meta_store_secret_access_key
                 .clone()
                 .context("missing meta store bucket secret access key")?,
+            session_token: config.meta_store_session_token.clone(),
             region: config
                 .meta_store_region
                 .clone()

--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -119,6 +119,7 @@ pub async fn metastore_connection_maker(
                 aws_endpoint: Some(config.bucket_endpoint),
                 access_key_id: Some(config.access_key_id),
                 secret_access_key: Some(config.secret_access_key),
+                session_token: config.session_token,
                 region: Some(config.region),
                 db_id: Some(config.backup_id),
                 bucket_name: config.bucket_name,


### PR DESCRIPTION
This PR adds the functionality to use temporary credentials to backup the database to S3. The AWS_SESSION_TOKEN can be optionally passed in to use temporary credentials locally or in an environment like EC2/EKS where roles are attached to the instance.

@avinassh Created a new PR as the old one had some problems with squashing commits.