### PR TITLE
Proof of concept of CDC on libsql-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,7 +1127,11 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "serde",
+ "serde_html_form",
+ "serde_json",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5250,6 +5254,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de514ef58196f1fc96dcaef80fe6170a1ce6215df9687a93fe8300e773fefc5"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5807,6 +5824,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ rusqlite = { package = "libsql-rusqlite", path = "vendored/rusqlite", version = 
     "modern_sqlite",
     "functions",
     "limits",
+    "hooks",
 ] }
 
 # Config for 'cargo dist'

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -15,7 +15,7 @@ async-stream = "0.3.5"
 async-tempfile = "0.4.0"
 async-trait = "0.1.58"
 axum = { version = "0.6.18", features = ["headers"] }
-axum-extra = "0.7"
+axum-extra = { version = "0.7", features = ["json-lines", "query"] }
 base64 = "0.21.0"
 bincode = "1.3.3"
 bottomless = { version = "0", path = "../bottomless", features = ["libsql_linked_statically"] }
@@ -67,7 +67,7 @@ sqlite3-parser = { package = "libsql-sqlite3-parser", path = "../vendored/sqlite
 tempfile = "3.7.0"
 thiserror = "1.0.38"
 tokio = { version = "1.22.2", features = ["rt-multi-thread", "net", "io-std", "io-util", "time", "macros", "sync", "fs", "signal"] }
-tokio-stream = "0.1.11"
+tokio-stream = { version = "0.1.11", features = ["sync"] }
 tokio-tungstenite = "0.20"
 tokio-util = { version = "0.7.8", features = ["io", "io-util"] }
 tonic = { version = "0.11", features = ["tls"] }

--- a/libsql-server/src/broadcaster.rs
+++ b/libsql-server/src/broadcaster.rs
@@ -1,0 +1,126 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast::{self};
+use tokio_stream::wrappers::BroadcastStream;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum BroadcastMsg {
+    Commit,
+    Rollback,
+    #[serde(untagged)]
+    Change {
+        action: Action,
+        rowid: i64,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Action {
+    UNKNOWN,
+    DELETE,
+    INSERT,
+    UPDATE,
+}
+
+impl From<rusqlite::hooks::Action> for Action {
+    fn from(value: rusqlite::hooks::Action) -> Self {
+        match value {
+            rusqlite::hooks::Action::SQLITE_DELETE => Action::DELETE,
+            rusqlite::hooks::Action::SQLITE_INSERT => Action::INSERT,
+            rusqlite::hooks::Action::SQLITE_UPDATE => Action::UPDATE,
+            _ => Action::UNKNOWN,
+        }
+    }
+}
+
+impl From<&str> for Action {
+    fn from(value: &str) -> Self {
+        match value {
+            "delete" => Action::DELETE,
+            "insert" => Action::INSERT,
+            "update" => Action::UPDATE,
+            _ => Action::UNKNOWN,
+        }
+    }
+}
+
+pub struct UpdateSubscription {
+    pub inner: BroadcastStream<BroadcastMsg>,
+}
+
+const BROADCAST_CAP: usize = 1024;
+
+#[derive(Debug, Default)]
+pub struct BroadcasterInner {
+    senders: Mutex<HashMap<String, broadcast::Sender<BroadcastMsg>>>,
+    active: AtomicBool,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Broadcaster {
+    inner: Arc<BroadcasterInner>,
+}
+
+impl Broadcaster {
+    pub fn active(&self) -> bool {
+        self.inner.active.load(Ordering::Relaxed)
+    }
+
+    pub fn notify(&self, table: &str, msg: BroadcastMsg) {
+        if !self.active() {
+            return;
+        }
+        self.inner
+            .senders
+            .lock()
+            .get(table)
+            .map(|sender| sender.send(msg));
+    }
+
+    pub fn notify_all(&self, msg: BroadcastMsg) {
+        if !self.active() {
+            return;
+        }
+        self.inner.senders.lock().values().for_each(|sender| {
+            _ = sender.send(msg.clone());
+        });
+    }
+
+    pub fn subscribe(&self, table: String) -> UpdateSubscription {
+        let receiver = match self.inner.senders.lock().entry(table) {
+            Entry::Occupied(entry) => entry.get().subscribe(),
+            Entry::Vacant(entry) => {
+                let (sender, receiver) = broadcast::channel(BROADCAST_CAP);
+                entry.insert(sender);
+                self.inner.active.store(true, Ordering::Relaxed);
+                receiver
+            }
+        };
+
+        UpdateSubscription {
+            inner: BroadcastStream::new(receiver),
+        }
+    }
+
+    pub fn unsubscribe(&self, table: String) {
+        let mut tables = self.inner.senders.lock();
+        if let Some(sender) = tables.get(&table) {
+            if sender.receiver_count() == 0 {
+                tables.remove(&table);
+                if tables.is_empty() {
+                    self.inner.active.store(false, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+}

--- a/libsql-server/src/broadcaster.rs
+++ b/libsql-server/src/broadcaster.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use tokio::sync::broadcast::{self};
 use tokio_stream::wrappers::BroadcastStream;
 
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Copy, Clone, Serialize, Default)]
 pub struct BroadcastMsg {
     #[serde(skip_serializing_if = "is_zero")]
     pub unknown: u64,
@@ -109,11 +109,11 @@ impl Broadcaster {
         BroadcastStream::new(receiver)
     }
 
-    pub fn unsubscribe(&self, table: String) {
+    pub fn unsubscribe(&self, table: &String) {
         let mut tables = self.inner.senders.lock();
-        if let Some(sender) = tables.get(&table) {
+        if let Some(sender) = tables.get(table) {
             if sender.receiver_count() == 0 {
-                tables.remove(&table);
+                tables.remove(table);
                 if tables.is_empty() {
                     self.inner.active.store(false, Ordering::Relaxed);
                 }

--- a/libsql-server/src/broadcaster.rs
+++ b/libsql-server/src/broadcaster.rs
@@ -20,6 +20,7 @@ pub struct BroadcastMsg {
     pub update: u64,
 }
 
+#[inline(always)]
 fn is_zero(num: &u64) -> bool {
     *num == 0
 }

--- a/libsql-server/src/broadcaster.rs
+++ b/libsql-server/src/broadcaster.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{hash_map::Entry, HashMap},
+    mem,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -7,61 +8,29 @@ use std::{
 };
 
 use parking_lot::Mutex;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tokio::sync::broadcast::{self};
 use tokio_stream::wrappers::BroadcastStream;
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "action", rename_all = "snake_case")]
-pub enum BroadcastMsg {
-    Commit,
-    Rollback,
-    #[serde(untagged)]
-    Change {
-        action: Action,
-        rowid: i64,
-    },
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct BroadcastMsg {
+    #[serde(skip_serializing_if = "is_zero")]
+    pub unknown: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub delete: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub insert: u64,
+    #[serde(skip_serializing_if = "is_zero")]
+    pub update: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum Action {
-    UNKNOWN,
-    DELETE,
-    INSERT,
-    UPDATE,
+fn is_zero(num: &u64) -> bool {
+    *num == 0
 }
-
-impl From<rusqlite::hooks::Action> for Action {
-    fn from(value: rusqlite::hooks::Action) -> Self {
-        match value {
-            rusqlite::hooks::Action::SQLITE_DELETE => Action::DELETE,
-            rusqlite::hooks::Action::SQLITE_INSERT => Action::INSERT,
-            rusqlite::hooks::Action::SQLITE_UPDATE => Action::UPDATE,
-            _ => Action::UNKNOWN,
-        }
-    }
-}
-
-impl From<&str> for Action {
-    fn from(value: &str) -> Self {
-        match value {
-            "delete" => Action::DELETE,
-            "insert" => Action::INSERT,
-            "update" => Action::UPDATE,
-            _ => Action::UNKNOWN,
-        }
-    }
-}
-
-pub struct UpdateSubscription {
-    pub inner: BroadcastStream<BroadcastMsg>,
-}
-
-const BROADCAST_CAP: usize = 1024;
 
 #[derive(Debug, Default)]
 pub struct BroadcasterInner {
+    state: Mutex<HashMap<String, BroadcastMsg>>,
     senders: Mutex<HashMap<String, broadcast::Sender<BroadcastMsg>>>,
     active: AtomicBool,
 }
@@ -72,44 +41,72 @@ pub struct Broadcaster {
 }
 
 impl Broadcaster {
+    const BROADCAST_CAP: usize = 1024;
+
     pub fn active(&self) -> bool {
         self.inner.active.load(Ordering::Relaxed)
     }
 
-    pub fn notify(&self, table: &str, msg: BroadcastMsg) {
+    pub fn notify(&self, table: &str, action: rusqlite::hooks::Action) {
         if !self.active() {
             return;
         }
-        self.inner
-            .senders
-            .lock()
-            .get(table)
-            .map(|sender| sender.send(msg));
+        let mut state = self.inner.state.lock();
+        if let Some(entry) = state.get_mut(table) {
+            Self::increment(entry, action);
+        } else {
+            let mut entry = BroadcastMsg::default();
+            Self::increment(&mut entry, action);
+            state.insert(table.into(), entry);
+        }
     }
 
-    pub fn notify_all(&self, msg: BroadcastMsg) {
+    fn increment(value: &mut BroadcastMsg, action: rusqlite::hooks::Action) {
+        match action {
+            rusqlite::hooks::Action::SQLITE_DELETE => value.delete += 1,
+            rusqlite::hooks::Action::SQLITE_INSERT => value.insert += 1,
+            rusqlite::hooks::Action::SQLITE_UPDATE => value.update += 1,
+            _ => value.unknown += 1,
+        }
+    }
+
+    pub fn commit(&self) {
         if !self.active() {
             return;
         }
-        self.inner.senders.lock().values().for_each(|sender| {
-            _ = sender.send(msg.clone());
-        });
+        let senders = self.inner.senders.lock();
+        for (table, entry) in self.flush_changes() {
+            if let Some(sender) = senders.get(&table) {
+                _ = sender.send(entry);
+            }
+        }
     }
 
-    pub fn subscribe(&self, table: String) -> UpdateSubscription {
+    pub fn flush_changes(&self) -> HashMap<String, BroadcastMsg> {
+        let mut changes = HashMap::new();
+        mem::swap(&mut changes, &mut *self.inner.state.lock());
+        changes
+    }
+
+    pub fn rollback(&self) {
+        if !self.active() {
+            return;
+        }
+        self.flush_changes();
+    }
+
+    pub fn subscribe(&self, table: String) -> BroadcastStream<BroadcastMsg> {
         let receiver = match self.inner.senders.lock().entry(table) {
             Entry::Occupied(entry) => entry.get().subscribe(),
             Entry::Vacant(entry) => {
-                let (sender, receiver) = broadcast::channel(BROADCAST_CAP);
+                let (sender, receiver) = broadcast::channel(Self::BROADCAST_CAP);
                 entry.insert(sender);
                 self.inner.active.store(true, Ordering::Relaxed);
                 receiver
             }
         };
 
-        UpdateSubscription {
-            inner: BroadcastStream::new(receiver),
-        }
+        BroadcastStream::new(receiver)
     }
 
     pub fn unsubscribe(&self, table: String) {

--- a/libsql-server/src/config.rs
+++ b/libsql-server/src/config.rs
@@ -62,6 +62,7 @@ pub struct UserApiConfig<A = AddrIncoming> {
     pub http_acceptor: Option<A>,
     pub enable_http_console: bool,
     pub self_url: Option<String>,
+    pub primary_url: Option<String>,
     pub auth_strategy: Auth,
 }
 
@@ -72,6 +73,7 @@ impl<A> Default for UserApiConfig<A> {
             http_acceptor: Default::default(),
             enable_http_console: Default::default(),
             self_url: Default::default(),
+            primary_url: Default::default(),
             auth_strategy: Auth::new(Disabled::new()),
         }
     }

--- a/libsql-server/src/connection/write_proxy.rs
+++ b/libsql-server/src/connection/write_proxy.rs
@@ -16,6 +16,7 @@ use tokio_stream::StreamExt;
 use tonic::transport::Channel;
 use tonic::{Request, Streaming};
 
+use crate::broadcaster::Broadcaster;
 use crate::connection::program::{DescribeCol, DescribeParam};
 use crate::error::Error;
 use crate::metrics::{REPLICA_LOCAL_EXEC_MISPREDICT, REPLICA_LOCAL_PROGRAM_EXEC};
@@ -68,6 +69,7 @@ impl MakeWriteProxyConn {
             db_path.clone(),
             PassthroughWalWrapper,
             stats.clone(),
+            Broadcaster::default(),
             config_store.clone(),
             extensions.clone(),
             max_response_size,

--- a/libsql-server/src/connection/write_proxy.rs
+++ b/libsql-server/src/connection/write_proxy.rs
@@ -16,10 +16,10 @@ use tokio_stream::StreamExt;
 use tonic::transport::Channel;
 use tonic::{Request, Streaming};
 
-use crate::broadcaster::Broadcaster;
 use crate::connection::program::{DescribeCol, DescribeParam};
 use crate::error::Error;
 use crate::metrics::{REPLICA_LOCAL_EXEC_MISPREDICT, REPLICA_LOCAL_PROGRAM_EXEC};
+use crate::namespace::broadcasters::BroadcasterHandle;
 use crate::namespace::meta_store::MetaStoreHandle;
 use crate::namespace::ResolveNamespacePathFn;
 use crate::query_analysis::TxnStatus;
@@ -55,6 +55,7 @@ impl MakeWriteProxyConn {
         channel: Channel,
         uri: tonic::transport::Uri,
         stats: Arc<Stats>,
+        broadcaster: BroadcasterHandle,
         config_store: MetaStoreHandle,
         applied_frame_no_receiver: watch::Receiver<Option<FrameNo>>,
         max_response_size: u64,
@@ -69,7 +70,7 @@ impl MakeWriteProxyConn {
             db_path.clone(),
             PassthroughWalWrapper,
             stats.clone(),
-            Broadcaster::default(),
+            broadcaster,
             config_store.clone(),
             extensions.clone(),
             max_response_size,

--- a/libsql-server/src/http/user/listen.rs
+++ b/libsql-server/src/http/user/listen.rs
@@ -1,0 +1,184 @@
+use std::{
+    collections::HashMap,
+    mem,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use crate::broadcaster::{Action, BroadcastMsg, UpdateSubscription};
+use crate::error::Error;
+use crate::{
+    auth::Authenticated,
+    namespace::{NamespaceName, NamespaceStore},
+};
+use axum::http::Uri;
+use axum::response::{IntoResponse, Response};
+use axum::{body::BoxBody, extract::State as AxumState};
+use axum_extra::{extract::Query, json_lines::JsonLines};
+use futures::{Stream, StreamExt};
+use hyper::HeaderMap;
+use serde::{Deserialize, Serialize};
+
+use super::db_factory::namespace_from_headers;
+use super::AppState;
+
+#[derive(Deserialize)]
+pub struct ListenQuery {
+    table: String,
+    action: Vec<Action>,
+}
+
+pub(super) async fn handle_listen(
+    auth: Authenticated,
+    AxumState(state): AxumState<AppState>,
+    headers: HeaderMap,
+    uri: Uri,
+    mut query: Query<ListenQuery>,
+) -> crate::Result<Response> {
+    let namespace = namespace_from_headers(
+        &headers,
+        state.disable_default_namespace,
+        state.disable_namespaces,
+    )?;
+
+    if !auth.is_namespace_authorized(&namespace) {
+        return Err(Error::NamespaceDoesntExist(namespace.to_string()));
+    }
+
+    if let Some(primary_url) = state.primary_url {
+        return Ok(Response::builder()
+            .status(307)
+            .header("Location", primary_url + uri.path())
+            .body(BoxBody::default())
+            .unwrap());
+    }
+
+    // TODO: validate table
+    let table = mem::take(&mut query.table);
+    let actions = mem::take(&mut query.action);
+
+    let stream =
+        SubscriptionAggregator::new(state.namespaces.clone(), namespace, table, actions).await?;
+    Ok(JsonLines::new(stream).into_response())
+}
+
+static LAGGED_MSG: &str = "some changes were lost";
+
+type AggregatorState = HashMap<Action, u64>;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum AggregatorEvent {
+    Error(&'static str),
+    #[serde(untagged)]
+    Changes(AggregatorState),
+}
+
+type AggregatorResult = Result<AggregatorEvent, Error>;
+type AggregatorPoll = Poll<Option<AggregatorResult>>;
+
+struct SubscriptionAggregator {
+    actions: Vec<Action>,
+    subscription: UpdateSubscription,
+    state: AggregatorState,
+    store: NamespaceStore,
+    namespace: NamespaceName,
+    table: String,
+    errored: bool,
+}
+
+impl SubscriptionAggregator {
+    async fn new(
+        store: NamespaceStore,
+        namespace: NamespaceName,
+        table: String,
+        actions: Vec<Action>,
+    ) -> crate::Result<Self> {
+        let subscription = store
+            .subscribe(namespace.clone(), table.clone())
+            .await
+            .unwrap();
+        Ok(Self {
+            actions,
+            subscription,
+            state: HashMap::new(),
+            store,
+            namespace,
+            table,
+            errored: false,
+        })
+    }
+}
+
+impl Drop for SubscriptionAggregator {
+    fn drop(&mut self) {
+        let namespace = mem::take(&mut self.namespace);
+        let table = mem::take(&mut self.table);
+        let store = self.store.clone();
+        tokio::spawn(async move { _ = store.unsubscribe(namespace, table).await });
+    }
+}
+
+impl Stream for SubscriptionAggregator {
+    type Item = AggregatorResult;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        loop {
+            if let Some(poll) = self.poll_inner(cx) {
+                return poll;
+            }
+        }
+    }
+}
+
+impl SubscriptionAggregator {
+    fn poll_inner(self: &mut Self, cx: &mut Context) -> Option<AggregatorPoll> {
+        match self.subscription.inner.poll_next_unpin(cx) {
+            Poll::Pending => Some(Poll::Pending),
+            Poll::Ready(value) => match value {
+                None => Some(Poll::Ready(None)),
+                Some(result) => match result {
+                    Ok(item) => match item {
+                        BroadcastMsg::Change { action, .. } => self.register(action),
+                        BroadcastMsg::Rollback => self.clear(),
+                        BroadcastMsg::Commit => self.flush(),
+                    },
+                    Err(_) => self.error(),
+                },
+            },
+        }
+    }
+
+    fn flush(&mut self) -> Option<AggregatorPoll> {
+        self.errored = false;
+        if self.state.is_empty() {
+            return None;
+        }
+        let changes = mem::take(&mut self.state);
+        Some(Poll::Ready(Some(Ok(AggregatorEvent::Changes(changes)))))
+    }
+
+    fn error(&mut self) -> Option<AggregatorPoll> {
+        let errored = self.errored;
+        self.clear();
+        self.errored = true;
+        if errored {
+            return None;
+        }
+        Some(Poll::Ready(Some(Ok(AggregatorEvent::Error(&LAGGED_MSG)))))
+    }
+
+    fn register(&mut self, action: Action) -> Option<AggregatorPoll> {
+        if self.actions.is_empty() || self.actions.contains(&action) {
+            let total = self.state.entry(action).or_insert(0);
+            *total += 1;
+        }
+        None
+    }
+
+    fn clear(&mut self) -> Option<AggregatorPoll> {
+        self.errored = false;
+        self.state.clear();
+        None
+    }
+}

--- a/libsql-server/src/http/user/listen.rs
+++ b/libsql-server/src/http/user/listen.rs
@@ -108,9 +108,7 @@ async fn listen_stream(
             table: table.clone(),
         };
 
-        let mut stream = store
-            .subscribe(namespace.clone(), table.clone())
-            .await?;
+        let mut stream = store.subscribe(namespace.clone(), table.clone());
 
         while let Some(item) = stream.next().await  {
             match item {

--- a/libsql-server/src/http/user/mod.rs
+++ b/libsql-server/src/http/user/mod.rs
@@ -2,6 +2,7 @@ pub mod db_factory;
 mod dump;
 mod extract;
 mod hrana_over_http_1;
+mod listen;
 mod result_builder;
 mod trace;
 mod types;
@@ -350,6 +351,7 @@ where
                 .route("/console", get(show_console))
                 .route("/health", get(handle_health))
                 .route("/dump", get(dump::handle_dump))
+                .route("/beta/listen", get(listen::handle_listen))
                 .route("/v1", get(hrana_over_http_1::handle_index))
                 .route("/v1/execute", post(hrana_over_http_1::handle_execute))
                 .route("/v1/batch", post(hrana_over_http_1::handle_batch))

--- a/libsql-server/src/http/user/mod.rs
+++ b/libsql-server/src/http/user/mod.rs
@@ -234,6 +234,7 @@ pub(crate) struct AppState {
     enable_console: bool,
     disable_default_namespace: bool,
     disable_namespaces: bool,
+    primary_url: Option<String>,
 }
 
 pub struct UserApi<A, P, S> {
@@ -249,6 +250,7 @@ pub struct UserApi<A, P, S> {
     pub max_response_size: u64,
     pub enable_console: bool,
     pub self_url: Option<String>,
+    pub primary_url: Option<String>,
     pub path: Arc<Path>,
     pub shutdown: Arc<Notify>,
 }
@@ -314,6 +316,7 @@ where
                 namespaces: self.namespaces,
                 disable_default_namespace: self.disable_default_namespace,
                 disable_namespaces: self.disable_namespaces,
+                primary_url: self.primary_url.clone(),
             };
 
             macro_rules! handle_hrana {

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -54,6 +54,7 @@ use self::net::AddrIncoming;
 use self::replication::script_backup_manager::{CommandHandler, ScriptBackupManager};
 
 pub mod auth;
+mod broadcaster;
 pub mod config;
 pub mod connection;
 pub mod net;

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -177,6 +177,7 @@ where
             max_response_size: self.db_config.max_response_size,
             enable_console: self.user_api_config.enable_http_console,
             self_url: self.user_api_config.self_url,
+            primary_url: self.user_api_config.primary_url,
             path: self.path.clone(),
             shutdown: self.shutdown.clone(),
         };

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -72,6 +72,8 @@ struct Cli {
     /// sessions" in Hrana over HTTP.
     #[clap(long, env = "SQLD_HTTP_SELF_URL")]
     http_self_url: Option<String>,
+    #[clap(long, env = "SQLD_HTTP_PRIMARY_URL")]
+    http_primary_url: Option<String>,
 
     /// The address and port the inter-node RPC protocol listens to. Example: `0.0.0.0:5001`.
     #[clap(
@@ -418,6 +420,7 @@ async fn make_user_api_config(config: &Cli) -> anyhow::Result<UserApiConfig> {
         hrana_ws_acceptor,
         enable_http_console: config.enable_http_console,
         self_url: config.http_self_url.clone(),
+        primary_url: config.http_primary_url.clone(),
         auth_strategy,
     })
 }

--- a/libsql-server/src/metrics.rs
+++ b/libsql-server/src/metrics.rs
@@ -143,3 +143,13 @@ pub static SERVER_COUNT: Lazy<Gauge> = Lazy::new(|| {
     describe_gauge!(NAME, "a gauge counting the number of active servers");
     register_gauge!(NAME)
 });
+pub static LISTEN_EVENTS_SENT: Lazy<Counter> = Lazy::new(|| {
+    const NAME: &str = "libsql_server_listen_events_sent";
+    describe_counter!(NAME, "Number of listen events sent");
+    register_counter!(NAME)
+});
+pub static LISTEN_EVENTS_DROPPED: Lazy<Counter> = Lazy::new(|| {
+    const NAME: &str = "libsql_server_listen_events_dropped";
+    describe_counter!(NAME, "Number of listen events dropped");
+    register_counter!(NAME)
+});

--- a/libsql-server/src/namespace/broadcasters.rs
+++ b/libsql-server/src/namespace/broadcasters.rs
@@ -1,0 +1,66 @@
+use std::sync::Arc;
+
+use hashbrown::HashMap;
+use parking_lot::Mutex;
+use tokio_stream::wrappers::BroadcastStream;
+
+use crate::broadcaster::{BroadcastMsg, Broadcaster};
+
+use super::NamespaceName;
+
+type BroadcasterRegistryInner = Mutex<HashMap<NamespaceName, Broadcaster>>;
+
+#[derive(Default)]
+pub struct BroadcasterRegistry {
+    inner: Arc<BroadcasterRegistryInner>,
+}
+
+impl BroadcasterRegistry {
+    pub(crate) fn handle(&self, namespace: NamespaceName) -> BroadcasterHandle {
+        BroadcasterHandle {
+            namespace: namespace,
+            registry: self.inner.clone(),
+        }
+    }
+
+    pub(crate) fn subscribe(
+        &self,
+        namespace: NamespaceName,
+        table: String,
+    ) -> BroadcastStream<BroadcastMsg> {
+        self.inner
+            .lock()
+            .entry(namespace.clone())
+            .or_insert_with(|| Default::default())
+            .subscribe(table)
+    }
+
+    pub(crate) fn unsubscribe(&self, namespace: NamespaceName, table: &String) {
+        let mut broadcasters = self.inner.lock();
+        let remove = broadcasters
+            .get(&namespace)
+            .map_or(false, |broadcaster| !broadcaster.unsubscribe(table));
+        if remove {
+            broadcasters.remove(&namespace);
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct BroadcasterHandle {
+    namespace: NamespaceName,
+    registry: Arc<BroadcasterRegistryInner>,
+}
+
+impl BroadcasterHandle {
+    pub fn get(&self) -> Option<Broadcaster> {
+        self.registry.lock().get(&self.namespace).map(|b| b.clone())
+    }
+
+    pub fn handle(&self, namespace: NamespaceName) -> BroadcasterHandle {
+        BroadcasterHandle {
+            namespace,
+            registry: self.registry.clone(),
+        }
+    }
+}

--- a/libsql-server/src/namespace/broadcasters.rs
+++ b/libsql-server/src/namespace/broadcasters.rs
@@ -57,6 +57,10 @@ impl BroadcasterHandle {
         self.registry.lock().get(&self.namespace).map(|b| b.clone())
     }
 
+    pub fn active(&self) -> bool {
+        self.registry.lock().contains_key(&self.namespace)
+    }
+
     pub fn handle(&self, namespace: NamespaceName) -> BroadcasterHandle {
         BroadcasterHandle {
             namespace,

--- a/libsql-server/src/namespace/fork.rs
+++ b/libsql-server/src/namespace/fork.rs
@@ -12,12 +12,12 @@ use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 use tokio::time::Duration;
 use tokio_stream::StreamExt;
 
-use crate::broadcaster::Broadcaster;
 use crate::namespace::ResolveNamespacePathFn;
 use crate::replication::primary::frame_stream::FrameStream;
 use crate::replication::{LogReadError, ReplicationLogger};
 use crate::{BLOCKING_RT, LIBSQL_PAGE_SIZE};
 
+use super::broadcasters::BroadcasterHandle;
 use super::meta_store::MetaStoreHandle;
 use super::{
     Namespace, NamespaceBottomlessDbId, NamespaceConfig, NamespaceName, NamespaceStore,
@@ -67,7 +67,7 @@ pub struct ForkTask<'a> {
     pub ns_config: &'a NamespaceConfig,
     pub resolve_attach: ResolveNamespacePathFn,
     pub store: NamespaceStore,
-    pub broadcaster: Broadcaster,
+    pub broadcaster: BroadcasterHandle,
 }
 
 pub struct PointInTimeRestore {

--- a/libsql-server/src/namespace/fork.rs
+++ b/libsql-server/src/namespace/fork.rs
@@ -12,6 +12,7 @@ use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 use tokio::time::Duration;
 use tokio_stream::StreamExt;
 
+use crate::broadcaster::Broadcaster;
 use crate::namespace::ResolveNamespacePathFn;
 use crate::replication::primary::frame_stream::FrameStream;
 use crate::replication::{LogReadError, ReplicationLogger};
@@ -66,6 +67,7 @@ pub struct ForkTask<'a> {
     pub ns_config: &'a NamespaceConfig,
     pub resolve_attach: ResolveNamespacePathFn,
     pub store: NamespaceStore,
+    pub broadcaster: Broadcaster,
 }
 
 pub struct PointInTimeRestore {
@@ -115,6 +117,7 @@ impl<'a> ForkTask<'a> {
             Box::new(|_op| {}),
             self.resolve_attach.clone(),
             self.store.clone(),
+            self.broadcaster,
         )
         .await
         .map_err(|e| ForkError::CreateNamespace(Box::new(e)))

--- a/libsql-server/src/namespace/store.rs
+++ b/libsql-server/src/namespace/store.rs
@@ -8,9 +8,10 @@ use moka::future::Cache;
 use once_cell::sync::OnceCell;
 use tokio::task::JoinSet;
 use tokio::time::{Duration, Instant};
+use tokio_stream::wrappers::BroadcastStream;
 
 use crate::auth::Authenticated;
-use crate::broadcaster::UpdateSubscription;
+use crate::broadcaster::BroadcastMsg;
 use crate::connection::config::DatabaseConfig;
 use crate::error::Error;
 use crate::metrics::NAMESPACE_LOAD_LATENCY;
@@ -477,7 +478,7 @@ impl NamespaceStore {
         &self,
         namespace: NamespaceName,
         table: String,
-    ) -> crate::Result<UpdateSubscription> {
+    ) -> crate::Result<BroadcastStream<BroadcastMsg>> {
         self.with(namespace, |ns| ns.broadcaster.subscribe(table))
             .await
     }

--- a/libsql-server/src/namespace/store.rs
+++ b/libsql-server/src/namespace/store.rs
@@ -489,7 +489,7 @@ impl NamespaceStore {
         self.inner.broadcasters.subscribe(namespace, table)
     }
 
-    pub(crate) async fn unsubscribe(&self, namespace: NamespaceName, table: &String) {
+    pub(crate) fn unsubscribe(&self, namespace: NamespaceName, table: &String) {
         self.inner.broadcasters.unsubscribe(namespace, table);
     }
 

--- a/libsql-server/src/namespace/store.rs
+++ b/libsql-server/src/namespace/store.rs
@@ -324,7 +324,7 @@ impl NamespaceStore {
 
     pub async fn with<Fun, R>(&self, namespace: NamespaceName, f: Fun) -> crate::Result<R>
     where
-        Fun: FnOnce(&Namespace) -> R + 'static,
+        Fun: FnOnce(&Namespace) -> R,
     {
         if namespace != NamespaceName::default()
             && !self.inner.metadata.exists(&namespace)
@@ -483,7 +483,7 @@ impl NamespaceStore {
             .await
     }
 
-    pub(crate) async fn unsubscribe(&self, namespace: NamespaceName, table: String) {
+    pub(crate) async fn unsubscribe(&self, namespace: NamespaceName, table: &String) {
         if self.inner.store.contains_key(&namespace) {
             _ = self
                 .with(namespace, |ns| ns.broadcaster.unsubscribe(table))

--- a/libsql-server/src/test/bottomless.rs
+++ b/libsql-server/src/test/bottomless.rs
@@ -104,6 +104,7 @@ async fn configure_server(
             http_acceptor: Some(http_acceptor),
             enable_http_console: false,
             self_url: None,
+            primary_url: None,
             auth_strategy: Auth::new(Disabled::new()),
         },
         path: path.into().into(),


### PR DESCRIPTION
Uses [SQLite's update hooks](https://sqlite.org/c3ref/update_hook.html) to allow users to listen for database changes.
Listening is pull-based, based on SSE.

This aims to offer a simple (implementation and API) and efficient (stateless, no need to query the table, nor store multiple versions of data) solution.
Users who want stricter guarantees should be able to combine this with other features to achieve their goals.
For instance, to get at least once delivery you can create a trigger that appends to an event table and listen to inserts to it.
To recover from crashes, clients can store the last processed entry somewhere (e.g. another libsql-server table).

---

Quirks to document and/or address:
- This will only work for rowid tables. Which excludes any virtual tables.
- This will not notify users of whole table deletions. From the link above:
> In the current implementation, the update hook is not invoked when conflicting rows are deleted because of an [ON CONFLICT REPLACE](https://sqlite.org/lang_conflict.html) clause. Nor is the update hook invoked when rows are deleted using the [truncate optimization](https://sqlite.org/lang_delete.html#truncateopt). The exceptions defined in this paragraph might change in a future release of SQLite.

- Updates are broadcasted when they are run, not when they are committed.

---

Before merging this we should discuss the ideal API.
My plan is to use [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) to notify listeners of any changes.
This is kind of implemented, I need to add the proper headers to make it 100% though.
Sending single-line JSON objects to notify changes seems like a good streaming strategy, it allows us to expand the API in the future and add arbitrary data.

Example of request and response:
```
➜  libsql git:(main) ✗ curl http://localhost:6060/beta/listen -H "Host: main.turso" -v
* Host localhost:6060 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:6060...
* Connected to localhost (::1) port 6060
> GET /beta/listen HTTP/1.1
> Host: main.turso
> User-Agent: curl/8.5.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< access-control-allow-origin: *
< vary: origin
< vary: access-control-request-method
< vary: access-control-request-headers
< transfer-encoding: chunked
< date: Sun, 12 May 2024 17:54:07 GMT
< 
{"db":"main","table":"t3","rowid":1}
{"db":"main","table":"t3","rowid":1}
{"db":"main","table":"t3","rowid":1}
{"db":"main","table":"t3","rowid":1}
{"db":"main","table":"t3","rowid":1}
```