### PR TITLE
fix metastore deadlock

### DIFF
--- a/bottomless/src/bottomless_wal.rs
+++ b/bottomless/src/bottomless_wal.rs
@@ -137,9 +137,9 @@ impl<T: Wal> WrapWal<T> for BottomlessWalWrapper {
                     replicator.skip_snapshot_for_current_generation();
                     return Err(Error::new(SQLITE_BUSY));
                 }
-                
+
                 let fut = tokio::time::timeout(std::time::Duration::from_secs(1), replicator.wait_until_committed(last_known_frame));
-                
+
                 match runtime.block_on(fut) {
                     Ok(Ok(_)) => (),
                     Ok(Err(e)) => {

--- a/bottomless/src/bottomless_wal.rs
+++ b/bottomless/src/bottomless_wal.rs
@@ -137,22 +137,41 @@ impl<T: Wal> WrapWal<T> for BottomlessWalWrapper {
                     replicator.skip_snapshot_for_current_generation();
                     return Err(Error::new(SQLITE_BUSY));
                 }
-                if let Err(e) = runtime.block_on(replicator.wait_until_committed(last_known_frame))
-                {
-                    tracing::error!(
-                        "Failed to wait for S3 replicator to confirm {} frames backup: {}",
-                        last_known_frame,
-                        e
-                    );
-                    return Err(Error::new(SQLITE_IOERR_WRITE));
+                
+                let fut = tokio::time::timeout(std::time::Duration::from_secs(1), replicator.wait_until_committed(last_known_frame));
+                
+                match runtime.block_on(fut) {
+                    Ok(Ok(_)) => (),
+                    Ok(Err(e)) => {
+                        tracing::error!(
+                            "Failed to wait for S3 replicator to confirm {} frames backup: {}",
+                            last_known_frame,
+                            e
+                        );
+                        return Err(Error::new(SQLITE_IOERR_WRITE));
+                    }
+                    Err(_) => {
+                        tracing::error!("timed out waiting for S3 replicator to confirm committed frames.");
+                        return Err(Error::new(SQLITE_BUSY));
+
+                    }
                 }
                 tracing::debug!("commited after {:?}", before.elapsed());
-                if let Err(e) = runtime.block_on(replicator.wait_until_snapshotted()) {
-                    tracing::error!(
-                        "Failed to wait for S3 replicator to confirm database snapshot backup: {}",
-                        e
-                    );
-                    return Err(Error::new(SQLITE_IOERR_WRITE));
+                let snapshotted = runtime.block_on(replicator.is_snapshotted());
+                match snapshotted {
+                    Ok(true) => (),
+                    Ok(false) => {
+                        tracing::warn!("previous generation not snapshotted, skipping checkpoint");
+                        return Err(Error::new(SQLITE_BUSY));
+                    }
+                    Err(e) => {
+
+                        tracing::error!(
+                            "Failed to wait for S3 replicator to confirm database snapshot backup: {}",
+                            e
+                        );
+                        return Err(Error::new(SQLITE_IOERR_WRITE));
+                    },
                 }
                 tracing::debug!("snapshotted after {:?}", before.elapsed());
 

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -477,24 +477,21 @@ impl Replicator {
         self.use_compression
     }
 
-    pub async fn is_snapshotted(&mut self) -> Result<bool> {
+    pub async fn is_snapshotted(&mut self) -> bool {
         if let Ok(generation) = self.generation() {
             if !self.main_db_exists_and_not_empty().await {
                 tracing::debug!("Not snapshotting, the main db file does not exist or is empty");
                 let _ = self.snapshot_notifier.send(Ok(Some(generation)));
-                return Ok(false);
+                return false;
             }
             tracing::debug!("waiting for generation snapshot {} to complete", generation);
             let current = self.snapshot_waiter.borrow();
-            let snapshotted = match &*current {
+            match &*current {
                 Ok(Some(gen)) => *gen == generation,
-                Ok(None) => false,
-                Err(_) => false,
-            };
-
-            Ok(snapshotted)
+                _ => false,
+            }
         } else {
-            Ok(false)
+            false
         }
     }
 


### PR DESCRIPTION
This PR fixes many issues that caused the metastore and bottomless to deadlock.

- blocking on `wait_for_snapshot`: instead of blocking to wait for snapshot, we return busy if the previous snapshot isn't ready yet. That prevents blocking when bottomless becomes unavailable.
- timeout on `wait_for_committed`: if all the send snapshot tasks failed, wait for committed would wait forever for an event that would never happen; since jobs are not enqueued, the whole connection would stale: checkpoint would wait for a recent enough committed index, and send loop would wait for checkpoint to flush new frames => deadlock. Instead, we timed out so that the connection would be throttled due to unavailability, but we can still make progress.
- Meta store deadlock: there was a slim chance that `MetaStore::exists` would wait to acquire the lock on the configs, while we were also holding a long living lock on the `MetaInner` when inserting a new entry, and bottomless was unavailable. If the reactor happened to be on the same thread as the waiting thread, then the `wait_for_committed` timeout would never fire, and this would cause a deadlock. Finer-grained locking solves the issue in the short term, but the design is flawed, and this code needs to be rewritten.
