### PR TITLE
Allow single transaction in schema migration

### DIFF
--- a/libsql-server/src/connection/program.rs
+++ b/libsql-server/src/connection/program.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use metrics::{histogram, increment_counter};
@@ -17,14 +16,12 @@ use super::RequestContext;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Program {
-    pub steps: Arc<Vec<Step>>,
+    pub steps: Vec<Step>,
 }
 
 impl Program {
     pub fn new(steps: Vec<Step>) -> Self {
-        Self {
-            steps: Arc::new(steps),
-        }
+        Self { steps }
     }
 
     pub fn is_read_only(&self) -> bool {

--- a/libsql-server/src/connection/program.rs
+++ b/libsql-server/src/connection/program.rs
@@ -15,7 +15,7 @@ use crate::query_result_builder::QueryResultBuilder;
 use super::config::DatabaseConfig;
 use super::RequestContext;
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Program {
     pub steps: Arc<Vec<Step>>,
 }

--- a/libsql-server/src/connection/write_proxy.rs
+++ b/libsql-server/src/connection/write_proxy.rs
@@ -461,10 +461,7 @@ impl Connection for WriteProxyConnection<RpcStream> {
             // We know that this program won't perform any writes. We attempt to run it on the
             // replica. If it leaves an open transaction, then this program is an interactive
             // transaction, so we rollback the replica, and execute again on the primary.
-            let builder = self
-                .read_conn
-                .execute_program(pgm.clone(), ctx.clone(), builder, replication_index)
-                .await?;
+            let (builder, pgm) = self.read_conn.execute(pgm, ctx.clone(), builder).await?;
             if !self.read_conn.is_autocommit().await? {
                 REPLICA_LOCAL_EXEC_MISPREDICT.increment(1);
                 self.read_conn.rollback(ctx.clone()).await?;

--- a/libsql-server/src/database/schema.rs
+++ b/libsql-server/src/database/schema.rs
@@ -31,7 +31,7 @@ impl SchemaConnection {
 impl crate::connection::Connection for SchemaConnection {
     async fn execute_program<B: crate::query_result_builder::QueryResultBuilder>(
         &self,
-        migration: Program,
+        mut migration: Program,
         ctx: RequestContext,
         builder: B,
         replication_index: Option<crate::replication::FrameNo>,
@@ -53,7 +53,7 @@ impl crate::connection::Connection for SchemaConnection {
         } else {
             check_program_auth(&ctx, &migration, &self.config.get())?;
             let connection = self.connection.clone();
-            validate_migration(&migration)?;
+            validate_migration(&mut migration)?;
             let migration = Arc::new(migration);
             let builder = tokio::task::spawn_blocking({
                 let migration = migration.clone();

--- a/libsql-server/src/hrana/batch.rs
+++ b/libsql-server/src/hrana/batch.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, bail, Result};
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::connection::program::{Cond, Program, Step};
 use crate::connection::{Connection, RequestContext};
@@ -140,9 +139,7 @@ pub fn proto_sequence_to_program(sql: &str) -> Result<Program> {
             Step { cond, query }
         })
         .collect();
-    Ok(Program {
-        steps: Arc::new(steps),
-    })
+    Ok(Program { steps })
 }
 
 pub async fn execute_sequence(

--- a/libsql-server/src/query_result_builder.rs
+++ b/libsql-server/src/query_result_builder.rs
@@ -525,6 +525,7 @@ impl<B: QueryResultBuilder> QueryResultBuilder for Take<B> {
 pub mod test {
     use std::fmt;
 
+    use crate::connection::program::Program;
     use arbitrary::{Arbitrary, Unstructured};
     use itertools::Itertools;
     use rand::{
@@ -1034,13 +1035,16 @@ pub mod test {
         fn add_stats(&mut self, _rows_read: u64, _rows_written: u64, _duration: Duration) {}
     }
 
-    pub fn test_driver(iter: usize, f: impl Fn(FsmQueryBuilder) -> crate::Result<FsmQueryBuilder>) {
+    pub fn test_driver(
+        iter: usize,
+        f: impl Fn(FsmQueryBuilder) -> crate::Result<(FsmQueryBuilder, Program)>,
+    ) {
         for _ in 0..iter {
             // inject random errors
             let builder = FsmQueryBuilder::new(true);
             match f(builder) {
                 Ok(b) => {
-                    assert_eq!(b.state, Finish);
+                    assert_eq!(b.0.state, Finish);
                 }
                 Err(e) => {
                     assert!(matches!(e, crate::Error::BuilderError(_)));

--- a/libsql-server/src/rpc/proxy.rs
+++ b/libsql-server/src/rpc/proxy.rs
@@ -30,8 +30,6 @@ use crate::replication::FrameNo;
 use crate::rpc::streaming_exec::make_proxy_stream;
 
 pub mod rpc {
-    use std::sync::Arc;
-
     use anyhow::Context;
     pub use libsql_replication::rpc::proxy::*;
 
@@ -223,14 +221,8 @@ pub mod rpc {
 
     impl From<connection::program::Program> for Program {
         fn from(pgm: connection::program::Program) -> Self {
-            // TODO: use unwrap_or_clone when stable
-            let steps = match Arc::try_unwrap(pgm.steps) {
-                Ok(steps) => steps,
-                Err(arc) => (*arc).clone(),
-            };
-
             Self {
-                steps: steps.into_iter().map(|s| s.into()).collect(),
+                steps: pgm.steps.into_iter().map(|s| s.into()).collect(),
             }
         }
     }

--- a/libsql-server/tests/namespaces/shared_schema.rs
+++ b/libsql-server/tests/namespaces/shared_schema.rs
@@ -241,13 +241,17 @@ fn migration_contains_txn_statements() {
         )
         .unwrap();
         let schema_conn = schema_db.connect().unwrap();
+        schema_conn
+            .execute_batch("begin; create table test1 (c);commit")
+            .await
+            .unwrap();
         assert_debug_snapshot!(schema_conn
             .execute_batch("begin; create table test (c)")
             .await
             .unwrap_err());
 
         let resp = client
-            .get("http://schema.primary:8080/v1/jobs/1")
+            .get("http://schema.primary:8080/v1/jobs/2")
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/libsql-sqlite3/test/rust_suite/Cargo.toml
+++ b/libsql-sqlite3/test/rust_suite/Cargo.toml
@@ -14,6 +14,7 @@ itertools = "0.10"
 tempfile = "3.3"
 wabt = "0.10.0"
 hex = "0.4.3"
+rustc-hash = "1"
 
 [features]
 default = []


### PR DESCRIPTION
Only allow single transaction that wraps the whole migration.