### PR TITLE
React Native support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ libsql-sqlite3/**.o.tmp
 /libsql-ffi/bundled/SQLite3MultipleCiphers/build/**
 # will be copied from bundled/src
 /libsql-ffi/bundled/SQLite3MultipleCiphers/src/sqlite3.c
+
+/bindings/c/generated
+/bindings/c/**.xcframework
+/bindings/**/.DS_Store

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -24,5 +24,10 @@ libsql = { path = "../../libsql", features = ["encryption"] }
 libsql = { path = "../../libsql"}
 
 
-[profile.release]
-strip = "symbols"
+# The produced binaries are too large for mobiles
+# When compiling for iOS or Android, you should turn on symbol stripping, lto and cut debug symbols
+# [profile.release]
+# debug = false # Exclude debug symbols
+# strip = "symbols" # Exclude the rest of the symbols
+# # opt-level = "z" # Did not use this, but it equals C++'s optimize for size (O3?)
+# lto = true # Link time optimization, not sure what this does but it helps reduce the size

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -13,6 +13,16 @@ cbindgen = "0.24.0"
 [dependencies]
 bytes = "1.5.0"
 lazy_static = "1.4.0"
-libsql = { path = "../../libsql", features = ["encryption"] }
 tokio = { version = "1.29.1", features = [ "rt-multi-thread" ] }
 hyper-rustls = { version = "0.25", features = ["webpki-roots"]}
+
+[target.'cfg(not(any(target_os = "ios", target_os = "android")))'.dependencies]
+libsql = { path = "../../libsql", features = ["encryption"] }
+
+# Disable encryption for ios and android targets
+[target.'cfg(any(target_os = "ios", target_os = "android"))'.dependencies]
+libsql = { path = "../../libsql"}
+
+
+[profile.release]
+strip = "symbols"

--- a/bindings/c/Makefile
+++ b/bindings/c/Makefile
@@ -1,6 +1,11 @@
 OS := $(shell uname)
 CFLAGS := -Iinclude
 LDFLAGS := -lm
+ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim
+ARCHS_ANDROID = aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
+LIB = libsql_experimental.a
+HEADER = libsql.h
+XCFRAMEWORK = libsql.xcframework
 
 # Set LIBSQL_PATH to the default path if not provided
 LIBSQL_EXPERIMENTAL_PATH ?= ../../target/release/libsql_experimental.a
@@ -9,8 +14,37 @@ ifeq ($(OS),Darwin)
 	CFLAGS += -framework Security -framework CoreServices
 endif
 
-.PHONY: all
+.PHONY: all $(ARCHS_IOS) ios $(ARCHS_ANDROID) android
+
 all: example
 
 example: example.c
 	$(CC) -o $@ $(CFLAGS) $< $(LIBSQL_EXPERIMENTAL_PATH) $(LDFLAGS)
+
+android: $(ARCHS_ANDROID)
+	rm -rf generated
+	mkdir -p generated/jniLibs
+	mkdir -p generated/jniLibs/arm64-v8a
+	mkdir -p generated/jniLibs/armeabi-v7a
+	mkdir -p generated/jniLibs/x86_64
+	mkdir -p generated/jniLibs/x86
+
+	cp ../../target/aarch64-linux-android/release/$(LIB) generated/jniLibs/arm64-v8a/$(LIB)
+	cp ../../target/armv7-linux-androideabi/release/$(LIB) generated/jniLibs/armeabi-v7a/$(LIB)
+	cp ../../target/x86_64-linux-android/release/$(LIB) generated/jniLibs/x86_64/$(LIB)
+	cp ../../target/i686-linux-android/release/$(LIB) generated/jniLibs/x86/$(LIB)
+
+$(ARCHS_ANDROID): %: 
+	cargo ndk --target $@ --platform 31 build --release
+
+ios: $(XCFRAMEWORK)
+
+$(ARCHS_IOS): %:
+	cargo build --release --target $@
+
+$(XCFRAMEWORK): $(ARCHS_IOS)
+	rm -rf generated
+	mkdir -p generated/simulator_fat
+	rm -rf $@
+	lipo -create $(wildcard ../../target/x86_64-apple-ios/release/$(LIB)) $(wildcard ../../target/aarch64-apple-ios-sim/release/$(LIB)) -output generated/simulator_fat/$(LIB)
+	xcodebuild -create-xcframework -library $(wildcard ../../target/aarch64-apple-ios/release/$(LIB)) -headers include -library generated/simulator_fat/$(LIB) -headers include -output $@

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 profile = "default"
 channel = "1.78.0"
+targets = ["x86_64-apple-ios", "aarch64-apple-ios", "aarch64-apple-ios-sim", "aarch64-linux-android", "armv7-linux-androideabi", "x86_64-linux-android", "i686-linux-android"]


### PR DESCRIPTION
Adds the necessary scripts to build the C bindings for iOS and Android which the in turn only need to be dropped into iOS/Android projects to be used via Obj-C++ or Android's JNI.

For my specific use case I use them in op-sqlite.