### PR TITLE
Add storage server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,6 +1221,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.5.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.66",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1690,16 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -2407,6 +2440,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "foundationdb"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bf4ae7238dbdb1ff01e9f981db028515cf66883c461e29faedfea130b2728"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "foundationdb-gen",
+ "foundationdb-macros",
+ "foundationdb-sys",
+ "futures",
+ "memchr",
+ "rand",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "static_assertions",
+ "uuid",
+]
+
+[[package]]
+name = "foundationdb-gen"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36878d54a76a48e794d0fe89be2096ab5968b071e7ec25f7becfe7846f55fa77"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
+name = "foundationdb-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8db6653cbc621a3810d95d55bd342be3e71181d6df21a4eb29ef986202d3f9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+ "try_map",
+]
+
+[[package]]
+name = "foundationdb-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace2f49db8614b7d7e3b656a12e0059b5fbd0a4da3410b1797374bec3db269fa"
+dependencies = [
+ "bindgen 0.69.4",
+ "libc",
 ]
 
 [[package]]
@@ -3298,7 +3383,7 @@ dependencies = [
 name = "libsql-ffi"
 version = "0.2.1"
 dependencies = [
- "bindgen",
+ "bindgen 0.66.1",
  "cc",
  "libsql-wasmtime-bindings",
 ]
@@ -3457,6 +3542,26 @@ dependencies = [
  "prost-build",
  "tonic 0.10.2",
  "tonic-build 0.10.2",
+]
+
+[[package]]
+name = "libsql-storage-server"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "clap 4.5.4",
+ "foundationdb",
+ "futures",
+ "libsql-storage",
+ "redis",
+ "serde",
+ "tokio",
+ "tonic 0.10.2",
+ "tracing",
+ "tracing-subscriber",
+ "vergen",
 ]
 
 [[package]]
@@ -4576,6 +4681,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
+dependencies = [
+ "combine",
+ "itoa",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5110,6 +5230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5164,6 +5293,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -5337,6 +5472,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_stack"
@@ -5982,6 +6123,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "try_map"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1626d07cb5c1bb2cf17d94c0be4852e8a7c02b041acec9a8c5bdda99f9d580"
 
 [[package]]
 name = "tungstenite"
@@ -7037,6 +7184,12 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "xtask", "libsql-hrana",
   "libsql-wal",
   "libsql-storage",
+  "libsql-storage-server",
 ]
 
 exclude = [

--- a/libsql-storage-server/Cargo.toml
+++ b/libsql-storage-server/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "libsql-storage-server"
+version = "0.0.1"
+edition = "2021"
+default-run = "libsql-storage-server"
+
+[[bin]]
+name = "libsql-storage-server"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0.66"
+bytes = "1.5.0"
+clap = { version = "4.0.23", features = ["derive", "env", "string"] }
+foundationdb = { version = "0.9.0", features = ["embedded-fdb-include", "fdb-7_3"] }
+futures = "0.3.30"
+libsql-storage = { path = "../libsql-storage" }
+redis = "0.25.3"
+tokio = { version = "1.22.2", features = ["rt-multi-thread", "net", "io-std", "io-util", "time", "macros", "sync", "fs", "signal"] }
+tonic = { version = "0.10.0", features = ["tls"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+async-trait = "0.1.80"
+serde = "1.0.203"
+
+[dev-dependencies]
+
+[build-dependencies]
+vergen = { version = "8", features = ["build", "git", "gitcl"] }
+

--- a/libsql-storage-server/Cargo.toml
+++ b/libsql-storage-server/Cargo.toml
@@ -2,6 +2,10 @@
 name = "libsql-storage-server"
 version = "0.0.1"
 edition = "2021"
+description = "libSQL Storage Server"
+repository = "https://github.com/tursodatabase/libsql"
+license = "MIT"
+publish = false
 default-run = "libsql-storage-server"
 
 [[bin]]

--- a/libsql-storage-server/build.rs
+++ b/libsql-storage-server/build.rs
@@ -1,0 +1,6 @@
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    EmitBuilder::builder().git_sha(false).all_build().emit()?;
+    Ok(())
+}

--- a/libsql-storage-server/src/lib.rs
+++ b/libsql-storage-server/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod version;

--- a/libsql-storage-server/src/main.rs
+++ b/libsql-storage-server/src/main.rs
@@ -1,0 +1,62 @@
+mod memory_store;
+mod service;
+mod store;
+
+use std::net::SocketAddr;
+
+use anyhow::Result;
+use clap::Parser;
+use libsql_storage::rpc::storage_server::StorageServer;
+use libsql_storage_server::version::Version;
+use service::Service;
+use tonic::transport::Server;
+use tracing::trace;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum StorageType {
+    InMemory,
+    Redis,
+    FoundationDB,
+}
+
+#[derive(Debug, Parser)]
+#[command(name = "libsql-storage-server")]
+#[command(about = "libSQL Storage Server", version = Version::default(), long_about = None)]
+struct Cli {
+    /// The address and port the storage RPC protocol listens to. Example: `127.0.0.1:5002`.
+    #[clap(long, env = "LIBSQL_STORAGE_LISTEN_ADDR", default_value = "[::]:5002")]
+    listen_addr: SocketAddr,
+
+    /// The type of storage backend to use. Example: `redis`
+    #[clap(value_enum, long, default_value = "in-memory")]
+    storage_type: StorageType,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("libsql_storage_server=trace"));
+    tracing::subscriber::set_global_default(
+        FmtSubscriber::builder().with_env_filter(filter).finish(),
+    )
+    .expect("setting default subscriber failed");
+
+    let args = Cli::parse();
+    let service = match args.storage_type {
+        StorageType::Redis => Service::new(),
+        StorageType::FoundationDB => Service::new(),
+        _ => Service::new(),
+    };
+
+    trace!(
+        "Starting libSQL storage server (with type {:?}) on {}",
+        args.storage_type,
+        args.listen_addr
+    );
+    Server::builder()
+        .add_service(StorageServer::new(service))
+        .serve(args.listen_addr)
+        .await?;
+    Ok(())
+}

--- a/libsql-storage-server/src/memory_store.rs
+++ b/libsql-storage-server/src/memory_store.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Mutex;
 
 use crate::store::FrameData;
 use crate::store::FrameStore;
@@ -7,6 +8,11 @@ use bytes::Bytes;
 
 #[derive(Default)]
 pub(crate) struct InMemFrameStore {
+    inner: Mutex<InMemInternal>,
+}
+
+#[derive(Default)]
+struct InMemInternal {
     // contains a frame data, key is the frame number
     frames: BTreeMap<u64, FrameData>,
     // pages map contains the page number as a key and the list of frames for the page as a value
@@ -23,50 +29,66 @@ impl InMemFrameStore {
 #[async_trait]
 impl FrameStore for InMemFrameStore {
     // inserts a new frame for the page number and returns the new frame value
-    async fn insert_frame(&mut self, _namespace: &str, page_no: u64, frame: Bytes) -> u64 {
-        let frame_no = self.max_frame_no + 1;
-        self.max_frame_no = frame_no;
-        self.frames.insert(
+    async fn insert_frame(&self, _namespace: &str, page_no: u64, frame: Bytes) -> u64 {
+        let mut inner = self.inner.lock().unwrap();
+        let frame_no = inner.max_frame_no + 1;
+        inner.max_frame_no = frame_no;
+        inner.frames.insert(
             frame_no,
             FrameData {
                 page_no,
                 data: frame,
             },
         );
-        self.pages
+        inner
+            .pages
             .entry(page_no)
             .or_insert_with(Vec::new)
             .push(frame_no);
         frame_no
     }
 
-    async fn insert_frames(&mut self, _namespace: &str, _frames: Vec<FrameData>) -> u64 {
+    async fn insert_frames(&self, _namespace: &str, _frames: Vec<FrameData>) -> u64 {
         todo!()
     }
 
     async fn read_frame(&self, _namespace: &str, frame_no: u64) -> Option<bytes::Bytes> {
-        self.frames.get(&frame_no).map(|frame| frame.data.clone())
+        self.inner
+            .lock()
+            .unwrap()
+            .frames
+            .get(&frame_no)
+            .map(|frame| frame.data.clone())
     }
 
     // given a page number, return the maximum frame for the page
     async fn find_frame(&self, _namespace: &str, page_no: u64) -> Option<u64> {
-        self.pages
+        self.inner
+            .lock()
+            .unwrap()
+            .pages
             .get(&page_no)
             .map(|frames| *frames.last().unwrap())
     }
 
     // given a frame num, return the page number
     async fn frame_page_no(&self, _namespace: &str, frame_no: u64) -> Option<u64> {
-        self.frames.get(&frame_no).map(|frame| frame.page_no)
+        self.inner
+            .lock()
+            .unwrap()
+            .frames
+            .get(&frame_no)
+            .map(|frame| frame.page_no)
     }
 
     async fn frames_in_wal(&self, _namespace: &str) -> u64 {
-        self.max_frame_no
+        self.inner.lock().unwrap().max_frame_no
     }
 
-    async fn destroy(&mut self, _namespace: &str) {
-        self.frames.clear();
-        self.pages.clear();
-        self.max_frame_no = 0;
+    async fn destroy(&self, _namespace: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.frames.clear();
+        inner.pages.clear();
+        inner.max_frame_no = 0;
     }
 }

--- a/libsql-storage-server/src/memory_store.rs
+++ b/libsql-storage-server/src/memory_store.rs
@@ -1,0 +1,72 @@
+use std::collections::BTreeMap;
+
+use crate::store::FrameData;
+use crate::store::FrameStore;
+use async_trait::async_trait;
+use bytes::Bytes;
+
+#[derive(Default)]
+pub(crate) struct InMemFrameStore {
+    // contains a frame data, key is the frame number
+    frames: BTreeMap<u64, FrameData>,
+    // pages map contains the page number as a key and the list of frames for the page as a value
+    pages: BTreeMap<u64, Vec<u64>>,
+    max_frame_no: u64,
+}
+
+impl InMemFrameStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl FrameStore for InMemFrameStore {
+    // inserts a new frame for the page number and returns the new frame value
+    async fn insert_frame(&mut self, _namespace: &str, page_no: u64, frame: Bytes) -> u64 {
+        let frame_no = self.max_frame_no + 1;
+        self.max_frame_no = frame_no;
+        self.frames.insert(
+            frame_no,
+            FrameData {
+                page_no,
+                data: frame,
+            },
+        );
+        self.pages
+            .entry(page_no)
+            .or_insert_with(Vec::new)
+            .push(frame_no);
+        frame_no
+    }
+
+    async fn insert_frames(&mut self, _namespace: &str, _frames: Vec<FrameData>) -> u64 {
+        todo!()
+    }
+
+    async fn read_frame(&self, _namespace: &str, frame_no: u64) -> Option<bytes::Bytes> {
+        self.frames.get(&frame_no).map(|frame| frame.data.clone())
+    }
+
+    // given a page number, return the maximum frame for the page
+    async fn find_frame(&self, _namespace: &str, page_no: u64) -> Option<u64> {
+        self.pages
+            .get(&page_no)
+            .map(|frames| *frames.last().unwrap())
+    }
+
+    // given a frame num, return the page number
+    async fn frame_page_no(&self, _namespace: &str, frame_no: u64) -> Option<u64> {
+        self.frames.get(&frame_no).map(|frame| frame.page_no)
+    }
+
+    async fn frames_in_wal(&self, _namespace: &str) -> u64 {
+        self.max_frame_no
+    }
+
+    async fn destroy(&mut self, _namespace: &str) {
+        self.frames.clear();
+        self.pages.clear();
+        self.max_frame_no = 0;
+    }
+}

--- a/libsql-storage-server/src/service.rs
+++ b/libsql-storage-server/src/service.rs
@@ -1,0 +1,153 @@
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
+
+use crate::memory_store::InMemFrameStore;
+use crate::store::FrameStore;
+use libsql_storage::rpc;
+use libsql_storage::rpc::storage_server::Storage;
+use tokio::sync::Mutex;
+use tonic::{Request, Response, Status};
+use tracing::{error, trace};
+
+pub struct Service {
+    store: Arc<Mutex<dyn FrameStore + Send + Sync>>,
+    db_size: AtomicU32,
+}
+
+impl Service {
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(Mutex::new(InMemFrameStore::new())),
+            db_size: AtomicU32::new(0),
+        }
+    }
+    pub fn with_store(store: Arc<Mutex<dyn FrameStore + Send + Sync>>) -> Self {
+        Self {
+            store,
+            db_size: AtomicU32::new(0),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl Storage for Service {
+    async fn insert_frames(
+        &self,
+        request: Request<rpc::InsertFramesRequest>,
+    ) -> Result<Response<rpc::InsertFramesResponse>, Status> {
+        let mut num_frames = 0;
+        let mut store = self.store.lock().await;
+        let request = request.into_inner();
+        let namespace = request.namespace;
+        for frame in request.frames.into_iter() {
+            trace!(
+                "inserted for page {} frame {}",
+                frame.page_no,
+                store
+                    .insert_frame(&namespace, frame.page_no, frame.data.into())
+                    .await
+            );
+            num_frames += 1;
+            self.db_size
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+        Ok(Response::new(rpc::InsertFramesResponse { num_frames }))
+    }
+
+    async fn find_frame(
+        &self,
+        request: Request<rpc::FindFrameRequest>,
+    ) -> Result<Response<rpc::FindFrameResponse>, Status> {
+        let request = request.into_inner();
+        let page_no = request.page_no;
+        let namespace = request.namespace;
+        trace!("find_frame(page_no={})", page_no);
+        if let Some(frame_no) = self
+            .store
+            .lock()
+            .await
+            .find_frame(&namespace, page_no)
+            .await
+        {
+            Ok(Response::new(rpc::FindFrameResponse {
+                frame_no: Some(frame_no),
+            }))
+        } else {
+            error!("find_frame() failed for page_no={}", page_no);
+            Ok(Response::new(rpc::FindFrameResponse { frame_no: None }))
+        }
+    }
+
+    async fn read_frame(
+        &self,
+        request: Request<rpc::ReadFrameRequest>,
+    ) -> Result<Response<rpc::ReadFrameResponse>, Status> {
+        let request = request.into_inner();
+        let frame_no = request.frame_no;
+        let namespace = request.namespace;
+        trace!("read_frame(frame_no={})", frame_no);
+        if let Some(data) = self
+            .store
+            .lock()
+            .await
+            .read_frame(&namespace, frame_no)
+            .await
+        {
+            Ok(Response::new(rpc::ReadFrameResponse {
+                frame: Some(data.clone().into()),
+            }))
+        } else {
+            error!("read_frame() failed for frame_no={}", frame_no);
+            Ok(Response::new(rpc::ReadFrameResponse { frame: None }))
+        }
+    }
+
+    async fn db_size(
+        &self,
+        _request: Request<rpc::DbSizeRequest>,
+    ) -> Result<Response<rpc::DbSizeResponse>, Status> {
+        let size = self.db_size.load(std::sync::atomic::Ordering::SeqCst) as u64;
+        Ok(Response::new(rpc::DbSizeResponse { size }))
+    }
+
+    async fn frames_in_wal(
+        &self,
+        request: Request<rpc::FramesInWalRequest>,
+    ) -> Result<Response<rpc::FramesInWalResponse>, Status> {
+        let namespace = request.into_inner().namespace;
+        Ok(Response::new(rpc::FramesInWalResponse {
+            count: self.store.lock().await.frames_in_wal(&namespace).await,
+        }))
+    }
+
+    async fn frame_page_num(
+        &self,
+        request: Request<rpc::FramePageNumRequest>,
+    ) -> Result<Response<rpc::FramePageNumResponse>, Status> {
+        let request = request.into_inner();
+        let frame_no = request.frame_no;
+        let namespace = request.namespace;
+        if let Some(page_no) = self
+            .store
+            .lock()
+            .await
+            .frame_page_no(&namespace, frame_no)
+            .await
+        {
+            Ok(Response::new(rpc::FramePageNumResponse { page_no }))
+        } else {
+            error!("frame_page_num() failed for frame_no={}", frame_no);
+            Ok(Response::new(rpc::FramePageNumResponse { page_no: 0 }))
+        }
+    }
+
+    async fn destroy(
+        &self,
+        request: Request<rpc::DestroyRequest>,
+    ) -> Result<Response<rpc::DestroyResponse>, Status> {
+        trace!("destroy()");
+        let namespace = request.into_inner().namespace;
+        self.store.lock().await.destroy(&namespace).await;
+        Ok(Response::new(rpc::DestroyResponse {}))
+    }
+}

--- a/libsql-storage-server/src/store.rs
+++ b/libsql-storage-server/src/store.rs
@@ -3,13 +3,14 @@ use bytes::Bytes;
 
 #[async_trait]
 pub trait FrameStore: Send + Sync {
-    async fn insert_frame(&mut self, namespace: &str, page_no: u64, frame: bytes::Bytes) -> u64;
-    async fn insert_frames(&mut self, namespace: &str, frames: Vec<FrameData>) -> u64;
+    async fn insert_frame(&self, namespace: &str, page_no: u64, frame: bytes::Bytes) -> u64;
+    #[allow(dead_code)]
+    async fn insert_frames(&self, namespace: &str, frames: Vec<FrameData>) -> u64;
     async fn read_frame(&self, namespace: &str, frame_no: u64) -> Option<bytes::Bytes>;
     async fn find_frame(&self, namespace: &str, page_no: u64) -> Option<u64>;
     async fn frame_page_no(&self, namespace: &str, frame_no: u64) -> Option<u64>;
     async fn frames_in_wal(&self, namespace: &str) -> u64;
-    async fn destroy(&mut self, namespace: &str);
+    async fn destroy(&self, namespace: &str);
 }
 
 #[derive(Default)]

--- a/libsql-storage-server/src/store.rs
+++ b/libsql-storage-server/src/store.rs
@@ -1,0 +1,19 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+
+#[async_trait]
+pub trait FrameStore: Send + Sync {
+    async fn insert_frame(&mut self, namespace: &str, page_no: u64, frame: bytes::Bytes) -> u64;
+    async fn insert_frames(&mut self, namespace: &str, frames: Vec<FrameData>) -> u64;
+    async fn read_frame(&self, namespace: &str, frame_no: u64) -> Option<bytes::Bytes>;
+    async fn find_frame(&self, namespace: &str, page_no: u64) -> Option<u64>;
+    async fn frame_page_no(&self, namespace: &str, frame_no: u64) -> Option<u64>;
+    async fn frames_in_wal(&self, namespace: &str) -> u64;
+    async fn destroy(&mut self, namespace: &str);
+}
+
+#[derive(Default)]
+pub struct FrameData {
+    pub(crate) page_no: u64,
+    pub(crate) data: Bytes,
+}

--- a/libsql-storage-server/src/version.rs
+++ b/libsql-storage-server/src/version.rs
@@ -1,0 +1,17 @@
+use clap::builder::{IntoResettable, Str};
+
+#[derive(Default)]
+pub struct Version;
+
+impl IntoResettable<Str> for Version {
+    fn into_resettable(self) -> clap::builder::Resettable<Str> {
+        version().into_resettable()
+    }
+}
+
+pub fn version() -> String {
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let git_sha = env!("VERGEN_GIT_SHA");
+    let build_date = env!("VERGEN_BUILD_DATE");
+    format!("sqld {} ({} {})", pkg_version, &git_sha[..8], build_date)
+}


### PR DESCRIPTION
This patch adds the storage gRPC server. It is based on the proto that was previously merged in https://github.com/tursodatabase/libsql/pull/1426

This adds a `FrameStore` trait which lets us implement different pluggable storage backends. Check the simple in-memory storage `InMemFrameStore` for a sample implementation