### PR TITLE
fix shared schema replicatioon

### DIFF
--- a/libsql-server/src/database/mod.rs
+++ b/libsql-server/src/database/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use bottomless::SavepointTracker;
 
 use crate::connection::{MakeConnection, RequestContext};
+use crate::replication::ReplicationLogger;
 
 pub use self::primary::{PrimaryConnection, PrimaryConnectionMaker, PrimaryDatabase};
 pub use self::replica::{ReplicaConnection, ReplicaDatabase};
@@ -175,6 +176,14 @@ impl Database {
             Database::Primary(db) => db.shutdown().await,
             Database::Replica(db) => db.shutdown().await,
             Database::Schema(db) => db.shutdown().await,
+        }
+    }
+
+    pub fn logger(&self) -> Option<Arc<ReplicationLogger>> {
+        match self {
+            Database::Primary(p) => Some(p.wal_wrapper.wrapper().logger()),
+            Database::Replica(_) => None,
+            Database::Schema(s) => Some(s.wal_wrapper.wrapper().logger()),
         }
     }
 

--- a/libsql-server/src/namespace/fork.rs
+++ b/libsql-server/src/namespace/fork.rs
@@ -18,7 +18,10 @@ use crate::replication::{LogReadError, ReplicationLogger};
 use crate::{BLOCKING_RT, LIBSQL_PAGE_SIZE};
 
 use super::meta_store::MetaStoreHandle;
-use super::{Namespace, NamespaceBottomlessDbId, NamespaceConfig, NamespaceName, RestoreOption};
+use super::{
+    Namespace, NamespaceBottomlessDbId, NamespaceConfig, NamespaceName, NamespaceStore,
+    RestoreOption,
+};
 
 type Result<T> = crate::Result<T, ForkError>;
 
@@ -62,6 +65,7 @@ pub struct ForkTask<'a> {
     pub bottomless_db_id: NamespaceBottomlessDbId,
     pub ns_config: &'a NamespaceConfig,
     pub resolve_attach: ResolveNamespacePathFn,
+    pub store: NamespaceStore,
 }
 
 pub struct PointInTimeRestore {
@@ -110,6 +114,7 @@ impl<'a> ForkTask<'a> {
             &self.to_namespace,
             Box::new(|_op| {}),
             self.resolve_attach.clone(),
+            self.store.clone(),
         )
         .await
         .map_err(|e| ForkError::CreateNamespace(Box::new(e)))

--- a/libsql-server/src/namespace/store.rs
+++ b/libsql-server/src/namespace/store.rs
@@ -181,6 +181,7 @@ impl NamespaceStore {
             &namespace,
             self.make_reset_cb(),
             self.resolve_attach_fn(),
+            self.clone(),
         )
         .await?;
 
@@ -286,6 +287,7 @@ impl NamespaceStore {
             handle.clone(),
             timestamp,
             self.resolve_attach_fn(),
+            self.clone(),
         )
         .await?;
 
@@ -376,6 +378,7 @@ impl NamespaceStore {
                     &namespace,
                     self.make_reset_cb(),
                     self.resolve_attach_fn(),
+                    self.clone(),
                 )
                 .await?;
                 tracing::info!("loaded namespace: `{namespace}`");

--- a/libsql-server/src/rpc/replication_log.rs
+++ b/libsql-server/src/rpc/replication_log.rs
@@ -153,12 +153,8 @@ impl ReplicationLogService {
             .with(namespace, |ns| -> Result<_, Status> {
                 let logger = ns
                     .db
-                    .as_primary()
-                    .ok_or_else(|| Status::invalid_argument("not a primary"))?
-                    .wal_wrapper
-                    .wrapper()
                     .logger()
-                    .clone();
+                    .ok_or_else(|| Status::invalid_argument("not a primary"))?;
                 let config_changed = ns.config_changed();
                 let config = ns.config();
                 let version = ns.config_version();

--- a/libsql-wal/src/wal.rs
+++ b/libsql-wal/src/wal.rs
@@ -52,7 +52,7 @@ impl<FS: Io> WalManager for LibsqlWalManager<FS> {
             .registry
             .clone()
             .open(db_path.as_ref())
-            .map_err(|e| dbg!(e.into()))?;
+            .map_err(|e| e.into())?;
         let conn_id = self
             .next_conn_id
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/libsql-wal/tests/oracle.rs
+++ b/libsql-wal/tests/oracle.rs
@@ -119,7 +119,7 @@ fn run_test_sample(path: &Path) -> Result {
         Ok(_) => (),
         Err(e) => {
             let path = tmp.into_path();
-            std::fs::rename(dbg!(path), "./failure").unwrap();
+            std::fs::rename(path, "./failure").unwrap();
             std::panic::resume_unwind(e)
         }
     }


### PR DESCRIPTION
Allow shared schema database to be used with replication. There were two issues:

- the master schema database was not considered a primary, this is solved by exposing it's logger
- when we replicated a shared schema db without it's master first, a constraint was violated in the meta store. This is solved by forcing replication of the master schema first.
