### PR TITLE
categorize namespace doesnt exist error replicator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 resolver = "2"
+default-members = ["libsql-server"]
 members = [
   "libsql",
   "bindings/c",

--- a/libsql-server/src/error.rs
+++ b/libsql-server/src/error.rs
@@ -192,7 +192,12 @@ impl IntoResponse for &Error {
             ConflictingRestoreParameters => self.format_err(StatusCode::BAD_REQUEST),
             Fork(e) => e.into_response(),
             FatalReplicationError => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
-            ReplicatorError(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
+            ReplicatorError(e) => match e {
+                libsql_replication::replicator::Error::NamespaceDoesntExist => {
+                    self.format_err(StatusCode::NOT_FOUND)
+                }
+                _ => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
+            },
             ReplicaMetaError(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             PrimaryStreamDisconnect => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             PrimaryStreamMisuse => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),


### PR DESCRIPTION
- add libsql-server to default-members
- return NOT_FOUND when replica query unexisting namespace
