### PR TITLE
fix dump import/export to support libsql-wal

### DIFF
--- a/libsql-server/src/connection/dump/exporter.rs
+++ b/libsql-server/src/connection/dump/exporter.rs
@@ -430,7 +430,7 @@ fn find_unused_str(haystack: &str, needle1: &str, needle2: &str) -> String {
     }
 }
 
-pub fn export_dump(mut db: rusqlite::Connection, writer: impl Write) -> anyhow::Result<()> {
+pub fn export_dump(db: &mut rusqlite::Connection, writer: impl Write) -> anyhow::Result<()> {
     let mut txn = db.transaction()?;
     txn.execute("PRAGMA writable_schema=ON", ())?;
     let savepoint = txn.savepoint_with_name("dump")?;
@@ -504,11 +504,11 @@ mod test {
     #[test]
     fn table_col_is_keyword() {
         let tmp = tempdir().unwrap();
-        let conn = Connection::open(tmp.path().join("data")).unwrap();
+        let mut conn = Connection::open(tmp.path().join("data")).unwrap();
         conn.execute(r#"create table test ("limit")"#, ()).unwrap();
 
         let mut out = Vec::new();
-        export_dump(conn, &mut out).unwrap();
+        export_dump(&mut conn, &mut out).unwrap();
 
         insta::assert_snapshot!(std::str::from_utf8(&out).unwrap());
     }

--- a/libsql-server/src/http/user/mod.rs
+++ b/libsql-server/src/http/user/mod.rs
@@ -234,7 +234,6 @@ pub(crate) struct AppState {
     enable_console: bool,
     disable_default_namespace: bool,
     disable_namespaces: bool,
-    path: Arc<Path>,
 }
 
 pub struct UserApi<A, P, S> {
@@ -315,7 +314,6 @@ where
                 namespaces: self.namespaces,
                 disable_default_namespace: self.disable_default_namespace,
                 disable_namespaces: self.disable_namespaces,
-                path: self.path,
             };
 
             macro_rules! handle_hrana {


### PR DESCRIPTION
dump import/export was using raw sqlite connection, thus bypassing libsql-wal. This PR fixes it.

I have removed the CLI to export dump because we can't rely on raw files anymore with libql-wal. Instead, one should use the http endpoint to export a dump.
