### PR TITLE
Refactor and update storage server proto

### DIFF
--- a/libsql-storage-server/src/fdb_store.rs
+++ b/libsql-storage-server/src/fdb_store.rs
@@ -87,7 +87,7 @@ impl FrameStore for FDBFrameStore {
                 frame_no,
                 FrameData {
                     page_no: f.page_no,
-                    data: f.data,
+                    data: f.data.into(),
                 },
             )
             .await;

--- a/libsql-storage-server/src/fdb_store.rs
+++ b/libsql-storage-server/src/fdb_store.rs
@@ -5,6 +5,7 @@ use foundationdb::api::NetworkAutoStop;
 use foundationdb::tuple::pack;
 use foundationdb::tuple::unpack;
 use foundationdb::Transaction;
+use libsql_storage::rpc::Frame;
 use tracing::error;
 
 pub struct FDBFrameStore {
@@ -72,7 +73,7 @@ impl FrameStore for FDBFrameStore {
         frame_no
     }
 
-    async fn insert_frames(&self, namespace: &str, frames: Vec<FrameData>) -> u64 {
+    async fn insert_frames(&self, namespace: &str, max_frame_no: u64, frames: Vec<Frame>) -> u64 {
         let max_frame_key = format!("{}/max_frame_no", namespace);
         let db = foundationdb::Database::default().unwrap();
         let txn = db.create_trx().expect("unable to create transaction");

--- a/libsql-storage-server/src/fdb_store.rs
+++ b/libsql-storage-server/src/fdb_store.rs
@@ -1,4 +1,3 @@
-use crate::store::FrameData;
 use crate::store::FrameStore;
 use async_trait::async_trait;
 use foundationdb::api::NetworkAutoStop;
@@ -39,7 +38,7 @@ impl FDBFrameStore {
         namespace: &str,
         txn: &Transaction,
         frame_no: u64,
-        frame: FrameData,
+        frame: Frame,
     ) {
         let frame_data_key = format!("{}/f/{}/f", namespace, frame_no);
         let frame_page_key = format!("{}/f/{}/p", namespace, frame_no);
@@ -61,16 +60,7 @@ impl FrameStore for FDBFrameStore {
 
         for f in frames {
             frame_no += 1;
-            self.insert_with_tx(
-                namespace,
-                &txn,
-                frame_no,
-                FrameData {
-                    page_no: f.page_no,
-                    data: f.data.into(),
-                },
-            )
-            .await;
+            self.insert_with_tx(namespace, &txn, frame_no, f).await;
         }
         txn.set(&max_frame_key.as_bytes(), &pack(&(frame_no)));
         txn.commit().await.expect("commit failed");

--- a/libsql-storage-server/src/fdb_store.rs
+++ b/libsql-storage-server/src/fdb_store.rs
@@ -53,27 +53,7 @@ impl FDBFrameStore {
 
 #[async_trait]
 impl FrameStore for FDBFrameStore {
-    async fn insert_frame(&self, namespace: &str, page_no: u32, frame: bytes::Bytes) -> u64 {
-        let max_frame_key = format!("{}/max_frame_no", namespace);
-        let db = foundationdb::Database::default().unwrap();
-        let txn = db.create_trx().expect("unable to create transaction");
-        let frame_no = self.get_max_frame_no(&txn, namespace).await + 1;
-        self.insert_with_tx(
-            namespace,
-            &txn,
-            frame_no,
-            FrameData {
-                page_no,
-                data: frame,
-            },
-        )
-        .await;
-        txn.set(&max_frame_key.as_bytes(), &pack(&(frame_no)));
-        txn.commit().await.expect("commit failed");
-        frame_no
-    }
-
-    async fn insert_frames(&self, namespace: &str, max_frame_no: u64, frames: Vec<Frame>) -> u64 {
+    async fn insert_frames(&self, namespace: &str, _max_frame_no: u64, frames: Vec<Frame>) -> u64 {
         let max_frame_key = format!("{}/max_frame_no", namespace);
         let db = foundationdb::Database::default().unwrap();
         let txn = db.create_trx().expect("unable to create transaction");

--- a/libsql-storage-server/src/memory_store.rs
+++ b/libsql-storage-server/src/memory_store.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::sync::Mutex;
 
-use crate::store::FrameData;
 use crate::store::FrameStore;
 use async_trait::async_trait;
 use libsql_storage::rpc::Frame;
@@ -14,7 +13,7 @@ pub(crate) struct InMemFrameStore {
 #[derive(Default)]
 struct InMemInternal {
     // contains a frame data, key is the frame number
-    frames: BTreeMap<u64, FrameData>,
+    frames: BTreeMap<u64, Frame>,
     // pages map contains the page number as a key and the list of frames for the page as a value
     pages: BTreeMap<u32, Vec<u64>>,
     max_frame_no: u64,
@@ -35,13 +34,7 @@ impl FrameStore for InMemFrameStore {
             let frame_no = inner.max_frame_no + 1;
             inner.max_frame_no = frame_no;
             let page_no = frame.page_no;
-            inner.frames.insert(
-                frame_no,
-                FrameData {
-                    page_no,
-                    data: frame.data.into(),
-                },
-            );
+            inner.frames.insert(frame_no, frame);
             inner
                 .pages
                 .entry(page_no)
@@ -59,7 +52,7 @@ impl FrameStore for InMemFrameStore {
             .unwrap()
             .frames
             .get(&frame_no)
-            .map(|frame| frame.data.clone())
+            .map(|frame| frame.data.clone().into())
     }
 
     // given a page number, return the maximum frame for the page

--- a/libsql-storage-server/src/memory_store.rs
+++ b/libsql-storage-server/src/memory_store.rs
@@ -29,25 +29,6 @@ impl InMemFrameStore {
 #[async_trait]
 impl FrameStore for InMemFrameStore {
     // inserts a new frame for the page number and returns the new frame value
-    async fn insert_frame(&self, _namespace: &str, page_no: u32, frame: bytes::Bytes) -> u64 {
-        let mut inner = self.inner.lock().unwrap();
-        let frame_no = inner.max_frame_no + 1;
-        inner.max_frame_no = frame_no;
-        inner.frames.insert(
-            frame_no,
-            FrameData {
-                page_no,
-                data: frame,
-            },
-        );
-        inner
-            .pages
-            .entry(page_no)
-            .or_insert_with(Vec::new)
-            .push(frame_no);
-        frame_no
-    }
-
     async fn insert_frames(&self, _namespace: &str, _max_frame_no: u64, frames: Vec<Frame>) -> u64 {
         let mut inner = self.inner.lock().unwrap();
         for frame in frames {

--- a/libsql-storage-server/src/memory_store.rs
+++ b/libsql-storage-server/src/memory_store.rs
@@ -4,6 +4,7 @@ use std::sync::Mutex;
 use crate::store::FrameData;
 use crate::store::FrameStore;
 use async_trait::async_trait;
+use libsql_storage::rpc::Frame;
 
 #[derive(Default)]
 pub(crate) struct InMemFrameStore {
@@ -47,7 +48,12 @@ impl FrameStore for InMemFrameStore {
         frame_no
     }
 
-    async fn insert_frames(&self, _namespace: &str, _frames: Vec<FrameData>) -> u64 {
+    async fn insert_frames(
+        &self,
+        _namespace: &str,
+        _max_frame_no: u64,
+        _frames: Vec<Frame>,
+    ) -> u64 {
         todo!()
     }
 

--- a/libsql-storage-server/src/redis_store.rs
+++ b/libsql-storage-server/src/redis_store.rs
@@ -18,37 +18,6 @@ impl RedisFrameStore {
 
 #[async_trait]
 impl FrameStore for RedisFrameStore {
-    async fn insert_frame(&self, namespace: &str, page_no: u32, frame: bytes::Bytes) -> u64 {
-        let max_frame_key = format!("{}/max_frame_no", namespace);
-
-        let mut con = self.client.get_connection().unwrap();
-        // max_frame_key might change if another client inserts a frame, so do
-        // all this in a transaction!
-        let (max_frame_no,): (u64,) =
-            redis::transaction(&mut con, &[&max_frame_key], |con, pipe| {
-                let result: RedisResult<u64> = con.get(max_frame_key.clone());
-                if result.is_err() && !is_nil_response(result.as_ref().err().unwrap()) {
-                    return Err(result.err().unwrap());
-                }
-                let max_frame_no = result.unwrap_or(0) + 1;
-                let frame_key = format!("f/{}/{}", namespace, max_frame_no);
-                let page_key = format!("p/{}/{}", namespace, page_no);
-
-                pipe.hset::<String, &str, Vec<u8>>(frame_key.clone(), "f", frame.to_vec())
-                    .ignore()
-                    .hset::<String, &str, u32>(frame_key.clone(), "p", page_no)
-                    .ignore()
-                    .set::<String, u64>(page_key, max_frame_no)
-                    .ignore()
-                    .set::<String, u64>(max_frame_key.clone(), max_frame_no)
-                    .ignore()
-                    .get(max_frame_key.clone())
-                    .query(con)
-            })
-            .unwrap();
-        max_frame_no
-    }
-
     async fn insert_frames(&self, namespace: &str, _max_frame_no: u64, frames: Vec<Frame>) -> u64 {
         let mut max_frame_no = 0;
         let max_frame_key = format!("{}/max_frame_no", namespace);

--- a/libsql-storage-server/src/redis_store.rs
+++ b/libsql-storage-server/src/redis_store.rs
@@ -1,7 +1,7 @@
-use crate::store::FrameData;
 use crate::store::FrameStore;
 use async_trait::async_trait;
 use bytes::Bytes;
+use libsql_storage::rpc::Frame;
 use redis::{Client, Commands, RedisResult};
 use tracing::error;
 
@@ -49,10 +49,10 @@ impl FrameStore for RedisFrameStore {
         max_frame_no
     }
 
-    async fn insert_frames(&self, namespace: &str, frames: Vec<FrameData>) -> u64 {
+    async fn insert_frames(&self, namespace: &str, _max_frame_no: u64, frames: Vec<Frame>) -> u64 {
         let mut max_frame_no = 0;
         for f in frames {
-            max_frame_no = self.insert_frame(namespace, f.page_no, f.data).await;
+            max_frame_no = self.insert_frame(namespace, f.page_no, f.data.into()).await;
         }
         max_frame_no
     }

--- a/libsql-storage-server/src/store.rs
+++ b/libsql-storage-server/src/store.rs
@@ -1,11 +1,12 @@
 use async_trait::async_trait;
 use bytes::Bytes;
+use libsql_storage::rpc::Frame;
 
 #[async_trait]
 pub trait FrameStore: Send + Sync {
     async fn insert_frame(&self, namespace: &str, page_no: u32, frame: bytes::Bytes) -> u64;
     #[allow(dead_code)]
-    async fn insert_frames(&self, namespace: &str, frames: Vec<FrameData>) -> u64;
+    async fn insert_frames(&self, namespace: &str, max_frame_no: u64, frames: Vec<Frame>) -> u64;
     async fn read_frame(&self, namespace: &str, frame_no: u64) -> Option<bytes::Bytes>;
     async fn find_frame(&self, namespace: &str, page_no: u32) -> Option<u64>;
     async fn frame_page_no(&self, namespace: &str, frame_no: u64) -> Option<u32>;

--- a/libsql-storage-server/src/store.rs
+++ b/libsql-storage-server/src/store.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use bytes::Bytes;
 use libsql_storage::rpc::Frame;
 
 #[async_trait]
@@ -10,10 +9,4 @@ pub trait FrameStore: Send + Sync {
     async fn frame_page_no(&self, namespace: &str, frame_no: u64) -> Option<u32>;
     async fn frames_in_wal(&self, namespace: &str) -> u64;
     async fn destroy(&self, namespace: &str);
-}
-
-#[derive(Default)]
-pub struct FrameData {
-    pub(crate) page_no: u32,
-    pub(crate) data: Bytes,
 }

--- a/libsql-storage-server/src/store.rs
+++ b/libsql-storage-server/src/store.rs
@@ -4,8 +4,6 @@ use libsql_storage::rpc::Frame;
 
 #[async_trait]
 pub trait FrameStore: Send + Sync {
-    async fn insert_frame(&self, namespace: &str, page_no: u32, frame: bytes::Bytes) -> u64;
-    #[allow(dead_code)]
     async fn insert_frames(&self, namespace: &str, max_frame_no: u64, frames: Vec<Frame>) -> u64;
     async fn read_frame(&self, namespace: &str, frame_no: u64) -> Option<bytes::Bytes>;
     async fn find_frame(&self, namespace: &str, page_no: u32) -> Option<u64>;

--- a/libsql-storage/proto/storage.proto
+++ b/libsql-storage/proto/storage.proto
@@ -10,6 +10,7 @@ message Frame {
 message InsertFramesRequest {
   string namespace = 1;
   repeated Frame frames = 2;
+  uint64 max_frame_no = 3;
 }
 
 message InsertFramesResponse {

--- a/libsql-storage/src/generated/storage.rs
+++ b/libsql-storage/src/generated/storage.rs
@@ -14,6 +14,8 @@ pub struct InsertFramesRequest {
     pub namespace: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "2")]
     pub frames: ::prost::alloc::vec::Vec<Frame>,
+    #[prost(uint64, tag = "3")]
+    pub max_frame_no: u64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/libsql-storage/src/lib.rs
+++ b/libsql-storage/src/lib.rs
@@ -337,6 +337,7 @@ impl Wal for DurableWal {
         let req = rpc::InsertFramesRequest {
             namespace: self.namespace.clone(),
             frames: self.write_cache.values().cloned().collect(),
+            max_frame_no: 0,
         };
         self.write_cache.clear();
         let mut binding = self.client.clone();


### PR DESCRIPTION
- Update proto to send `max_frame_no` while inserting frames so that we can have multiple writers
- cleanup: remove `insert_frame` method and impl. Use `insert_frames` instead
- Remove `FrameData`, use `Frame` from proto instead