### PR TITLE
libsql: SQLite extension loading support

### DIFF
--- a/libsql/src/connection.rs
+++ b/libsql/src/connection.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::params::{IntoParams, Params};
@@ -25,6 +26,14 @@ pub(crate) trait Conn {
     fn last_insert_rowid(&self) -> i64;
 
     async fn reset(&self);
+
+    fn enable_load_extension(&self, _onoff: bool) -> Result<()> {
+        Err(crate::Error::LoadExtensionNotSupported)
+    }
+
+    fn load_extension(&self, _dylib_path: &Path, _entry_point: Option<&str>) -> Result<()> {
+        Err(crate::Error::LoadExtensionNotSupported)
+    }
 }
 
 /// A connection to some libsql database, this can be a remote one or a local one.
@@ -124,5 +133,41 @@ impl Connection {
 
     pub async fn reset(&self) {
         self.conn.reset().await
+    }
+
+    /// Enable loading SQLite extensions from SQL queries and Rust API.
+    ///
+    /// See [`load_extension`](Connection::load_extension) documentation for more details.
+    pub fn load_extension_enable(&self) -> Result<()> {
+        self.conn.enable_load_extension(true)
+    }
+
+    /// Disable loading SQLite extensions from SQL queries and Rust API.
+    ///
+    /// See [`load_extension`](Connection::load_extension) documentation for more details.
+    pub fn load_extension_disable(&self) -> Result<()> {
+        self.conn.enable_load_extension(false)
+    }
+
+    /// Load a SQLite extension from a dynamic library at `dylib_path`, specifying optional
+    /// entry point `entry_point`.
+    ///
+    /// # Security
+    ///
+    /// Loading extensions from dynamic libraries is a potential security risk, as it allows
+    /// arbitrary code execution. Only load extensions that you trust.
+    ///
+    /// Extension loading is disabled by default. Please use the [`load_extension_enable`](Connection::load_extension_enable)
+    /// method to enable it. It's recommended to disable extension loading after you're done
+    /// loading extensions to avoid SQL injection attacks from loading extensions.
+    ///
+    /// See SQLite's documentation on `sqlite3_load_extension` for more information:
+    /// https://sqlite.org/c3ref/load_extension.html
+    pub fn load_extension<P: AsRef<Path>>(
+        &self,
+        dylib_path: P,
+        entry_point: Option<&str>,
+    ) -> Result<()> {
+        self.conn.load_extension(dylib_path.as_ref(), entry_point)
     }
 }

--- a/libsql/src/errors.rs
+++ b/libsql/src/errors.rs
@@ -18,6 +18,8 @@ pub enum Error {
     ToSqlConversionFailure(crate::BoxError),
     #[error("Sync is not supported in databases opened in {0} mode.")]
     SyncNotSupported(String), // Not in rusqlite
+    #[error("Loading extension is only supported in local databases.")]
+    LoadExtensionNotSupported, // Not in rusqlite
     #[error("Column not found: {0}")]
     ColumnNotFound(i32), // Not in rusqlite
     #[error("Hrana: `{0}`")]

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -126,6 +126,7 @@ pub use params::params_from_iter;
 
 mod connection;
 mod database;
+mod load_extension_guard;
 
 cfg_parser! {
     mod parser;
@@ -148,6 +149,7 @@ cfg_hrana! {
 pub use self::{
     connection::Connection,
     database::{Builder, Database},
+    load_extension_guard::LoadExtensionGuard,
     rows::{Column, Row, Rows},
     statement::Statement,
     transaction::{Transaction, TransactionBehavior},

--- a/libsql/src/load_extension_guard.rs
+++ b/libsql/src/load_extension_guard.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use crate::connection::Conn;
+use crate::{Connection, Result};
+
+/// A guard for safely loading SQLite extensions.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// let _guard = LoadExtensionGuard::new(conn)?;
+/// conn.load_extension("uuid", None)?;
+/// ```
+pub struct LoadExtensionGuard {
+    pub(crate) conn: Arc<dyn Conn + Send + Sync>,
+}
+
+impl LoadExtensionGuard {
+    pub fn new(conn: &Connection) -> Result<LoadExtensionGuard> {
+        let conn = conn.conn.clone();
+        conn.enable_load_extension(true).map(|_| Self { conn })
+    }
+}
+
+impl Drop for LoadExtensionGuard {
+    fn drop(&mut self) {
+        let _ = self.conn.enable_load_extension(false);
+    }
+}

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, path::Path};
 use std::sync::Arc;
 
 use crate::{
@@ -65,6 +65,14 @@ impl Conn for LibsqlConnection {
     }
 
     async fn reset(&self) {}
+
+    fn enable_load_extension(&self, onoff: bool) -> Result<()> {
+        self.conn.enable_load_extension(onoff)
+    }
+
+    fn load_extension(&self, dylib_path: &Path, entry_point: Option<&str>) -> Result<()> {
+        self.conn.load_extension(dylib_path, entry_point)
+    }
 }
 
 impl Drop for LibsqlConnection {


### PR DESCRIPTION
This adds a load_extension() API for loading SQLite extensions, which is API compatible with Rusqlite.

Fixes #402