### PR TITLE
Integrate durable WAL into libsql server

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,10 +130,6 @@ jobs:
       env:
         LIBSQL_EXPERIMENTAL_PAGER: 1000
       run: cargo nextest run
-
-    - name: Run tests with durable WAL
-      run: cargo nextest run --features durable-wal
-
     - name: clean build dir
       run: rm -rf libsql-ffi/bundled/SQLite3MultipleCiphers/build
     - name: embedded replica encryption tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,6 +130,10 @@ jobs:
       env:
         LIBSQL_EXPERIMENTAL_PAGER: 1000
       run: cargo nextest run
+
+    - name: Run tests with durable WAL
+      run: cargo nextest run --features durable-wal
+
     - name: clean build dir
       run: rm -rf libsql-ffi/bundled/SQLite3MultipleCiphers/build
     - name: embedded replica encryption tests

--- a/.github/workflows/server-pr-images.yml
+++ b/.github/workflows/server-pr-images.yml
@@ -69,6 +69,19 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push Docker image with durable-wal
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-durable-wal-${{ steps.get-short-sha.outputs.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            ENABLE_FEATURES=durable-wal
+
       - name: Echo image name
         run: |
           echo "Pushed: ${{ steps.meta.outputs.tags }}-${{ steps.get-short-sha.outputs.sha }}"
+          echo "Pushed: ${{ steps.meta.outputs.tags }}-durable-wal-${{ steps.get-short-sha.outputs.sha }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,6 +3470,7 @@ dependencies = [
  "libsql-hrana",
  "libsql-rusqlite",
  "libsql-sqlite3-parser",
+ "libsql-storage",
  "libsql-sys",
  "libsql-wal",
  "libsql_replication",

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,12 @@ FROM chef AS builder
 COPY --from=planner /recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN cargo build -p libsql-server --release
-
+ARG ENABLE_FEATURES=""
+RUN if [ "$ENABLE_FEATURES" == "" ]; then \
+        cargo build -p libsql-server --release ; \
+    else \
+        cargo build -p libsql-server --features "$ENABLE_FEATURES" --release ; \
+    fi
 # runtime
 FROM debian:bullseye-slim
 RUN apt update

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -38,6 +38,7 @@ jsonwebtoken = "9"
 libsql = { path = "../libsql/", optional = true }
 libsql_replication = { path = "../libsql-replication" }
 libsql-wal = { path = "../libsql-wal/" }
+libsql-storage = { path = "../libsql-storage" }
 metrics = "0.21.1"
 metrics-util = "0.15"
 metrics-exporter-prometheus = "0.12.2"

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -38,7 +38,7 @@ jsonwebtoken = "9"
 libsql = { path = "../libsql/", optional = true }
 libsql_replication = { path = "../libsql-replication" }
 libsql-wal = { path = "../libsql-wal/" }
-libsql-storage = { path = "../libsql-storage" }
+libsql-storage = { path = "../libsql-storage", optional = true }
 metrics = "0.21.1"
 metrics-util = "0.15"
 metrics-exporter-prometheus = "0.12.2"
@@ -117,3 +117,4 @@ wasm-udfs = ["rusqlite/libsql-wasm-experimental"]
 unix-excl-vfs = ["libsql-sys/unix-excl-vfs"]
 encryption = ["dep:aes", "dep:cbc", "libsql-sys/encryption", "libsql_replication/encryption", "bottomless/encryption"]
 test-encryption = ["libsql/encryption"]
+durable-wal = ["libsql-storage"]

--- a/libsql-server/src/connection/connection_manager.rs
+++ b/libsql-server/src/connection/connection_manager.rs
@@ -6,7 +6,11 @@ use std::time::{Duration, Instant};
 use crossbeam::deque::Steal;
 use crossbeam::sync::{Parker, Unparker};
 use hashbrown::HashMap;
+#[cfg(feature = "durable-wal")]
 use libsql_storage::{DurableWal, DurableWalManager};
+#[cfg(not(feature = "durable-wal"))]
+use libsql_sys::wal::either::Either;
+#[cfg(feature = "durable-wal")]
 use libsql_sys::wal::either::Either3;
 use libsql_sys::wal::wrapper::{WrapWal, WrappedWal};
 use libsql_sys::wal::{CheckpointMode, Sqlite3Wal, Sqlite3WalManager, Wal};
@@ -20,8 +24,17 @@ use super::libsql::Connection;
 use super::TXN_TIMEOUT;
 
 pub type ConnId = u64;
+#[cfg(feature = "durable-wal")]
+
 pub type InnerWalManager = Either3<Sqlite3WalManager, LibsqlWalManager<StdIO>, DurableWalManager>;
+#[cfg(feature = "durable-wal")]
 pub type InnerWal = Either3<Sqlite3Wal, LibsqlWal<StdIO>, DurableWal>;
+#[cfg(not(feature = "durable-wal"))]
+
+pub type InnerWalManager = Either<Sqlite3WalManager, LibsqlWalManager<StdIO>>;
+#[cfg(not(feature = "durable-wal"))]
+
+pub type InnerWal = Either<Sqlite3Wal, LibsqlWal<StdIO>>;
 pub type ManagedConnectionWal = WrappedWal<ManagedConnectionWalWrapper, InnerWal>;
 
 #[derive(Copy, Clone, Debug)]

--- a/libsql-server/src/connection/connection_manager.rs
+++ b/libsql-server/src/connection/connection_manager.rs
@@ -6,7 +6,8 @@ use std::time::{Duration, Instant};
 use crossbeam::deque::Steal;
 use crossbeam::sync::{Parker, Unparker};
 use hashbrown::HashMap;
-use libsql_sys::wal::either::Either;
+use libsql_storage::{DurableWal, DurableWalManager};
+use libsql_sys::wal::either::Either3;
 use libsql_sys::wal::wrapper::{WrapWal, WrappedWal};
 use libsql_sys::wal::{CheckpointMode, Sqlite3Wal, Sqlite3WalManager, Wal};
 use libsql_wal::io::StdIO;
@@ -19,8 +20,8 @@ use super::libsql::Connection;
 use super::TXN_TIMEOUT;
 
 pub type ConnId = u64;
-pub type InnerWalManager = Either<Sqlite3WalManager, LibsqlWalManager<StdIO>>;
-pub type InnerWal = Either<Sqlite3Wal, LibsqlWal<StdIO>>;
+pub type InnerWalManager = Either3<Sqlite3WalManager, LibsqlWalManager<StdIO>, DurableWalManager>;
+pub type InnerWal = Either3<Sqlite3Wal, LibsqlWal<StdIO>, DurableWal>;
 pub type ManagedConnectionWal = WrappedWal<ManagedConnectionWalWrapper, InnerWal>;
 
 #[derive(Copy, Clone, Debug)]

--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -169,7 +169,7 @@ pub struct LibSqlConnection<T> {
 #[cfg(test)]
 impl LibSqlConnection<libsql_sys::wal::wrapper::PassthroughWalWrapper> {
     pub async fn new_test(path: &Path) -> Self {
-        use libsql_sys::wal::either::Either;
+        use libsql_sys::wal::either::Either3;
         use libsql_sys::wal::Sqlite3WalManager;
 
         Self::new(
@@ -183,7 +183,7 @@ impl LibSqlConnection<libsql_sys::wal::wrapper::PassthroughWalWrapper> {
             Default::default(),
             Arc::new(|_| unreachable!()),
             ConnectionManager::new(TXN_TIMEOUT),
-            Arc::new(|| Either::A(Sqlite3WalManager::default())),
+            Arc::new(|| Either3::A(Sqlite3WalManager::default())),
         )
         .await
         .unwrap()
@@ -706,7 +706,7 @@ where
 #[cfg(test)]
 mod test {
     use itertools::Itertools;
-    use libsql_sys::wal::either::Either;
+    use libsql_sys::wal::either::Either3;
     use libsql_sys::wal::wrapper::PassthroughWalWrapper;
     use libsql_sys::wal::{Sqlite3Wal, Sqlite3WalManager};
     use rand::Rng;
@@ -770,7 +770,7 @@ mod test {
             None,
             Default::default(),
             Arc::new(|_| unreachable!()),
-            Arc::new(|| Either::A(Sqlite3WalManager::default())),
+            Arc::new(|| Either3::A(Sqlite3WalManager::default())),
         )
         .await
         .unwrap();
@@ -817,7 +817,7 @@ mod test {
             None,
             Default::default(),
             Arc::new(|_| unreachable!()),
-            Arc::new(|| Either::A(Sqlite3WalManager::default())),
+            Arc::new(|| Either3::A(Sqlite3WalManager::default())),
         )
         .await
         .unwrap();
@@ -868,7 +868,7 @@ mod test {
             None,
             Default::default(),
             Arc::new(|_| unreachable!()),
-            Arc::new(|| Either::A(Sqlite3WalManager::default())),
+            Arc::new(|| Either3::A(Sqlite3WalManager::default())),
         )
         .await
         .unwrap();
@@ -953,7 +953,7 @@ mod test {
             None,
             Default::default(),
             Arc::new(|_| unreachable!()),
-            Arc::new(|| Either::A(Sqlite3WalManager::default())),
+            Arc::new(|| Either3::A(Sqlite3WalManager::default())),
         )
         .await
         .unwrap();
@@ -1039,7 +1039,7 @@ mod test {
             None,
             Default::default(),
             Arc::new(|_| unreachable!()),
-            Arc::new(|| Either::A(Sqlite3WalManager::default())),
+            Arc::new(|| Either3::A(Sqlite3WalManager::default())),
         )
         .await
         .unwrap();

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -105,6 +105,7 @@ type StatsSender = mpsc::Sender<(NamespaceName, MetaStoreHandle, Weak<Stats>)>;
 #[derive(clap::ValueEnum, PartialEq, Clone, Copy, Debug)]
 pub enum CustomWAL {
     LibsqlWal,
+    #[cfg(feature = "durable-wal")]
     DurableWal,
 }
 
@@ -645,84 +646,86 @@ where
         Arc<dyn Fn() -> InnerWalManager + Sync + Send + 'static>,
         Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + Sync + 'static>>,
     )> {
-        if self.use_custom_wal.is_none() {
-            tracing::info!("using sqlite3 wal");
-            #[cfg(not(feature = "durable-wal"))]
-            return Ok((
-                Arc::new(|| Either::A(Sqlite3WalManager::default())),
-                Box::pin(ready(Ok(()))),
-            ));
-            #[cfg(feature = "durable-wal")]
-            return Ok((
-                Arc::new(|| Either3::A(Sqlite3WalManager::default())),
-                Box::pin(ready(Ok(()))),
-            ));
-        };
-
-        let use_custom_wal = self.use_custom_wal.unwrap();
-
-        #[cfg(feature = "durable-wal")]
-        if use_custom_wal == CustomWAL::DurableWal {
-            tracing::info!("using durable wal");
-            let lock_manager = Arc::new(std::sync::Mutex::new(LockManager::new()));
-            let wal = DurableWalManager::new(lock_manager, self.storage_server_address.clone());
-            return Ok((
-                Arc::new(move || Either3::C(wal.clone())),
-                Box::pin(ready(Ok(()))),
-            ));
-        };
-
         let wal_path = self.path.join("wals");
         let enable_libsql_wal_test = {
             let is_primary = self.rpc_server_config.is_some();
             let is_libsql_wal_test = std::env::var("LIBSQL_WAL_TEST").is_ok();
             is_primary && is_libsql_wal_test
         };
-
-        let use_libsql_wal = use_custom_wal == CustomWAL::LibsqlWal || enable_libsql_wal_test;
-
-        if wal_path.try_exists()? && !use_libsql_wal {
-            anyhow::bail!("database was previously setup to use libsql-wal");
+        let use_libsql_wal =
+            self.use_custom_wal == Some(CustomWAL::LibsqlWal) || enable_libsql_wal_test;
+        if !use_libsql_wal {
+            if wal_path.try_exists()? {
+                anyhow::bail!("database was previously setup to use libsql-wal");
+            }
         }
 
-        if self.db_config.bottomless_replication.is_some() {
-            anyhow::bail!("bottomless not supported with libsql_wal");
+        if self.use_custom_wal.is_some() {
+            if self.db_config.bottomless_replication.is_some() {
+                anyhow::bail!("bottomless not supported with custom WAL");
+            }
+            if self.rpc_client_config.is_some() {
+                anyhow::bail!("custom WAL not supported in replica mode");
+            }
         }
 
-        if self.rpc_client_config.is_some() {
-            anyhow::bail!("lisbl wal not supported in replica mode");
+        match self.use_custom_wal {
+            Some(CustomWAL::LibsqlWal) => {
+                let namespace_resolver = |path: &Path| {
+                    NamespaceName::from_string(
+                        path.parent()
+                            .unwrap()
+                            .file_name()
+                            .unwrap()
+                            .to_str()
+                            .unwrap()
+                            .to_string(),
+                    )
+                    .unwrap()
+                    .into()
+                };
+
+                let registry = Arc::new(WalRegistry::new(wal_path, namespace_resolver, ())?);
+
+                let wal = LibsqlWalManager::new(registry.clone());
+                let shutdown_notify = self.shutdown.clone();
+                let shutdown_fut = Box::pin(async move {
+                    shutdown_notify.notified().await;
+                    tokio::task::spawn_blocking(move || registry.shutdown())
+                        .await
+                        .unwrap()?;
+                    Ok(())
+                });
+
+                tracing::info!("using libsql wal");
+                #[cfg(not(feature = "durable-wal"))]
+                return Ok((Arc::new(move || Either::B(wal.clone())), shutdown_fut));
+                #[cfg(feature = "durable-wal")]
+                Ok((Arc::new(move || Either3::B(wal.clone())), shutdown_fut))
+            }
+            #[cfg(feature = "durable-wal")]
+            Some(CustomWAL::DurableWal) => {
+                tracing::info!("using durable wal");
+                let lock_manager = Arc::new(std::sync::Mutex::new(LockManager::new()));
+                let wal = DurableWalManager::new(lock_manager, self.storage_server_address.clone());
+                Ok((
+                    Arc::new(move || Either3::C(wal.clone())),
+                    Box::pin(ready(Ok(()))),
+                ))
+            }
+            None => {
+                tracing::info!("using sqlite3 wal");
+                #[cfg(not(feature = "durable-wal"))]
+                return Ok((
+                    Arc::new(|| Either::A(Sqlite3WalManager::default())),
+                    Box::pin(ready(Ok(()))),
+                ));
+                #[cfg(feature = "durable-wal")]
+                Ok((
+                    Arc::new(|| Either3::A(Sqlite3WalManager::default())),
+                    Box::pin(ready(Ok(()))),
+                ))
+            }
         }
-
-        let namespace_resolver = |path: &Path| {
-            NamespaceName::from_string(
-                path.parent()
-                    .unwrap()
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .to_string(),
-            )
-            .unwrap()
-            .into()
-        };
-
-        let registry = Arc::new(WalRegistry::new(wal_path, namespace_resolver, ())?);
-
-        let wal = LibsqlWalManager::new(registry.clone());
-        let shutdown_notify = self.shutdown.clone();
-        let shutdown_fut = Box::pin(async move {
-            shutdown_notify.notified().await;
-            tokio::task::spawn_blocking(move || registry.shutdown())
-                .await
-                .unwrap()?;
-            Ok(())
-        });
-
-        tracing::info!("using libsql wal");
-        #[cfg(not(feature = "durable-wal"))]
-        return Ok((Arc::new(move || Either::B(wal.clone())), shutdown_fut));
-        #[cfg(feature = "durable-wal")]
-        return Ok((Arc::new(move || Either3::B(wal.clone())), shutdown_fut));
     }
 }

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -21,6 +21,7 @@ use libsql_server::config::{
 };
 use libsql_server::net::AddrIncoming;
 use libsql_server::version::Version;
+use libsql_server::CustomWAL;
 use libsql_server::Server;
 use libsql_sys::{Cipher, EncryptionConfig};
 
@@ -245,8 +246,8 @@ struct Cli {
     #[clap(long, env = "SQLD_SHUTDOWN_TIMEOUT")]
     shutdown_timeout: Option<u64>,
 
-    #[clap(long)]
-    use_libsql_wal: bool,
+    #[clap(value_enum, long)]
+    use_custom_wal: Option<CustomWAL>,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -630,7 +631,7 @@ async fn build_server(config: &Cli) -> anyhow::Result<Server> {
             .shutdown_timeout
             .map(Duration::from_secs)
             .unwrap_or(Duration::from_secs(30)),
-        use_libsql_wal: config.use_libsql_wal,
+        use_custom_wal: config.use_custom_wal,
     })
 }
 

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -248,6 +248,13 @@ struct Cli {
 
     #[clap(value_enum, long)]
     use_custom_wal: Option<CustomWAL>,
+
+    #[clap(
+        long,
+        env = "LIBSQL_STORAGE_SERVER_ADDR",
+        default_value = "http://0.0.0.0:5002"
+    )]
+    storage_server_address: String,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -632,6 +639,7 @@ async fn build_server(config: &Cli) -> anyhow::Result<Server> {
             .map(Duration::from_secs)
             .unwrap_or(Duration::from_secs(30)),
         use_custom_wal: config.use_custom_wal,
+        storage_server_address: config.storage_server_address.clone(),
     })
 }
 

--- a/libsql-server/src/schema/scheduler.rs
+++ b/libsql-server/src/schema/scheduler.rs
@@ -779,9 +779,9 @@ async fn step_job_run_success(
 mod test {
     use insta::assert_debug_snapshot;
     #[cfg(not(feature = "durable-wal"))]
-    use libsql_sys::wal::either::Either;
+    use libsql_sys::wal::either::Either as EitherWAL;
     #[cfg(feature = "durable-wal")]
-    use libsql_sys::wal::either::Either3;
+    use libsql_sys::wal::either::Either3 as EitherWAL;
     use libsql_sys::wal::Sqlite3WalManager;
     use std::path::Path;
     use tempfile::tempdir;
@@ -881,10 +881,6 @@ mod test {
     }
 
     fn make_config(migration_scheduler: SchedulerHandle, path: &Path) -> NamespaceConfig {
-        #[cfg(not(feature = "durable-wal"))]
-        let wal = Arc::new(|| Either::A(Sqlite3WalManager::default()));
-        #[cfg(feature = "durable-wal")]
-        let wal = Arc::new(|| Either3::A(Sqlite3WalManager::default()));
         NamespaceConfig {
             db_kind: DatabaseKind::Primary,
             base_path: path.to_path_buf().into(),
@@ -903,7 +899,7 @@ mod test {
             bottomless_replication: None,
             scripted_backup: None,
             migration_scheduler,
-            make_wal_manager: wal,
+            make_wal_manager: Arc::new(|| EitherWAL::A(Sqlite3WalManager::default())),
         }
     }
 

--- a/libsql-server/src/schema/scheduler.rs
+++ b/libsql-server/src/schema/scheduler.rs
@@ -778,6 +778,9 @@ async fn step_job_run_success(
 #[cfg(test)]
 mod test {
     use insta::assert_debug_snapshot;
+    #[cfg(not(feature = "durable-wal"))]
+    use libsql_sys::wal::either::Either;
+    #[cfg(feature = "durable-wal")]
     use libsql_sys::wal::either::Either3;
     use libsql_sys::wal::Sqlite3WalManager;
     use std::path::Path;
@@ -878,6 +881,10 @@ mod test {
     }
 
     fn make_config(migration_scheduler: SchedulerHandle, path: &Path) -> NamespaceConfig {
+        #[cfg(not(feature = "durable-wal"))]
+        let wal = Arc::new(|| Either::A(Sqlite3WalManager::default()));
+        #[cfg(feature = "durable-wal")]
+        let wal = Arc::new(|| Either3::A(Sqlite3WalManager::default()));
         NamespaceConfig {
             db_kind: DatabaseKind::Primary,
             base_path: path.to_path_buf().into(),
@@ -896,7 +903,7 @@ mod test {
             bottomless_replication: None,
             scripted_backup: None,
             migration_scheduler,
-            make_wal_manager: Arc::new(|| Either3::A(Sqlite3WalManager::default())),
+            make_wal_manager: wal,
         }
     }
 

--- a/libsql-server/src/schema/scheduler.rs
+++ b/libsql-server/src/schema/scheduler.rs
@@ -778,7 +778,7 @@ async fn step_job_run_success(
 #[cfg(test)]
 mod test {
     use insta::assert_debug_snapshot;
-    use libsql_sys::wal::either::Either;
+    use libsql_sys::wal::either::Either3;
     use libsql_sys::wal::Sqlite3WalManager;
     use std::path::Path;
     use tempfile::tempdir;
@@ -896,7 +896,7 @@ mod test {
             bottomless_replication: None,
             scripted_backup: None,
             migration_scheduler,
-            make_wal_manager: Arc::new(|| Either::A(Sqlite3WalManager::default())),
+            make_wal_manager: Arc::new(|| Either3::A(Sqlite3WalManager::default())),
         }
     }
 


### PR DESCRIPTION
This patch adds the durable WAL from `libsql-storage` module to sqld. 

This has one (minor) breaking change. The CLI arg `use-libsql-wal` changed to `use-custom-wal` and it takes two options `libsql-wal` or `durable-wal`