### PR TITLE
Use the namespace resolver to extract namespace

### DIFF
--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -706,7 +706,11 @@ where
             Some(CustomWAL::DurableWal) => {
                 tracing::info!("using durable wal");
                 let lock_manager = Arc::new(std::sync::Mutex::new(LockManager::new()));
-                let wal = DurableWalManager::new(lock_manager, self.storage_server_address.clone());
+                let wal = DurableWalManager::new(
+                    lock_manager,
+                    namespace_resolver,
+                    self.storage_server_address.clone(),
+                );
                 Ok((
                     Arc::new(move || EitherWAL::C(wal.clone())),
                     Box::pin(ready(Ok(()))),

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -671,22 +671,22 @@ where
             }
         }
 
+        let namespace_resolver = |path: &Path| {
+            NamespaceName::from_string(
+                path.parent()
+                    .unwrap()
+                    .file_name()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string(),
+            )
+            .unwrap()
+            .into()
+        };
+
         match self.use_custom_wal {
             Some(CustomWAL::LibsqlWal) => {
-                let namespace_resolver = |path: &Path| {
-                    NamespaceName::from_string(
-                        path.parent()
-                            .unwrap()
-                            .file_name()
-                            .unwrap()
-                            .to_str()
-                            .unwrap()
-                            .to_string(),
-                    )
-                    .unwrap()
-                    .into()
-                };
-
                 let registry = Arc::new(WalRegistry::new(wal_path, namespace_resolver, ())?);
 
                 let wal = LibsqlWalManager::new(registry.clone());

--- a/libsql-server/src/namespace/name.rs
+++ b/libsql-server/src/namespace/name.rs
@@ -14,9 +14,9 @@ impl fmt::Debug for NamespaceName {
     }
 }
 
-impl Into<libsql_wal::name::NamespaceName> for NamespaceName {
-    fn into(self) -> libsql_wal::name::NamespaceName {
-        libsql_wal::name::NamespaceName(self.0)
+impl Into<libsql_sys::name::NamespaceName> for NamespaceName {
+    fn into(self) -> libsql_sys::name::NamespaceName {
+        libsql_sys::name::NamespaceName(self.0)
     }
 }
 

--- a/libsql-sys/src/lib.rs
+++ b/libsql-sys/src/lib.rs
@@ -63,6 +63,7 @@ pub mod ffi {
 #[cfg(feature = "api")]
 pub mod connection;
 pub mod error;
+pub mod name;
 #[cfg(feature = "api")]
 pub mod statement;
 #[cfg(feature = "api")]

--- a/libsql-sys/src/name.rs
+++ b/libsql-sys/src/name.rs
@@ -1,6 +1,6 @@
-use std::fmt;
-
 use bytes::Bytes;
+use std::fmt;
+use std::path::Path;
 
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct NamespaceName(pub Bytes);
@@ -47,5 +47,16 @@ impl NamespaceName {
 impl fmt::Display for NamespaceName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_str().fmt(f)
+    }
+}
+
+/// Translates a path to a namespace name
+pub trait NamespaceResolver: Send + Sync + 'static {
+    fn resolve(&self, path: &Path) -> NamespaceName;
+}
+
+impl<F: Fn(&Path) -> NamespaceName + Send + Sync + 'static> NamespaceResolver for F {
+    fn resolve(&self, path: &Path) -> NamespaceName {
+        (self)(path)
     }
 }

--- a/libsql-wal/benches/benchmarks.rs
+++ b/libsql-wal/benches/benchmarks.rs
@@ -2,11 +2,11 @@ use std::path::Path;
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use libsql_sys::name::NamespaceName;
 use libsql_sys::rusqlite::{self, OpenFlags};
 use libsql_sys::wal::{Sqlite3Wal, Sqlite3WalManager, Wal};
 use libsql_sys::Connection;
 use libsql_wal::io::StdIO;
-use libsql_wal::name::NamespaceName;
 use libsql_wal::wal::LibsqlWal;
 use libsql_wal::{registry::WalRegistry, wal::LibsqlWalManager};
 use tempfile::tempdir;

--- a/libsql-wal/src/bottomless/job.rs
+++ b/libsql-wal/src/bottomless/job.rs
@@ -197,11 +197,11 @@ mod test {
 
     use crate::io::file::{async_read_all_to_vec, FileExt};
     use crate::io::StdIO;
-    use crate::name::NamespaceName;
     use crate::registry::{SegmentSwapHandler, WalRegistry};
     use crate::segment::sealed::SealedSegment;
     use crate::segment::FrameHeader;
     use crate::wal::{LibsqlWal, LibsqlWalManager};
+    use libsql_sys::name::NamespaceName;
 
     use super::*;
 

--- a/libsql-wal/src/bottomless/mod.rs
+++ b/libsql-wal/src/bottomless/mod.rs
@@ -7,8 +7,8 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::{JoinHandle, JoinSet};
 
 use crate::io::Io;
-use crate::name::NamespaceName;
 use crate::segment::sealed::SealedSegment;
+use libsql_sys::name::NamespaceName;
 
 use self::job::JobResult;
 use self::scheduler::Scheduler;

--- a/libsql-wal/src/bottomless/restore.rs
+++ b/libsql-wal/src/bottomless/restore.rs
@@ -2,8 +2,8 @@ use chrono::{DateTime, Utc};
 use tokio::io::AsyncWrite;
 
 use super::storage::Storage;
-use super::NamespaceName;
 use super::Result;
+use libsql_sys::name::NamespaceName;
 
 /// Restore a Namespace from bottomless
 pub struct BottomlessRestore<C> {

--- a/libsql-wal/src/bottomless/scheduler.rs
+++ b/libsql-wal/src/bottomless/scheduler.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc;
 
 use super::job::{IndexedRequest, Job, JobResult};
 use super::StoreSegmentRequest;
-use crate::name::NamespaceName;
+use libsql_sys::name::NamespaceName;
 
 struct NamespaceRequests<C, F> {
     requests: VecDeque<IndexedRequest<C, F>>,
@@ -155,7 +155,7 @@ mod test {
     use chrono::Utc;
 
     use crate::bottomless::Error;
-    use crate::name::NamespaceName;
+    use libsql_sys::name::NamespaceName;
 
     use super::*;
 

--- a/libsql-wal/src/bottomless/storage/fs.rs
+++ b/libsql-wal/src/bottomless/storage/fs.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::bottomless::job::CompactedSegmentDataHeader;
 use crate::bottomless::{Error, Result};
 use crate::io::{FileExt, Io};
-use crate::name::NamespaceName;
+use libsql_sys::name::NamespaceName;
 
 use super::Storage;
 

--- a/libsql-wal/src/bottomless/storage/mod.rs
+++ b/libsql-wal/src/bottomless/storage/mod.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use super::Result;
 use crate::io::file::FileExt;
-use crate::name::NamespaceName;
+use libsql_sys::name::NamespaceName;
 
 mod fs;
 mod s3;

--- a/libsql-wal/src/bottomless/storage/s3.rs
+++ b/libsql-wal/src/bottomless/storage/s3.rs
@@ -1,8 +1,7 @@
 //! S3 implementation of storage
 
-use std::{future::Future, path::Path};
 use libsql_sys::name::NamespaceName;
-
+use std::{future::Future, path::Path};
 
 use super::Storage;
 use crate::{bottomless::Result, io::file::FileExt};

--- a/libsql-wal/src/bottomless/storage/s3.rs
+++ b/libsql-wal/src/bottomless/storage/s3.rs
@@ -1,9 +1,11 @@
 //! S3 implementation of storage
 
 use std::{future::Future, path::Path};
+use libsql_sys::name::NamespaceName;
+
 
 use super::Storage;
-use crate::{bottomless::Result, io::file::FileExt, name::NamespaceName};
+use crate::{bottomless::Result, io::file::FileExt};
 
 pub struct S3Storage {}
 

--- a/libsql-wal/src/lib.rs
+++ b/libsql-wal/src/lib.rs
@@ -3,7 +3,6 @@
 pub mod bottomless;
 pub mod error;
 pub mod io;
-pub mod name;
 pub mod registry;
 pub mod replication;
 pub mod segment;

--- a/libsql-wal/src/registry.rs
+++ b/libsql-wal/src/registry.rs
@@ -12,22 +12,11 @@ use zerocopy::{AsBytes, FromZeroes};
 use crate::error::Result;
 use crate::io::file::FileExt;
 use crate::io::{Io, StdIO};
-use crate::name::NamespaceName;
 use crate::segment::list::SegmentList;
 use crate::segment::{current::CurrentSegment, sealed::SealedSegment};
 use crate::shared_wal::SharedWal;
 use crate::transaction::{Transaction, TxGuard};
-
-/// Translates a path to a namespace name
-pub trait NamespaceResolver: Send + Sync + 'static {
-    fn resolve(&self, path: &Path) -> NamespaceName;
-}
-
-impl<F: Fn(&Path) -> NamespaceName + Send + Sync + 'static> NamespaceResolver for F {
-    fn resolve(&self, path: &Path) -> NamespaceName {
-        (self)(path)
-    }
-}
+use libsql_sys::name::{NamespaceName, NamespaceResolver};
 
 /// called on every segment on swap.
 pub trait SegmentSwapHandler<F>: Send + Sync + 'static {

--- a/libsql-wal/src/replication/injector.rs
+++ b/libsql-wal/src/replication/injector.rs
@@ -66,13 +66,13 @@ impl<'a, IO: Io> Injector<'a, IO> {
 mod test {
     use std::{path::Path, sync::Arc};
 
+    use libsql_sys::name::NamespaceName;
     use libsql_sys::rusqlite::OpenFlags;
     use tempfile::tempdir;
     use tokio_stream::StreamExt;
 
     use crate::{
-        name::NamespaceName, registry::WalRegistry, replication::replicator::Replicator,
-        wal::LibsqlWalManager,
+        registry::WalRegistry, replication::replicator::Replicator, wal::LibsqlWalManager,
     };
 
     use super::*;

--- a/libsql-wal/src/replication/replicator.rs
+++ b/libsql-wal/src/replication/replicator.rs
@@ -101,9 +101,9 @@ mod test {
     use libsql_sys::rusqlite::OpenFlags;
     use tempfile::tempdir;
 
-    use crate::name::NamespaceName;
     use crate::registry::WalRegistry;
     use crate::wal::LibsqlWalManager;
+    use libsql_sys::name::NamespaceName;
 
     use super::*;
 

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -11,10 +11,10 @@ use parking_lot::{Mutex, MutexGuard};
 use crate::error::{Error, Result};
 use crate::io::file::FileExt;
 use crate::io::Io;
-use crate::name::NamespaceName;
 use crate::registry::WalRegistry;
 use crate::segment::current::CurrentSegment;
 use crate::transaction::{ReadTransaction, Savepoint, Transaction, TxGuard, WriteTransaction};
+use libsql_sys::name::NamespaceName;
 
 #[derive(Default)]
 pub struct WalLock {

--- a/libsql-wal/tests/flaky_fs.rs
+++ b/libsql-wal/tests/flaky_fs.rs
@@ -5,10 +5,10 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
 use std::sync::Arc;
 
+use libsql_sys::name::NamespaceName;
 use libsql_sys::rusqlite::{self, ErrorCode, OpenFlags};
 use libsql_wal::{
     io::{file::FileExt, Io},
-    name::NamespaceName,
     registry::WalRegistry,
     wal::LibsqlWalManager,
 };

--- a/libsql-wal/tests/misc.rs
+++ b/libsql-wal/tests/misc.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
+use libsql_sys::name::NamespaceName;
 use libsql_sys::rusqlite::OpenFlags;
-use libsql_wal::name::NamespaceName;
 use libsql_wal::registry::WalRegistry;
 use libsql_wal::wal::LibsqlWalManager;
 use tempfile::tempdir;

--- a/libsql-wal/tests/oracle.rs
+++ b/libsql-wal/tests/oracle.rs
@@ -9,10 +9,10 @@ use std::path::Path;
 use std::sync::Arc;
 
 use libsql_sys::ffi::{sqlite3_finalize, sqlite3_prepare, Sqlite3DbHeader};
+use libsql_sys::name::NamespaceName;
 use libsql_sys::rusqlite::OpenFlags;
 use libsql_sys::wal::{Sqlite3WalManager, Wal};
 use libsql_sys::Connection;
-use libsql_wal::name::NamespaceName;
 use libsql_wal::registry::WalRegistry;
 use libsql_wal::wal::LibsqlWalManager;
 use once_cell::sync::Lazy;


### PR DESCRIPTION
Storage server requires namespace UUID to operate. In the `WALManager` we do not have access to the namespace, so this patch extracts the namespace from the `db_path`

The large diff is due to I moved `NamespaceName` from `libsql-wal` to `libsql-sys` so that `libsql-storage` also can use it. Or else I could copy the resolver method https://github.com/tursodatabase/libsql/blob/7ebe45b52/libsql-server/src/lib.rs#L672-L684 inside `libsql-storage` and use that.

