### PR TITLE
Add a link to my (experimental) D driver based on the C driver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The comprehensive description can be found [here](libsql-sqlite3/doc/libsql_exte
 
 ### Community Drivers
 * [PHP](https://github.com/tursodatabase/turso-client-php)
+* [D](https://github.com/pdenapo/libsql-d) (experimental, based on the C driver)
 
 ## Getting Started
 


### PR DESCRIPTION
I have created a D driver for libsql (It uses the C driver but replacing the C header for a D version). 

A nice feature is that some tests are included using the Silly test runner for D.