### PR TITLE
fix current segment replicator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,6 +2036,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3596,6 +3606,7 @@ dependencies = [
  "crc32fast",
  "criterion",
  "crossbeam",
+ "crossbeam-skiplist",
  "fst",
  "hashbrown 0.14.5",
  "hex",

--- a/libsql-wal/Cargo.toml
+++ b/libsql-wal/Cargo.toml
@@ -13,6 +13,7 @@ bytes = "1.6.0"
 chrono = "0.4.38"
 crc32fast = "1.4.2"
 crossbeam = "0.8.4"
+crossbeam-skiplist = "0.1.3"
 fst = "0.4.7"
 hashbrown = "0.14.3"
 libsql-sys = { path = "../libsql-sys", features = ["rusqlite"] }

--- a/libsql-wal/src/replication/injector.rs
+++ b/libsql-wal/src/replication/injector.rs
@@ -159,11 +159,8 @@ mod test {
             .execute("insert into test values (123)", ())
             .unwrap();
 
-        // FIXME(adhoc): stream is returning one frame too many, fix this asap.
-        for _ in 0..2 {
-            let frame = stream.next().await.unwrap().unwrap();
-            injector.insert_frame(Box::new(frame)).await.unwrap();
-        }
+        let frame = stream.next().await.unwrap().unwrap();
+        injector.insert_frame(Box::new(frame)).await.unwrap();
 
         replica_conn
             .query_row("select count(*) from test", (), |r| {

--- a/libsql-wal/src/replication/replicator.rs
+++ b/libsql-wal/src/replication/replicator.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use tokio::sync::watch;
@@ -41,50 +40,20 @@ impl<IO: Io> Replicator<IO> {
                 // in the current segment, frames are ordered by frame no, so we can start reading from
                 // the end until we hit the current frame_no
                 if self.next_frame_no >= current_start {
-                    let stream = current.rev_frame_stream();
-                    let mut size_after = 0;
+                    let stream = current.frame_stream_from(self.next_frame_no);
                     let mut new_current_frame_no = 0;
                     tokio::pin!(stream);
-                    let mut seen = HashSet::new();
                     loop {
                         match stream.try_next().await? {
-                            Some(mut frame) => {
-                                if size_after == 0 {
-                                    assert_ne!(
-                                        frame.header().size_after(),
-                                        0,
-                                        "first frame should be a commit frame"
-                                    );
-                                    size_after = frame.header().size_after();
-                                    new_current_frame_no = frame.header().frame_no();
-                                }
-
-                                let page_no = frame.header().page_no();
-                                if seen.contains(&page_no) {
-                                    continue;
-                                }
-
-                                seen.insert(page_no);
-
-                                // patch the size after so that the last frame in the batch is the
-                                // commit frame
-                                let new_size_after = if frame.header().frame_no() <= self.next_frame_no {
-                                    size_after
-                                } else {
-                                    0
-                                };
-                                frame.header_mut().set_size_after(new_size_after);
-
+                            Some(frame) => {
+                                new_current_frame_no = new_current_frame_no.max(frame.header().frame_no());
                                 yield frame;
-
-                                if new_size_after != 0 {
-                                    self.next_frame_no = new_current_frame_no + 1;
-                                    break
-                                }
                             }
                             None => break
                         }
                     }
+
+                    self.next_frame_no = new_current_frame_no + 1;
                 } else {
                     todo!("handle frame not in current log");
                 }
@@ -98,8 +67,10 @@ mod test {
     use std::path::Path;
     use std::time::Duration;
 
+    use insta::assert_debug_snapshot;
     use libsql_sys::rusqlite::OpenFlags;
     use tempfile::tempdir;
+    use tokio_stream::StreamExt;
 
     use crate::name::NamespaceName;
     use crate::registry::WalRegistry;
@@ -138,12 +109,10 @@ mod test {
         conn.execute("create table test (x)", ()).unwrap();
 
         let frame = stream.try_next().await.unwrap().unwrap();
-        assert_eq!(frame.header().frame_no(), 2);
-        assert_eq!(frame.header().size_after(), 0);
+        assert_debug_snapshot!(frame.header());
 
         let frame = stream.try_next().await.unwrap().unwrap();
-        assert_eq!(frame.header().frame_no(), 1);
-        assert_eq!(frame.header().size_after(), 2);
+        assert_debug_snapshot!(frame.header());
 
         // no more frames for now...
         assert!(
@@ -171,12 +140,10 @@ mod test {
         tokio::pin!(stream);
 
         let frame = stream.try_next().await.unwrap().unwrap();
-        assert_eq!(frame.header().frame_no(), 3);
-        assert_eq!(frame.header().size_after(), 0);
+        assert_debug_snapshot!(frame.header());
 
         let frame = stream.try_next().await.unwrap().unwrap();
-        assert_eq!(frame.header().frame_no(), 1);
-        assert_eq!(frame.header().size_after(), 2);
+        assert_debug_snapshot!(frame.header());
 
         // no more frames for now...
         assert!(

--- a/libsql-wal/src/replication/snapshots/libsql_wal__replication__replicator__test__stream_from_current_log-2.snap
+++ b/libsql-wal/src/replication/snapshots/libsql_wal__replication__replicator__test__stream_from_current_log-2.snap
@@ -1,0 +1,15 @@
+---
+source: libsql-wal/src/replication/replicator.rs
+expression: frame.header()
+---
+FrameHeader {
+    page_no: U32(
+        2,
+    ),
+    size_after: U32(
+        2,
+    ),
+    frame_no: U64(
+        2,
+    ),
+}

--- a/libsql-wal/src/replication/snapshots/libsql_wal__replication__replicator__test__stream_from_current_log-3.snap
+++ b/libsql-wal/src/replication/snapshots/libsql_wal__replication__replicator__test__stream_from_current_log-3.snap
@@ -1,0 +1,15 @@
+---
+source: libsql-wal/src/replication/replicator.rs
+expression: frame.header()
+---
+FrameHeader {
+    page_no: U32(
+        1,
+    ),
+    size_after: U32(
+        0,
+    ),
+    frame_no: U64(
+        1,
+    ),
+}

--- a/libsql-wal/src/replication/snapshots/libsql_wal__replication__replicator__test__stream_from_current_log-4.snap
+++ b/libsql-wal/src/replication/snapshots/libsql_wal__replication__replicator__test__stream_from_current_log-4.snap
@@ -1,0 +1,15 @@
+---
+source: libsql-wal/src/replication/replicator.rs
+expression: frame.header()
+---
+FrameHeader {
+    page_no: U32(
+        2,
+    ),
+    size_after: U32(
+        2,
+    ),
+    frame_no: U64(
+        3,
+    ),
+}

--- a/libsql-wal/src/replication/snapshots/libsql_wal__replication__replicator__test__stream_from_current_log.snap
+++ b/libsql-wal/src/replication/snapshots/libsql_wal__replication__replicator__test__stream_from_current_log.snap
@@ -1,0 +1,15 @@
+---
+source: libsql-wal/src/replication/replicator.rs
+expression: frame.header()
+---
+FrameHeader {
+    page_no: U32(
+        1,
+    ),
+    size_after: U32(
+        0,
+    ),
+    frame_no: U64(
+        1,
+    ),
+}


### PR DESCRIPTION
The previous implementation was reading 1 frame too many. The new implementation selects frames from the segment index to read the minimum amount of frames to bring the replica up to date.

The new segment index is probably too slow, I'll optimize the datastructure in a followup.
