### PR TITLE
implemented custom headers passing in auth layer

### DIFF
--- a/libsql-server/src/auth/constants.rs
+++ b/libsql-server/src/auth/constants.rs
@@ -1,2 +1,3 @@
+pub(crate) static AUTH_HEADER: &str = "authorization";
 pub(crate) static GRPC_AUTH_HEADER: &str = "x-authorization";
 pub(crate) static GRPC_PROXY_AUTH_HEADER: &str = "x-proxy-authorization";

--- a/libsql-server/src/auth/mod.rs
+++ b/libsql-server/src/auth/mod.rs
@@ -27,10 +27,7 @@ impl Auth {
         }
     }
 
-    pub fn authenticate(
-        &self,
-        context: Result<UserAuthContext, AuthError>,
-    ) -> Result<Authenticated, AuthError> {
+    pub fn authenticate(&self, context: UserAuthContext) -> Result<Authenticated, AuthError> {
         self.user_strategy.authenticate(context)
     }
 }

--- a/libsql-server/src/auth/user_auth_strategies/disabled.rs
+++ b/libsql-server/src/auth/user_auth_strategies/disabled.rs
@@ -4,10 +4,7 @@ use crate::auth::{AuthError, Authenticated};
 pub struct Disabled {}
 
 impl UserAuthStrategy for Disabled {
-    fn authenticate(
-        &self,
-        _context: Result<UserAuthContext, AuthError>,
-    ) -> Result<Authenticated, AuthError> {
+    fn authenticate(&self, _context: UserAuthContext) -> Result<Authenticated, AuthError> {
         tracing::trace!("executing disabled auth");
         Ok(Authenticated::FullAccess)
     }
@@ -26,7 +23,7 @@ mod tests {
     #[test]
     fn authenticates() {
         let strategy = Disabled::new();
-        let context = Ok(UserAuthContext::empty());
+        let context = UserAuthContext::empty();
 
         assert!(matches!(
             strategy.authenticate(context).unwrap(),

--- a/libsql-server/src/auth/user_auth_strategies/jwt.rs
+++ b/libsql-server/src/auth/user_auth_strategies/jwt.rs
@@ -1,7 +1,11 @@
 use chrono::{DateTime, Utc};
 
 use crate::{
-    auth::{authenticated::LegacyAuth, AuthError, Authenticated, Authorized, Permission},
+    auth::{
+        authenticated::LegacyAuth,
+        constants::{AUTH_HEADER, GRPC_AUTH_HEADER},
+        AuthError, Authenticated, Authorized, Permission,
+    },
     namespace::NamespaceName,
 };
 
@@ -12,27 +16,26 @@ pub struct Jwt {
 }
 
 impl UserAuthStrategy for Jwt {
-    fn authenticate(
-        &self,
-        context: Result<UserAuthContext, AuthError>,
-    ) -> Result<Authenticated, AuthError> {
+    fn authenticate(&self, ctx: UserAuthContext) -> Result<Authenticated, AuthError> {
         tracing::trace!("executing jwt auth");
+        let auth_str = ctx
+            .get_field(AUTH_HEADER)
+            .or_else(|| ctx.get_field(GRPC_AUTH_HEADER))
+            .ok_or_else(|| AuthError::AuthHeaderNotFound)?;
 
-        let ctx = context?;
-
-        let UserAuthContext {
-            scheme: Some(scheme),
-            token: Some(token),
-        } = ctx
-        else {
-            return Err(AuthError::HttpAuthHeaderInvalid);
-        };
+        let (scheme, token) = auth_str
+            .split_once(' ')
+            .ok_or(AuthError::AuthStringMalformed)?;
 
         if !scheme.eq_ignore_ascii_case("bearer") {
             return Err(AuthError::HttpAuthHeaderUnsupportedScheme);
         }
 
         validate_any_jwt(&self.keys, &token)
+    }
+
+    fn required_fields(&self) -> Vec<&'static str> {
+        vec![AUTH_HEADER, GRPC_AUTH_HEADER]
     }
 }
 
@@ -190,7 +193,7 @@ mod tests {
         };
         let token = encode(&token, &enc);
 
-        let context = Ok(UserAuthContext::bearer(token.as_str()));
+        let context = UserAuthContext::bearer(token.as_str());
 
         assert!(matches!(
             strategy(dec).authenticate(context).unwrap(),
@@ -212,7 +215,7 @@ mod tests {
         };
         let token = encode(&token, &enc);
 
-        let context = Ok(UserAuthContext::bearer(token.as_str()));
+        let context = UserAuthContext::bearer(token.as_str());
 
         let Authenticated::Legacy(a) = strategy(dec).authenticate(context).unwrap() else {
             panic!()
@@ -225,7 +228,7 @@ mod tests {
     #[test]
     fn errors_when_jwt_token_invalid() {
         let (_enc, dec) = generate_key_pair();
-        let context = Ok(UserAuthContext::bearer("abc"));
+        let context = UserAuthContext::bearer("abc");
 
         assert_eq!(
             strategy(dec).authenticate(context).unwrap_err(),
@@ -245,7 +248,7 @@ mod tests {
 
         let token = encode(&token, &enc);
 
-        let context = Ok(UserAuthContext::bearer(token.as_str()));
+        let context = UserAuthContext::bearer(token.as_str());
 
         assert_eq!(
             strategy(dec).authenticate(context).unwrap_err(),
@@ -267,7 +270,7 @@ mod tests {
 
         let token = encode(&token, &enc);
 
-        let context = Ok(UserAuthContext::bearer(token.as_str()));
+        let context = UserAuthContext::bearer(token.as_str());
 
         let Authenticated::Authorized(a) = strategy(dec).authenticate(context).unwrap() else {
             panic!()
@@ -304,7 +307,7 @@ mod tests {
         for enc in multi_enc.iter() {
             let token = encode(&token, &enc);
 
-            let context = Ok(UserAuthContext::bearer(token.as_str()));
+            let context = UserAuthContext::bearer(token.as_str());
 
             let Authenticated::Authorized(a) = strategy.authenticate(context).unwrap() else {
                 panic!()
@@ -331,7 +334,7 @@ mod tests {
         });
         let token = encode(&token, &enc);
 
-        let context = Ok(UserAuthContext::bearer(token.as_str()));
+        let context = UserAuthContext::bearer(token.as_str());
 
         assert_eq!(
             strategy_with_multiple(multi_dec)
@@ -352,7 +355,7 @@ mod tests {
         };
         let token = encode(&token, &multi_enc[0]);
 
-        let context = Ok(UserAuthContext::bearer(token.as_str()));
+        let context = UserAuthContext::bearer(token.as_str());
 
         assert_eq!(
             strategy_with_multiple(multi_dec)
@@ -373,7 +376,7 @@ mod tests {
         };
         let token = encode(&token, &multi_enc[2]);
 
-        let context = Ok(UserAuthContext::bearer(token.as_str()));
+        let context = UserAuthContext::bearer(token.as_str());
 
         assert_eq!(
             strategy_with_multiple(multi_dec)

--- a/libsql-server/src/http/user/mod.rs
+++ b/libsql-server/src/http/user/mod.rs
@@ -467,20 +467,36 @@ impl FromRequestParts<AppState> for Authenticated {
             .with(ns.clone(), |ns| ns.jwt_keys())
             .await??;
 
-        let context = parts
-            .headers
-            .get(hyper::header::AUTHORIZATION)
-            .ok_or(AuthError::AuthHeaderNotFound)
-            .and_then(|h| h.to_str().map_err(|_| AuthError::AuthHeaderNonAscii))
-            .and_then(|t| UserAuthContext::from_auth_str(t));
-
-        let authenticated = namespace_jwt_keys
+        let auth = namespace_jwt_keys
             .map(Jwt::new)
             .map(Auth::new)
-            .unwrap_or_else(|| state.user_auth_strategy.clone())
-            .authenticate(context)?;
-        Ok(authenticated)
+            .unwrap_or_else(|| state.user_auth_strategy.clone());
+
+        let context = build_context(&parts.headers, &auth.user_strategy.required_fields());
+
+        Ok(auth.authenticate(context)?)
     }
+}
+
+fn build_context(
+    headers: &hyper::HeaderMap<HeaderValue>,
+    required_fields: &Vec<&'static str>,
+) -> UserAuthContext {
+    let mut ctx = headers
+        .get(hyper::header::AUTHORIZATION)
+        .ok_or(AuthError::AuthHeaderNotFound)
+        .and_then(|h| h.to_str().map_err(|_| AuthError::AuthHeaderNonAscii))
+        .and_then(|t| UserAuthContext::from_auth_str(t))
+        .unwrap_or(UserAuthContext::empty());
+
+    for field in required_fields.iter() {
+        headers
+            .get(field.to_string())
+            .map(|h| h.to_str().ok())
+            .and_then(|t| t.map(|s| ctx.add_field(field, s.into())));
+    }
+
+    ctx
 }
 
 impl FromRef<AppState> for Auth {

--- a/libsql-server/src/rpc/proxy.rs
+++ b/libsql-server/src/rpc/proxy.rs
@@ -327,7 +327,11 @@ impl ProxyService {
         };
 
         let auth = if let Some(auth) = auth {
-            let context = parse_grpc_auth_header(req.metadata());
+            let context =
+                parse_grpc_auth_header(req.metadata(), &auth.user_strategy.required_fields())
+                    .map_err(|e| {
+                        tonic::Status::internal(format!("Error parsing auth header: {}", e))
+                    })?;
             auth.authenticate(context)?
         } else {
             Authenticated::from_proxy_grpc_request(req)?

--- a/libsql-server/src/rpc/replica_proxy.rs
+++ b/libsql-server/src/rpc/replica_proxy.rs
@@ -45,7 +45,7 @@ impl ReplicaProxyService {
 
         let namespace_jwt_keys = jwt_result.and_then(|s| s);
 
-        let auth_strategy = match namespace_jwt_keys {
+        let auth = match namespace_jwt_keys {
             Ok(Some(key)) => Ok(Auth::new(Jwt::new(key))),
             Ok(None) | Err(crate::error::Error::NamespaceDoesntExist(_)) => {
                 Ok(self.user_auth_strategy.clone())
@@ -56,10 +56,12 @@ impl ReplicaProxyService {
             ))),
         }?;
 
-        let auth_context = parse_grpc_auth_header(req.metadata());
-        auth_strategy
-            .authenticate(auth_context)?
-            .upgrade_grpc_request(req);
+        let auth_context =
+            parse_grpc_auth_header(req.metadata(), &auth.user_strategy.required_fields()).map_err(
+                |e| tonic::Status::internal(format!("Error parsing auth header: {}", e)),
+            )?;
+        auth.authenticate(auth_context)?.upgrade_grpc_request(req);
+
         return Ok(());
     }
 }

--- a/libsql-server/src/rpc/replication_log.rs
+++ b/libsql-server/src/rpc/replication_log.rs
@@ -94,8 +94,12 @@ impl ReplicationLogService {
         };
 
         if let Some(auth) = auth {
-            let user_credential = parse_grpc_auth_header(req.metadata());
-            auth.authenticate(user_credential)?;
+            let context =
+                parse_grpc_auth_header(req.metadata(), &auth.user_strategy.required_fields())
+                    .map_err(|e| {
+                        tonic::Status::internal(format!("Error parsing auth header: {}", e))
+                    })?;
+            auth.authenticate(context)?;
         }
 
         Ok(())


### PR DESCRIPTION
every auth strategy now advertises the headers it needs by implementing required_fields method
the higher layer is responsible for providing the fields in UserAuthContext
UserAuthContext is not passed in as a result type, it is always required
if the higher layer is not able to provide required_fields, it should assume the particular auth strategy will not work
if required fields are not provided, auth strategy should not attempt to fall back unless there is a clear algorithm to do so