### PR TITLE
provide one more required argument for SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION config command

### DIFF
--- a/libsql/src/local/connection.rs
+++ b/libsql/src/local/connection.rs
@@ -293,7 +293,9 @@ impl Connection {
     }
 
     pub fn enable_load_extension(&self, onoff: bool) -> Result<()> {
-        let err = unsafe { ffi::sqlite3_db_config(self.raw, ffi::SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION, onoff as i32) };
+        // SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION configration verb accepts 2 additional parameters: an on/off flag and a pointer to an c_int where new state of the parameter will be written (or NULL if reporting back the setting is not needed)
+        // See: https://sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfigenableloadextension
+        let err = unsafe { ffi::sqlite3_db_config(self.raw, ffi::SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION, onoff as i32, std::ptr::null::<c_int>()) };
         match err {
             ffi::SQLITE_OK => Ok(()),
             _ => Err(errors::Error::SqliteFailure(err, errors::error_from_code(err))),

--- a/libsql/tests/integration_tests.rs
+++ b/libsql/tests/integration_tests.rs
@@ -17,6 +17,14 @@ async fn setup() -> Connection {
 }
 
 #[tokio::test]
+async fn enable_disable_extension() {
+    let db = Database::open(":memory:").unwrap();
+    let conn = db.connect().unwrap();
+    conn.load_extension_enable().unwrap();
+    conn.load_extension_disable().unwrap();
+}
+
+#[tokio::test]
 async fn connection_drops_before_statements() {
     let db = Database::open(":memory:").unwrap();
     let conn = db.connect().unwrap();


### PR DESCRIPTION
## Context

`SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION` config verb require 2 additional arguments: `on/off` flag and pointer to the location where new state of the config will be written.

`libsql` misses last parameter which generally leads to UB and more specifically SEGFAULT under release builds (see https://github.com/tursodatabase/libsql/issues/1473)

This PR set second additional argument to null in order to comply with SQLite API specification.

See https://sqlite.org/c3ref/c_dbconfig_defensive.html#sqlitedbconfigenableloadextension for the config verb description

## Testing

- Add simple `enable_disable_extension` test which just trigger the method (better to load extension too - but it's a bit harder to setup)