### PR TITLE
wait for migration task to finish

### DIFF
--- a/libsql-server/src/database/schema.rs
+++ b/libsql-server/src/database/schema.rs
@@ -92,8 +92,7 @@ impl crate::connection::Connection for SchemaConnection {
 
             handle
                 .wait_for(|status| match status {
-                    MigrationJobStatus::DryRunSuccess
-                    | MigrationJobStatus::DryRunFailure
+                    MigrationJobStatus::DryRunFailure
                     | MigrationJobStatus::RunSuccess
                     | MigrationJobStatus::RunFailure => true,
                     _ => false,


### PR DESCRIPTION
In the previous iteration, we waited for the dry-run to succeed before returning the result of a schema migration. Instead, wait for the migration to complete before returning, as this is less confusing to users.
