### PR TITLE
use mimalloc for sqlite

### DIFF
--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -8,7 +8,6 @@ use bytesize::ByteSize;
 use clap::Parser;
 use hyper::client::HttpConnector;
 use libsql_server::auth::{parse_http_basic_auth_arg, parse_jwt_keys, user_auth_strategies, Auth};
-use mimalloc::MiMalloc;
 use tokio::sync::Notify;
 use tokio::time::Duration;
 use tracing_subscriber::prelude::*;
@@ -24,9 +23,6 @@ use libsql_server::version::Version;
 use libsql_server::CustomWAL;
 use libsql_server::Server;
 use libsql_sys::{Cipher, EncryptionConfig};
-
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
 
 /// SQL daemon
 #[derive(Debug, Parser)]


### PR DESCRIPTION
Sqlite and sqld use a different allocator, which can cause memory fragmentation. This PR provides a custom allocator for sqlite that uses rust's global allocator (mimalloc).
