### PR TITLE
fix bottomless bug when restoring from uncompressed snapshots

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -1405,7 +1405,7 @@ impl Replicator {
 
         for algo in algos_to_try {
             let main_db_path = match algo {
-                CompressionKind::None => format!("{}-{}/db.db", self.db_name, generation),
+                CompressionKind::None => format!("{}-{}/db.raw", self.db_name, generation),
                 CompressionKind::Gzip => format!("{}-{}/db.gz", self.db_name, generation),
                 CompressionKind::Zstd => format!("{}-{}/db.zstd", self.db_name, generation),
             };


### PR DESCRIPTION
Fix a bug in restoring from uncompressed snapshot where the file extension was hardcoded to `.db` when everywhere else, it was `.raw`. This caused the restore function to reccurse in the generation until it hit the first generation, effectively discarding everything.
