### PR TITLE
fix bottomless deadlock

### DIFF
--- a/libsql-server/src/database/mod.rs
+++ b/libsql-server/src/database/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::sync::Arc;
 
-use bottomless::SavepointTracker;
+use bottomless::replicator::Replicator;
 
 use crate::connection::{MakeConnection, RequestContext};
 use crate::replication::ReplicationLogger;
@@ -203,11 +203,11 @@ impl Database {
         }
     }
 
-    pub(crate) fn backup_savepoint(&self) -> Option<SavepointTracker> {
+    pub(crate) fn replicator(&self) -> Option<Arc<tokio::sync::Mutex<Option<Replicator>>>> {
         match self {
-            Database::Primary(db) => db.backup_savepoint(),
+            Database::Primary(db) => db.replicator(),
             Database::Replica(_) => None,
-            Database::Schema(db) => db.backup_savepoint(),
+            Database::Schema(db) => db.replicator(),
         }
     }
 }

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -493,7 +493,7 @@ where
         .await?;
 
         let meta_conn = metastore_conn_maker()?;
-        let scheduler = Scheduler::new(namespace_store.clone(), meta_conn)?;
+        let scheduler = Scheduler::new(namespace_store.clone(), meta_conn).await?;
 
         join_set.spawn(async move {
             scheduler.run(scheduler_receiver).await;

--- a/libsql-server/src/namespace/replication_wal.rs
+++ b/libsql-server/src/namespace/replication_wal.rs
@@ -16,6 +16,6 @@ pub fn make_replication_wal_wrapper(
     logger: Arc<ReplicationLogger>,
 ) -> ReplicationWalWrapper {
     ReplicationLoggerWalWrapper::new(logger).then(
-        bottomless.map(|b| BottomlessWalWrapper::new(Arc::new(std::sync::Mutex::new(Some(b))))),
+        bottomless.map(|b| BottomlessWalWrapper::new(Arc::new(tokio::sync::Mutex::new(Some(b))))),
     )
 }


### PR DESCRIPTION
When locking the replicator in the wal, bottomless assumed that it could hold on the lock across await points because the lock was uncontended. This assumption was not true, so when another thread tried to acquire the lock from a runtime thread, there was a slim chance that the reactor was on that thread, and the runtime would get blocked. the checkpointing thread could not make any progress because the runtime was blocked, and the runtime thread could not acquire the lock, because the checkpointing thread could not make progress. IOW, a deadlock.

This PR replaces the replicator lock from a std for an async lock. This is, of course, a poor man's fix, but it's not worth making any better with bottomless2 being cooked.

/!\: with an async replicator lock, be careful to always call sqlite in a `spawn_blocking` content, or sqld will panic.
