### PR TITLE
flag sqlite mimalloc allocator

### DIFF
--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -391,7 +391,9 @@ where
         static INIT: std::sync::Once = std::sync::Once::new();
         let mut join_set = JoinSet::new();
 
-        setup_sqlite_alloc();
+        if std::env::var("LIBSQL_SQLITE_MIMALLOC").is_ok() {
+            setup_sqlite_alloc();
+        }
 
         INIT.call_once(|| {
             if let Ok(size) = std::env::var("LIBSQL_EXPERIMENTAL_PAGER") {

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -748,6 +748,11 @@ fn setup_sqlite_alloc() {
         let size_total = size as usize + size_of::<usize>();
         let layout = Layout::from_size_align(size_total, align_of::<usize>()).unwrap();
         let ptr = GLOBAL.alloc(layout);
+
+        if ptr.is_null() {
+            return std::ptr::null_mut();
+        }
+
         *(ptr as *mut usize) = size as usize;
         ptr.offset(size_of::<usize>() as _) as *mut _
     }
@@ -768,6 +773,11 @@ fn setup_sqlite_alloc() {
             layout,
             new_size as usize + size_of::<usize>(),
         );
+
+        if ptr.is_null() {
+            return std::ptr::null_mut();
+        }
+
         *(new_ptr as *mut usize) = new_size as usize;
         new_ptr.offset(size_of::<usize>() as _) as *mut _
     }


### PR DESCRIPTION
since fragmentation is not the cause of the leak, put the sqlite mimalloc allocator behind a flag for now
