### PR TITLE
Move in-memory cache to disk

### DIFF
--- a/libsql-storage/src/lib.rs
+++ b/libsql-storage/src/lib.rs
@@ -1,14 +1,17 @@
-use std::collections::BTreeMap;
+mod local_cache;
+
 use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+use crate::local_cache::LocalCache;
+use crate::rpc::Frame;
 use libsql_sys::ffi::{SQLITE_ABORT, SQLITE_BUSY};
 use libsql_sys::name::{NamespaceName, NamespaceResolver};
 use libsql_sys::rusqlite;
 use libsql_sys::wal::{Result, Vfs, Wal, WalManager};
 use rpc::storage_client::StorageClient;
-use sieve_cache::SieveCache;
 use tonic::transport::Channel;
 use tracing::{error, trace};
 
@@ -74,13 +77,24 @@ impl WalManager for DurableWalManager {
     ) -> Result<Self::Wal> {
         let db_path = OsStr::from_bytes(&db_path.to_bytes());
         let namespace = self.resolver.resolve(db_path.as_ref());
+        let cache_path = {
+            let parent_dir = Path::new(db_path).parent().unwrap_or(Path::new("."));
+            &parent_dir.join(format!("{}_local_cache.db", namespace))
+        };
+        let local_cache = LocalCache::new(cache_path).unwrap();
+
         // TODO:
         // the namespace can be `default` and multiple databases belonging to different
         // groups might use same `default` as namespace. Either force only UUIDs to be supported
         // as namespaces for durable-wal or use a different specifier like (<libsql_id>, <ns>)
         trace!("DurableWalManager::open() ns = {}", namespace);
         let rt = tokio::runtime::Handle::current();
-        let resp = DurableWal::new(namespace, self.config.clone(), self.lock_manager.clone());
+        let resp = DurableWal::new(
+            namespace,
+            self.config.clone(),
+            self.lock_manager.clone(),
+            local_cache,
+        );
         let resp = tokio::task::block_in_place(|| rt.block_on(resp));
         Ok(resp)
     }
@@ -119,8 +133,7 @@ pub struct DurableWal {
     namespace: NamespaceName,
     conn_id: String,
     client: StorageClient<Channel>,
-    frames_cache: SieveCache<std::num::NonZeroU64, Vec<u8>>,
-    write_cache: BTreeMap<u32, rpc::Frame>,
+    local_cache: LocalCache,
     lock_manager: Arc<Mutex<LockManager>>,
 }
 
@@ -129,17 +142,16 @@ impl DurableWal {
         namespace: NamespaceName,
         config: DurableWalConfig,
         lock_manager: Arc<Mutex<LockManager>>,
+        local_cache: LocalCache,
     ) -> Self {
         let client = StorageClient::connect(config.storage_server_address)
             .await
             .unwrap();
-        let page_frames = SieveCache::new(1000).unwrap();
         Self {
             namespace,
             conn_id: uuid::Uuid::new_v4().to_string(),
             client,
-            frames_cache: page_frames,
-            write_cache: BTreeMap::new(),
+            local_cache,
             lock_manager,
         }
     }
@@ -225,12 +237,15 @@ impl Wal for DurableWal {
     fn read_frame(&mut self, page_no: std::num::NonZeroU32, buffer: &mut [u8]) -> Result<()> {
         trace!("DurableWal::read_frame()");
         let rt = tokio::runtime::Handle::current();
-        if let Some(frame) = self.write_cache.get(&(u32::from(page_no))) {
+        if let Ok(Some(frame)) = self
+            .local_cache
+            .get_page(self.conn_id.as_str(), u32::from(page_no))
+        {
             trace!(
                 "DurableWal::read_frame(page_no: {:?}) -- write cache hit",
                 page_no
             );
-            buffer.copy_from_slice(&frame.data);
+            buffer.copy_from_slice(&frame);
             return Ok(());
         }
         // TODO: this call is unnecessary since `read_frame` is always called after `find_frame`
@@ -239,7 +254,10 @@ impl Wal for DurableWal {
                 .unwrap()
                 .unwrap();
         // check if the frame exists in the local cache
-        if let Some(frame) = self.frames_cache.get(&frame_no) {
+        if let Ok(Some(frame)) = self
+            .local_cache
+            .get_frame(self.namespace.as_str(), frame_no.into())
+        {
             trace!(
                 "DurableWal::read_frame(page_no: {:?}) -- read cache hit",
                 page_no
@@ -256,8 +274,9 @@ impl Wal for DurableWal {
         let resp = tokio::task::block_in_place(|| rt.block_on(resp)).unwrap();
         let frame = resp.into_inner().frame.unwrap();
         buffer.copy_from_slice(&frame);
-        self.frames_cache
-            .insert(std::num::NonZeroU64::new(frame_no.get()).unwrap(), frame);
+        let _ = self
+            .local_cache
+            .insert_frame(self.namespace.as_str(), frame_no.into(), &frame);
         Ok(())
     }
 
@@ -325,18 +344,13 @@ impl Wal for DurableWal {
         let mut lock_manager = self.lock_manager.lock().unwrap();
         if !lock_manager.is_lock_owner(self.namespace.to_string(), self.conn_id.clone()) {
             error!("DurableWal::insert_frames() was called without acquiring lock!",);
-            self.write_cache.clear();
             return Err(rusqlite::ffi::Error::new(SQLITE_ABORT));
         };
         // add the updated frames from frame_headers to writeCache
         for (page_no, frame) in page_headers.iter() {
-            self.write_cache.insert(
-                page_no,
-                rpc::Frame {
-                    page_no: page_no,
-                    data: frame.to_vec(),
-                },
-            );
+            self.local_cache
+                .insert_page(self.conn_id.as_str(), page_no, frame.into())
+                .expect("failed to insert in local cache");
             // todo: update size after
         }
 
@@ -346,12 +360,22 @@ impl Wal for DurableWal {
             return Ok(0);
         }
 
+        let frames: Vec<Frame> = self
+            .local_cache
+            .get_all_pages(self.conn_id.as_str())
+            .unwrap()
+            .into_iter()
+            .map(|(page_no, frame)| Frame {
+                page_no,
+                data: frame.into(),
+            })
+            .collect();
+
         let req = rpc::InsertFramesRequest {
             namespace: self.namespace.to_string(),
-            frames: self.write_cache.values().cloned().collect(),
+            frames,
             max_frame_no: 0,
         };
-        self.write_cache.clear();
         let mut binding = self.client.clone();
         trace!("sending DurableWal::insert_frames() {:?}", req.frames.len());
         let resp = binding.insert_frames(req);

--- a/libsql-storage/src/lib.rs
+++ b/libsql-storage/src/lib.rs
@@ -254,10 +254,7 @@ impl Wal for DurableWal {
                 .unwrap()
                 .unwrap();
         // check if the frame exists in the local cache
-        if let Ok(Some(frame)) = self
-            .local_cache
-            .get_frame(self.namespace.as_str(), frame_no.into())
-        {
+        if let Ok(Some(frame)) = self.local_cache.get_frame(frame_no.into()) {
             trace!(
                 "DurableWal::read_frame(page_no: {:?}) -- read cache hit",
                 page_no
@@ -274,9 +271,7 @@ impl Wal for DurableWal {
         let resp = tokio::task::block_in_place(|| rt.block_on(resp)).unwrap();
         let frame = resp.into_inner().frame.unwrap();
         buffer.copy_from_slice(&frame);
-        let _ = self
-            .local_cache
-            .insert_frame(self.namespace.as_str(), frame_no.into(), &frame);
+        let _ = self.local_cache.insert_frame(frame_no.into(), &frame);
         Ok(())
     }
 

--- a/libsql-storage/src/local_cache.rs
+++ b/libsql-storage/src/local_cache.rs
@@ -1,0 +1,105 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use libsql_sys::rusqlite::{params, Connection, Error, Result};
+
+pub struct LocalCache {
+    conn: Connection,
+    path: Arc<Path>,
+}
+
+impl LocalCache {
+    pub fn new(db_path: &Path) -> Result<Self> {
+        let conn = Connection::open(db_path)?;
+        let path: Arc<Path> = Arc::from(PathBuf::from(db_path));
+        let local_cache = LocalCache { conn, path };
+        local_cache.create_table()?;
+        Ok(local_cache)
+    }
+
+    fn create_table(&self) -> Result<()> {
+        self.conn.pragma_update(None, "journal_mode", &"WAL")?;
+        self.conn.pragma_update(None, "synchronous", &"NORMAL")?;
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS frames (
+                namespace TEXT NOT NULL,
+                frame_no INTEGER NOT NULL,
+                data BLOB NOT NULL,
+                PRIMARY KEY (namespace, frame_no)
+            )",
+            [],
+        )?;
+
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS transactions (
+                txn_id TEXT PRIMARY KEY NOT NULL,
+                page_no INTEGER NOT NULL,
+                data BLOB NOT NULL
+            )",
+            [],
+        )?;
+        Ok(())
+    }
+
+    pub fn insert_frame(&self, namespace: &str, frame_no: u64, frame_data: &[u8]) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO frames (namespace, frame_no, data) VALUES (?1, ?2, ?3)",
+            params![namespace, frame_no, frame_data],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_frame(&self, namespace: &str, frame_no: u64) -> Result<Option<Vec<u8>>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT data FROM frames WHERE namespace = ?1 AND frame_no = ?2")?;
+        match stmt.query_row(params![namespace, frame_no], |row| row.get(0)) {
+            Ok(frame_data) => Ok(Some(frame_data)),
+            Err(Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn insert_page(&self, txn_id: &str, page_no: u32, frame_data: &[u8]) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO transactions (txn_id, page_no, data) VALUES (?1, ?2, ?3)",
+            params![txn_id, page_no, frame_data],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_page(&self, txn_id: &str, page_no: u32) -> Result<Option<Vec<u8>>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT data FROM transactions WHERE txn_id = ?1 AND page_no = ?2")?;
+        match stmt.query_row(params![txn_id, page_no], |row| row.get(0)) {
+            Ok(frame_data) => Ok(Some(frame_data)),
+            Err(Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn get_all_pages(&self, txn_id: &str) -> Result<Vec<(u32, Vec<u8>)>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT page_no, data FROM transactions WHERE txn_id = ?1")?;
+        let pages: Result<Vec<(u32, Vec<u8>)>> = stmt
+            .query_map(params![txn_id], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect();
+        self.conn.execute(
+            "DELETE FROM transactions WHERE txn_id = ?1",
+            params![txn_id],
+        )?;
+        pages
+    }
+}
+
+impl Clone for LocalCache {
+    fn clone(&self) -> Self {
+        let conn = Connection::open(&*self.path).expect("failed to open database");
+        LocalCache {
+            conn,
+            path: Arc::clone(&self.path),
+        }
+    }
+}


### PR DESCRIPTION
Previously, `libsql-storage` stored all the data in-memory. It kept a in-memory frame cache and also cached all the transient transaction writes in-memory. This patch changes it to store the data on local disk. This data is transient in nature, disk loss should not cause any issues.