### PR TITLE
add in-process heap profiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,16 +1139,16 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line 0.22.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.35.0",
+ "object 0.36.0",
  "rustc-demangle",
 ]
 
@@ -2414,6 +2414,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.4.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +2770,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,6 +2857,24 @@ checksum = "1f7685beb53fc20efc2605f32f5d51e9ba18b8ef237961d1760169d2290d3bee"
 dependencies = [
  "outref",
  "vsimd",
+]
+
+[[package]]
+name = "hipptrack"
+version = "0.1.0"
+source = "git+https://github.com/MarinPostma/hipptrack.git?tag=v0.1.0#2886a4483ad9f1b59d82485229090453669dd1ed"
+dependencies = [
+ "backtrace",
+ "crc",
+ "hashbrown 0.14.5",
+ "itertools 0.13.0",
+ "parking_lot",
+ "rand",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thread-id",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3228,6 +3267,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,7 +3482,7 @@ dependencies = [
  "doc-comment",
  "fallible-iterator 0.2.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.8.4",
  "lazy_static",
  "libsql-ffi",
  "regex",
@@ -3481,6 +3529,7 @@ dependencies = [
  "futures-core",
  "hashbrown 0.14.5",
  "hdrhistogram",
+ "hipptrack",
  "hmac",
  "http-body 0.4.6",
  "hyper",
@@ -3525,6 +3574,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha256",
+ "tar",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3692,6 +3742,16 @@ dependencies = [
  "tracing",
  "uuid",
  "zerocopy",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4111,9 +4171,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
  "memchr",
 ]
@@ -4198,7 +4258,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.1",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -4735,6 +4795,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
@@ -4905,6 +4974,20 @@ dependencies = [
  "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.5.0",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -5656,6 +5739,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tar"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5706,6 +5800,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "thread-id"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -6349,6 +6453,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
@@ -7242,6 +7352,17 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.4.14",
+ "rustix 0.38.34",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "hipptrack"
 version = "0.1.0"
-source = "git+https://github.com/MarinPostma/hipptrack.git?tag=v0.1.0#2886a4483ad9f1b59d82485229090453669dd1ed"
+source = "git+https://github.com/MarinPostma/hipptrack.git?tag=v0.1.1#5f24248d62539241cad9e59e88291d4da7fc017f"
 dependencies = [
  "backtrace",
  "crc",

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -89,7 +89,7 @@ hdrhistogram = "7.5.4"
 crossbeam = "0.8.4"
 async-recursion = "1"
 mimalloc = "0.1.42"
-hipptrack = { git = "https://github.com/MarinPostma/hipptrack.git", tag = "v0.1.0" }
+hipptrack = { git = "https://github.com/MarinPostma/hipptrack.git", tag = "v0.1.1" }
 tar = "0.4.41"
 
 [dev-dependencies]

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -89,6 +89,8 @@ hdrhistogram = "7.5.4"
 crossbeam = "0.8.4"
 async-recursion = "1"
 mimalloc = "0.1.42"
+hipptrack = { git = "https://github.com/MarinPostma/hipptrack.git", tag = "v0.1.0" }
+tar = "0.4.41"
 
 [dev-dependencies]
 arbitrary = { version = "1.3.0", features = ["derive_arbitrary"] }

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -150,6 +150,7 @@ where
         }))
         .route("/profile/heap/enable", post(enable_profile_heap))
         .route("/profile/heap/disable/:id", post(disable_profile_heap))
+        .route("/profile/heap/:id", delete(delete_profile_heap))
         .layer(
             tower_http::trace::TraceLayer::new_for_http()
                 .on_request(trace_request)
@@ -498,4 +499,10 @@ async fn disable_profile_heap(Path(profile): Path<String>) -> impl axum::respons
     let body = StreamBody::new(stream);
 
     body
+}
+
+async fn delete_profile_heap(Path(profile): Path<String>) -> crate::Result<()> {
+    let profile_dir = PathBuf::from("heap_profile").join(&profile);
+    tokio::fs::remove_dir_all(&profile_dir).await?;
+    Ok(())
 }

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -1,20 +1,23 @@
 use anyhow::Context as _;
+use axum::body::StreamBody;
 use axum::extract::{FromRef, Path, State};
 use axum::routing::delete;
 use axum::Json;
 use chrono::NaiveDateTime;
-use futures::TryStreamExt;
+use futures::{SinkExt, StreamExt, TryStreamExt};
 use hyper::{Body, Request};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::cell::OnceCell;
+use std::convert::Infallible;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
-use tokio_util::io::ReaderStream;
+use tokio_util::io::{CopyToBytes, ReaderStream, SinkWriter};
+use tokio_util::sync::PollSender;
 use tower_http::trace::DefaultOnResponse;
 use url::Url;
 
@@ -145,6 +148,8 @@ where
             user_http_server,
             metrics,
         }))
+        .route("/profile/heap/enable", post(enable_profile_heap))
+        .route("/profile/heap/disable/:id", post(disable_profile_heap))
         .layer(
             tower_http::trace::TraceLayer::new_for_http()
                 .on_request(trace_request)
@@ -192,7 +197,6 @@ async fn handle_get_config<C: Connector>(
         allow_attach: config.allow_attach,
         txn_timeout_s: config.txn_timeout.map(|d| d.as_secs() as u64),
     };
-
     Ok(Json(resp))
 }
 
@@ -440,4 +444,58 @@ async fn handle_checkpoint<C>(
 ) -> crate::Result<()> {
     app_state.namespaces.checkpoint(namespace).await?;
     Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct EnableHeapProfileRequest {
+    #[serde(default)]
+    max_stack_depth: Option<usize>,
+    #[serde(default)]
+    max_trackers: Option<usize>,
+    #[serde(default)]
+    tracker_event_buffer_size: Option<usize>,
+    #[serde(default)]
+    sample_rate: Option<f64>,
+}
+
+async fn enable_profile_heap(Json(req): Json<EnableHeapProfileRequest>) -> crate::Result<String> {
+    let path = tokio::task::spawn_blocking(move || {
+        hipptrack::enable_tracking(hipptrack::TrackerConfig {
+            max_stack_depth: req.max_stack_depth.unwrap_or(30),
+            max_trackers: req.max_trackers.unwrap_or(200),
+            tracker_event_buffer_size: req.tracker_event_buffer_size.unwrap_or(5_000),
+            sample_rate: req.sample_rate.unwrap_or(1.0),
+            profile_dir: PathBuf::from("heap_profile"),
+        })
+        .map_err(|e| crate::Error::Anyhow(anyhow::anyhow!("{e}")))
+    })
+    .await??;
+
+    Ok(path.file_name().unwrap().to_str().unwrap().to_string())
+}
+
+async fn disable_profile_heap(Path(profile): Path<String>) -> impl axum::response::IntoResponse {
+    let (tx, rx) = tokio::sync::mpsc::channel::<bytes::Bytes>(1);
+    tokio::task::spawn_blocking(move || {
+        hipptrack::disable_tracking();
+        let profile_dir = PathBuf::from("heap_profile").join(&profile);
+        let sink =
+            PollSender::new(tx).sink_map_err(|_| std::io::Error::from(ErrorKind::BrokenPipe));
+        let writer = tokio_util::io::SyncIoBridge::new(SinkWriter::new(CopyToBytes::new(sink)));
+        let mut builder = tar::Builder::new(writer);
+        if let Err(e) = builder.append_dir_all(&profile, &profile_dir) {
+            tracing::error!("io error sending trace: {e}");
+            return;
+        }
+        if let Err(e) = builder.finish() {
+            tracing::error!("io error sending trace: {e}");
+            return;
+        }
+    });
+
+    let stream =
+        tokio_stream::wrappers::ReceiverStream::new(rx).map(|b| Result::<_, Infallible>::Ok(b));
+    let body = StreamBody::new(stream);
+
+    body
 }

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -107,8 +107,11 @@ pub(crate) static BLOCKING_RT: Lazy<Runtime> = Lazy::new(|| {
 type Result<T, E = Error> = std::result::Result<T, E>;
 type StatsSender = mpsc::Sender<(NamespaceName, MetaStoreHandle, Weak<Stats>)>;
 
+// #[global_allocator]
+// static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: hipptrack::Allocator<mimalloc::MiMalloc> = hipptrack::Allocator::from_allocator(mimalloc::MiMalloc);
 
 #[derive(clap::ValueEnum, PartialEq, Clone, Copy, Debug)]
 pub enum CustomWAL {

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -111,7 +111,8 @@ type StatsSender = mpsc::Sender<(NamespaceName, MetaStoreHandle, Weak<Stats>)>;
 // static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[global_allocator]
-static GLOBAL: hipptrack::Allocator<mimalloc::MiMalloc> = hipptrack::Allocator::from_allocator(mimalloc::MiMalloc);
+static GLOBAL: hipptrack::Allocator<mimalloc::MiMalloc> =
+    hipptrack::Allocator::from_allocator(mimalloc::MiMalloc);
 
 #[derive(clap::ValueEnum, PartialEq, Clone, Copy, Debug)]
 pub enum CustomWAL {


### PR DESCRIPTION
This PR introduces a in-process heap profiler, using [hipptrack](https://github.com/MarinPostma/hipptrack).

The profiler is enabled by sending a request to the admin api:
```
echo '{}' | POST /profile/heap/enable
```

when enabled, hipptrack will start recording all allocation. The name of the profile is returned by the call to the endpoint.

to stop recording and download the profile:

```
POST /profile/heap/disable/:profile-id
```

this will download a tarball of the profile. The profile can then be analyzed using hipptrack:

```
POST /profile/heap/disable/hip-84397533 > profile.tar
tar xvf profile.tar
hipptrack hip-84397533 profile.db

sqlite3 profile.db
```

to remove the profile file from the server:

```
DELETE /profile/heap/:profile-id
```
