### PR TITLE
Use `max_frame_no` for transaction reads and writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3615,6 +3615,7 @@ dependencies = [
  "libsql-storage",
  "redis",
  "serde",
+ "thiserror",
  "tokio",
  "tonic 0.10.2",
  "tracing",

--- a/libsql-storage-server/Cargo.toml
+++ b/libsql-storage-server/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 async-trait = "0.1.80"
 serde = "1.0.203"
+thiserror = "1.0.61"
 
 [features]
 foundation-db = ["foundationdb"]

--- a/libsql-storage-server/src/errors.rs
+++ b/libsql-storage-server/src/errors.rs
@@ -1,0 +1,18 @@
+use tonic::Status;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Write conflict")]
+    WriteConflict,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl From<Error> for Status {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::WriteConflict => Status::aborted("write conflict"),
+            Error::Other(err) => Status::internal(err.to_string()),
+        }
+    }
+}

--- a/libsql-storage-server/src/fdb_store.rs
+++ b/libsql-storage-server/src/fdb_store.rs
@@ -1,9 +1,11 @@
+use crate::errors::Error;
+use crate::errors::Error::WriteConflict;
 use crate::store::FrameStore;
 use async_trait::async_trait;
 use foundationdb::api::NetworkAutoStop;
 use foundationdb::tuple::pack;
 use foundationdb::tuple::unpack;
-use foundationdb::Transaction;
+use foundationdb::{KeySelector, Transaction};
 use libsql_storage::rpc::Frame;
 use tracing::error;
 

--- a/libsql-storage-server/src/main.rs
+++ b/libsql-storage-server/src/main.rs
@@ -1,3 +1,4 @@
+mod errors;
 #[cfg(feature = "foundation-db")]
 mod fdb_store;
 mod memory_store;

--- a/libsql-storage-server/src/memory_store.rs
+++ b/libsql-storage-server/src/memory_store.rs
@@ -53,7 +53,7 @@ impl FrameStore for InMemFrameStore {
             tracing::trace!("inserted for page {} frame {}", page_no, frame_no)
         }
         let count = inner.max_frame_no;
-        count
+        Ok(count)
     }
 
     async fn read_frame(&self, _namespace: &str, frame_no: u64) -> Option<bytes::Bytes> {
@@ -66,7 +66,7 @@ impl FrameStore for InMemFrameStore {
     }
 
     // given a page number, return the maximum frame for the page
-    async fn find_frame(&self, _namespace: &str, page_no: u32) -> Option<u64> {
+    async fn find_frame(&self, _namespace: &str, page_no: u32, _max_frame_no: u64) -> Option<u64> {
         self.inner
             .lock()
             .unwrap()

--- a/libsql-storage-server/src/redis_store.rs
+++ b/libsql-storage-server/src/redis_store.rs
@@ -75,7 +75,7 @@ impl FrameStore for RedisFrameStore {
         }
     }
 
-    async fn find_frame(&self, namespace: &str, page_no: u32) -> Option<u64> {
+    async fn find_frame(&self, namespace: &str, page_no: u32, _max_frame_no: u64) -> Option<u64> {
         let page_key = format!("p/{}/{}", namespace, page_no);
         let mut con = self.client.get_connection().unwrap();
         let frame_no = con.get::<String, u64>(page_key.clone());

--- a/libsql-storage-server/src/redis_store.rs
+++ b/libsql-storage-server/src/redis_store.rs
@@ -1,3 +1,4 @@
+use crate::errors::Error;
 use crate::store::FrameStore;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -18,7 +19,12 @@ impl RedisFrameStore {
 
 #[async_trait]
 impl FrameStore for RedisFrameStore {
-    async fn insert_frames(&self, namespace: &str, _max_frame_no: u64, frames: Vec<Frame>) -> u64 {
+    async fn insert_frames(
+        &self,
+        namespace: &str,
+        _max_frame_no: u64,
+        frames: Vec<Frame>,
+    ) -> Result<u64, Error> {
         let mut max_frame_no = 0;
         let max_frame_key = format!("{}/max_frame_no", namespace);
         let mut con = self.client.get_connection().unwrap();
@@ -48,7 +54,7 @@ impl FrameStore for RedisFrameStore {
                 pipe.get(max_frame_key.clone()).query(con)
             })
             .unwrap();
-        max_frame_no
+        Ok(max_frame_no)
     }
 
     async fn read_frame(&self, namespace: &str, frame_no: u64) -> Option<Bytes> {

--- a/libsql-storage-server/src/service.rs
+++ b/libsql-storage-server/src/service.rs
@@ -38,7 +38,7 @@ impl Storage for Service {
         let ns = request.namespace;
         let frames = request.frames;
         let max_frame_no = request.max_frame_no;
-        let num_frames = self.store.insert_frames(&ns, max_frame_no, frames).await as u32;
+        let num_frames = self.store.insert_frames(&ns, max_frame_no, frames).await? as u32;
         Ok(Response::new(rpc::InsertFramesResponse { num_frames }))
     }
 
@@ -50,7 +50,11 @@ impl Storage for Service {
         let page_no = request.page_no;
         let namespace = request.namespace;
         trace!("find_frame(page_no={})", page_no);
-        if let Some(frame_no) = self.store.find_frame(&namespace, page_no).await {
+        if let Some(frame_no) = self
+            .store
+            .find_frame(&namespace, page_no, request.max_frame_no)
+            .await
+        {
             Ok(Response::new(rpc::FindFrameResponse {
                 frame_no: Some(frame_no),
             }))

--- a/libsql-storage-server/src/store.rs
+++ b/libsql-storage-server/src/store.rs
@@ -1,11 +1,17 @@
+use crate::errors::Error;
 use async_trait::async_trait;
 use libsql_storage::rpc::Frame;
 
 #[async_trait]
 pub trait FrameStore: Send + Sync {
-    async fn insert_frames(&self, namespace: &str, max_frame_no: u64, frames: Vec<Frame>) -> u64;
+    async fn insert_frames(
+        &self,
+        namespace: &str,
+        max_frame_no: u64,
+        frames: Vec<Frame>,
+    ) -> Result<u64, Error>;
     async fn read_frame(&self, namespace: &str, frame_no: u64) -> Option<bytes::Bytes>;
-    async fn find_frame(&self, namespace: &str, page_no: u32) -> Option<u64>;
+    async fn find_frame(&self, namespace: &str, page_no: u32, max_frame_no: u64) -> Option<u64>;
     async fn frame_page_no(&self, namespace: &str, frame_no: u64) -> Option<u32>;
     async fn frames_in_wal(&self, namespace: &str) -> u64;
     async fn destroy(&self, namespace: &str);


### PR DESCRIPTION
- Storage server now uses `max_frame_no` from the txn to read frames
  It will make sure to not read any frames beyond the `max_frame_no`
  of the transaction. This fixes the bug in the isolation level.
- Storage server now checks `max_frame_no` before inserting. If it
  has changed meanwhile, then it rejects the insertion request.

This lets us have multiple (non concurrent) writers or even multiple
logical primary instances.

Minor changes:
-  Improved the way we handle keys in Foundation DB
- Added basic tonic error handling 