### PR TITLE
libsql: Add Statement::run() API

### DIFF
--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -189,6 +189,10 @@ impl crate::statement::Stmt for crate::hrana::Statement<HttpSender> {
         self.query(params).await
     }
 
+    async fn run(&mut self, params: &Params) -> crate::Result<()> {
+        self.run(params).await
+    }
+
     fn reset(&mut self) {}
 
     fn parameter_count(&self) -> usize {

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -158,6 +158,14 @@ where
         Ok(result.affected_row_count as usize)
     }
 
+    pub async fn run(&mut self, params: &Params) -> crate::Result<()> {
+        let mut stmt = self.inner.clone();
+        bind_params(params.clone(), &mut stmt);
+
+        let _ = self.stream.execute_inner(stmt, self.close_stream).await?;
+        Ok(())
+    }
+
     pub(crate) async fn query_raw(
         &mut self,
         params: &Params,

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -105,6 +105,13 @@ impl Stmt for LibsqlStmt {
             .map(|r| Rows { inner: Box::new(r) })
     }
 
+    async fn run(&mut self, params: &Params) -> Result<()> {
+        let params = params.clone();
+        let stmt = self.0.clone();
+
+        stmt.run(&params)
+    }
+
     fn reset(&mut self) {
         self.0.reset();
     }

--- a/libsql/src/local/statement.rs
+++ b/libsql/src/local/statement.rs
@@ -50,6 +50,19 @@ impl Statement {
         Ok(MappedRows::new(rows, f))
     }
 
+    pub fn run(&self, params: &Params) -> Result<()> {
+        self.bind(params);
+        let err = self.inner.step();
+        match err {
+            crate::ffi::SQLITE_DONE => Ok(()),
+            crate::ffi::SQLITE_ROW => Ok(()),
+            _ => Err(Error::SqliteFailure(
+                errors::extended_error_code(self.conn.raw),
+                errors::error_from_handle(self.conn.raw),
+            )),
+        }
+    }
+
     pub fn query(&self, params: &Params) -> Result<Rows> {
         self.bind(params);
         let err = self.inner.step();

--- a/libsql/src/statement.rs
+++ b/libsql/src/statement.rs
@@ -12,6 +12,8 @@ pub(crate) trait Stmt {
 
     async fn query(&mut self, params: &Params) -> Result<Rows>;
 
+    async fn run(&mut self, params: &Params) -> Result<()>;
+
     fn reset(&mut self);
 
     fn parameter_count(&self) -> usize;
@@ -42,6 +44,20 @@ impl Statement {
     pub async fn query(&mut self, params: impl IntoParams) -> Result<Rows> {
         tracing::trace!("query for prepared statement");
         self.inner.query(&params.into_params()?).await
+    }
+
+    /// Run a query on the statement.
+    ///
+    /// The `execute()` method returns an error if the query returns rows, which makes
+    /// it unsuitable for running any type of SQL queries. Similarly, the `query()` method
+    /// only works on SQL statements that return rows. Therefore, the `run()` method is
+    /// provided to execute any type of SQL statement.
+    ///
+    /// Note: This is an extension to the Rusqlite API.
+    pub async fn run(&mut self, params: impl IntoParams) -> Result<()> {
+        tracing::trace!("run for prepared statement");
+        self.inner.run(&params.into_params()?).await?;
+        Ok(())
     }
 
     /// Execute a query that returns the first [`Row`].


### PR DESCRIPTION
The `execute()` method returns an error if the query returns rows, which makes it unsuitable for running any type of SQL queries. Similarly, the `query()` method only works on SQL statements that return rows. Therefore, the `run()` method is provided to execute any type of SQL statement.

This is needed, for example, for the libSQL JavaScript library that needs to preserve `better-sqlite3` semantics.