### PR TITLE
libsql: Add Connection::total_changes() API

### DIFF
--- a/libsql/src/connection.rs
+++ b/libsql/src/connection.rs
@@ -23,6 +23,8 @@ pub(crate) trait Conn {
 
     fn changes(&self) -> u64;
 
+    fn total_changes(&self) -> u64;
+
     fn last_insert_rowid(&self) -> i64;
 
     async fn reset(&self);
@@ -124,6 +126,11 @@ impl Connection {
     /// Check the amount of changes the last query created.
     pub fn changes(&self) -> u64 {
         self.conn.changes()
+    }
+
+    /// Check the total amount of changes the connection has done.
+    pub fn total_changes(&self) -> u64 {
+        self.conn.total_changes()
     }
 
     /// Check the last inserted row id.

--- a/libsql/src/hrana/connection.rs
+++ b/libsql/src/hrana/connection.rs
@@ -54,6 +54,10 @@ where
         self.current_stream().affected_row_count()
     }
 
+    pub fn total_changes(&self) -> u64 {
+        self.current_stream().total_changes()
+    }
+
     pub fn last_insert_rowid(&self) -> i64 {
         self.current_stream().last_insert_rowid()
     }

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -168,6 +168,10 @@ impl Conn for HttpConnection<HttpSender> {
         self.affected_row_count()
     }
 
+    fn total_changes(&self) -> u64 {
+        self.total_changes()
+    }
+
     fn last_insert_rowid(&self) -> i64 {
         self.last_insert_rowid()
     }
@@ -314,6 +318,10 @@ impl Conn for HranaStream<HttpSender> {
 
     fn changes(&self) -> u64 {
         self.affected_row_count()
+    }
+
+    fn total_changes(&self) -> u64 {
+        self.total_changes()
     }
 
     fn last_insert_rowid(&self) -> i64 {

--- a/libsql/src/hrana/stream.rs
+++ b/libsql/src/hrana/stream.rs
@@ -58,6 +58,7 @@ where
         HranaStream {
             inner: Arc::new(Inner {
                 affected_row_count: AtomicU64::new(0),
+                total_changes: AtomicU64::new(0),
                 last_insert_rowid: AtomicI64::new(0),
                 is_autocommit: AtomicBool::new(true),
                 stream: Mutex::new(RawStream {
@@ -93,6 +94,7 @@ where
             (0, 0)
         };
 
+        self.inner.total_changes.fetch_add(affected_row_count, Ordering::SeqCst);
         self.inner
             .affected_row_count
             .store(affected_row_count, Ordering::SeqCst);
@@ -259,6 +261,10 @@ where
         self.inner.affected_row_count.load(Ordering::SeqCst)
     }
 
+    pub fn total_changes(&self) -> u64 {
+        self.inner.total_changes.load(Ordering::SeqCst)
+    }
+
     pub fn last_insert_rowid(&self) -> i64 {
         self.inner.last_insert_rowid.load(Ordering::SeqCst)
     }
@@ -278,6 +284,7 @@ where
     T: HttpSend,
 {
     affected_row_count: AtomicU64,
+    total_changes: AtomicU64,
     last_insert_rowid: AtomicI64,
     is_autocommit: AtomicBool,
     stream: Mutex<RawStream<T>>,

--- a/libsql/src/local/connection.rs
+++ b/libsql/src/local/connection.rs
@@ -275,6 +275,10 @@ impl Connection {
         unsafe { ffi::sqlite3_changes64(self.raw) as u64 }
     }
 
+    pub fn total_changes(&self) -> u64 {
+        unsafe { ffi::sqlite3_total_changes(self.raw) as u64 }
+    }
+
     pub fn last_insert_rowid(&self) -> i64 {
         unsafe { ffi::sqlite3_last_insert_rowid(self.raw) }
     }

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -60,6 +60,10 @@ impl Conn for LibsqlConnection {
         self.conn.changes()
     }
 
+    fn total_changes(&self) -> u64 {
+        self.conn.total_changes()
+    }
+
     fn last_insert_rowid(&self) -> i64 {
         self.conn.last_insert_rowid()
     }

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -31,6 +31,7 @@ pub struct RemoteConnection {
 struct Inner {
     state: State,
     changes: u64,
+    total_changes: u64,
     last_insert_rowid: i64,
 }
 
@@ -253,6 +254,7 @@ impl RemoteConnection {
             state.last_insert_rowid = *rowid;
         }
 
+        state.total_changes += row.affected_row_count;
         state.changes = row.affected_row_count;
     }
 
@@ -474,6 +476,10 @@ impl Conn for RemoteConnection {
 
     fn changes(&self) -> u64 {
         self.inner.lock().changes
+    }
+
+    fn total_changes(&self) -> u64 {
+        self.inner.lock().total_changes
     }
 
     fn last_insert_rowid(&self) -> i64 {


### PR DESCRIPTION
It's a rusqlite API that we're missing.