### PR TITLE
use dedicated destroy_wal_manager function to destroy wal as it can be static

### DIFF
--- a/libsql-sqlite3/src/main.c
+++ b/libsql-sqlite3/src/main.c
@@ -3356,8 +3356,8 @@ static int openDatabase(
   ){
     db->mutex = sqlite3MutexAlloc(SQLITE_MUTEX_RECURSIVE);
     if( db->mutex==0 ){
-      wal_manager->ref.xDestroy(wal_manager->ref.pData);
-      sqlite3_free(db->wal_manager);
+      db->wal_manager->ref.xDestroy(db->wal_manager->ref.pData);
+      destroy_wal_manager(db->wal_manager);
       sqlite3_free(db);
       db = 0;
       goto opendb_out;


### PR DESCRIPTION
## Context

TCL `recoverfault` tests are failing in master right now with the following error:
```
$> ./testfixture ext/recover/recoverfault.test
recoverfault-1.0... Ok
recoverfault-1-oom-persistent.1... Ok
recoverfault-1-oom-persistent.2... Ok
free(): invalid pointer
[1]    415207 IOT instruction (core dumped)  ./testfixture ext/recover/recoverfault.test
```

This is indeed happens due to the bug (rather minor - but still): if `sqlite3MutexAlloc` will fail during open call wal manager will be destroyed incorrectly with `sqlite3_free` function while it can be statically allocated.

## Changes

Use dedicated `destroy_wal_manager` function which takes into account lifetime of the wal manager

## Testing

Compiled `testfixture` and run it locally