### PR TITLE
add CI job to validate that bundle is up to date

### DIFF
--- a/.github/workflows/c-bindings.yml
+++ b/.github/workflows/c-bindings.yml
@@ -8,6 +8,31 @@ on:
     branches: [ "main" ]
 
 jobs:
+  c-bundle-validate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Set up cargo cache
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-
+
+    - name: Generate C bundle
+      run: cargo xtask build-bundled
+
+    - name: Check that C bundle is up to date
+      run: git diff --quiet || (echo "found uncommited changes in the bundle; please run 'cargo xtask build-bundled' and commit the result" && exit 1)
+
   c-bindings:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Context

Follow up for #1514. I forgot to generate bundled C code for rust bindings with fix in `openDatabase` function.

## Changes

- Run `cargo xtask build-bundled`
- Add `c-bundle-validate` which check that C code for FFI in repo is up to date with `libsql-sqlite3` sources. In case of mismatch job will fail with the following error:
```
$> Run git diff --quiet || (echo "found uncommited changes in the bundle; please run 'cargo xtask build-bundled' and commit the result" && exit 1)
found uncommited changes in the bundle; please run 'cargo xtask build-bundled' and commit the result
Error: Process completed with exit code 1.
```