### PR TITLE
adjust ALTER COLUMN parsing

### DIFF
--- a/libsql-sqlite3/src/alter.c
+++ b/libsql-sqlite3/src/alter.c
@@ -1770,9 +1770,11 @@ renameColumnFunc_done:
 */
 static void alterColumnFunc(
   sqlite3_context *context,
-  int NotUsed,
+  int argc,
   sqlite3_value **argv
 ){
+  UNUSED_PARAMETER(argc);
+
   sqlite3 *db = sqlite3_context_db_handle(context);
   RenameCtx sCtx;
   const char *zSql = (const char*)sqlite3_value_text(argv[0]);
@@ -1795,7 +1797,6 @@ static void alterColumnFunc(
   sqlite3_xauth xAuth = db->xAuth;
 #endif
 
-  UNUSED_PARAMETER(NotUsed);
   if( zSql==0 ) return;
   if( zTable==0 ) return;
   if( zNew==0 ) return;
@@ -1848,9 +1849,10 @@ static void alterColumnFunc(
       }
     } else {
       rc = SQLITE_ERROR;
-      sParse.zErrMsg = sqlite3MPrintf(sParse.db, "Only ordinary tables can be altered, not ", IsView(sParse.pNewTable) ? "views" : "virtual tables");
-      goto alterColumnFunc_done;    }
-  } else if (sParse.pNewIndex) {
+      sParse.zErrMsg = sqlite3MPrintf(sParse.db, "Only ordinary tables can be altered, not %s", IsView(sParse.pNewTable) ? "views" : "virtual tables");
+      goto alterColumnFunc_done;
+    }
+  } else if( sParse.pNewIndex ){
     rc = SQLITE_ERROR;
     sParse.zErrMsg = sqlite3MPrintf(sParse.db, "Only ordinary tables can be altered, not indexes");
     goto alterColumnFunc_done;

--- a/libsql-sqlite3/src/alter.c
+++ b/libsql-sqlite3/src/alter.c
@@ -690,7 +690,8 @@ void libsqlAlterAlterColumn(
   Parse *pParse,                  /* Parsing context */
   SrcList *pSrc,                  /* Table being altered.  pSrc->nSrc==1 */
   Token *pOld,                    /* Name of column being changed */
-  Token *pNew                     /* New column declaration */
+  Token *pNew,                    /* New column declaration */
+  int nNewSqlLength               /* New column declaration SQL string length (pNew.z is the start of the declaration) */
 ){
   sqlite3 *db = pParse->db;       /* Database connection */
   Table *pTab;                    /* Table being updated */
@@ -748,9 +749,7 @@ void libsqlAlterAlterColumn(
   }
   // NOTICE: this is the main difference in ALTER COLUMN compared to RENAME COLUMN,
   // we just take the whole new column declaration as it is.
-  // FIXME: the semicolon can also appear in the middle of the declaration when it's quoted,
-  // so we should check from the end.
-  pNew->n = sqlite3Strlen30(pNew->z);
+  pNew->n = nNewSqlLength;
   while (pNew->n > 0 && pNew->z[pNew->n - 1] == ';') pNew->n--;
   zNew = sqlite3DbStrNDup(db, pNew->z, pNew->n);
   if( !zNew ) goto exit_update_column;

--- a/libsql-sqlite3/src/parse.y
+++ b/libsql-sqlite3/src/parse.y
@@ -1740,7 +1740,8 @@ cmd ::= ALTER TABLE fullname(X) RENAME kwcolumn_opt nm(Y) TO nm(Z). {
 }
 
 cmd ::= ALTER TABLE fullname(X) ALTER COLUMNKW columnname(Y) TO columnname(Z) carglist. {
-  libsqlAlterAlterColumn(pParse, X, &Y, &Z);
+  int definitionLength = (int)(pParse->sLastToken.z-Z.z) + pParse->sLastToken.n;
+  libsqlAlterAlterColumn(pParse, X, &Y, &Z, definitionLength);
 }
 
 kwcolumn_opt ::= .

--- a/libsql-sqlite3/src/sqliteInt.h
+++ b/libsql-sqlite3/src/sqliteInt.h
@@ -5312,7 +5312,7 @@ void sqlite3Reindex(Parse*, Token*, Token*);
 void sqlite3AlterFunctions(void);
 void sqlite3AlterRenameTable(Parse*, SrcList*, Token*);
 void sqlite3AlterRenameColumn(Parse*, SrcList*, Token*, Token*);
-void libsqlAlterAlterColumn(Parse*, SrcList*, Token*, Token*);
+void libsqlAlterAlterColumn(Parse*, SrcList*, Token*, Token*, int);
 int sqlite3GetToken(const unsigned char *, int *);
 void sqlite3NestedParse(Parse*, const char*, ...);
 void sqlite3ExpirePreparedStatements(sqlite3*, int);

--- a/libsql-sqlite3/test/libsql_alter.test
+++ b/libsql-sqlite3/test/libsql_alter.test
@@ -1,0 +1,54 @@
+set testdir [file dirname $argv0]
+
+source $testdir/tester.tcl
+
+# Test Organisation:
+# ------------------
+#
+# libsql_alter-ok.*: Test that ALTER COLUMN correctly modifies the CREATE TABLE sql.
+# libsql_alter-err.*: Test error messages.
+#
+
+do_test libsql_alter-ok.1 {
+  execsql {CREATE TABLE t1(x);}
+  execsql {ALTER TABLE t1 ALTER COLUMN x TO x;}
+  execsql {SELECT sql FROM sqlite_master WHERE tbl_name = 't1';}
+} {{CREATE TABLE t1(x)}}
+
+do_test libsql_alter-ok.2 {
+  execsql {CREATE TABLE t2(x);}
+  execsql {ALTER TABLE t2 ALTER COLUMN x TO x INTEGER DEFAULT(-1);}
+  execsql {SELECT sql FROM sqlite_master WHERE tbl_name = 't2';}
+} {{CREATE TABLE t2(x INTEGER DEFAULT(-1))}}
+
+do_test libsql_alter-ok.3 {
+  execsql {CREATE TABLE t3(x);}
+  # NOTE: extra spaces in the end of ALTER COLUMN command
+  execsql { ALTER TABLE t3 ALTER COLUMN x TO x INTEGER DEFAULT(-1);   }
+  execsql {SELECT sql FROM sqlite_master WHERE tbl_name = 't3';}
+} {{CREATE TABLE t3(x INTEGER DEFAULT(-1))}}
+
+do_test libsql_alter-ok.4 {
+  execsql {CREATE TABLE t4(x);}
+  execsql { ALTER TABLE t4 ALTER COLUMN x TO x INTEGER DEFAULT(-1); -- explain alter command }
+  execsql {SELECT sql FROM sqlite_master WHERE tbl_name = 't4';}
+} {{CREATE TABLE t4(x INTEGER DEFAULT(-1))}}
+
+reset_db
+do_test libsql_alter-err.1 {
+  execsql { CREATE TABLE t1(x); }
+  catchsql { ALTER TABLE t1 ALTER COLUMN x TO x PRIMARY KEY; }
+} {1 {error in adding x PRIMARY KEY to t1: PRIMARY KEY constraint cannot be altered}}
+
+do_test libsql_alter-err.2 {
+  execsql { CREATE TABLE t2(x); }
+  catchsql { ALTER TABLE t2 ALTER COLUMN x TO x INTEGER UNIQUE; }
+} {1 {error in adding x INTEGER UNIQUE to t2: UNIQUE constraint cannot be altered}}
+
+do_test libsql_alter-err.3 {
+  execsql { CREATE TABLE t3(x, y); }
+  catchsql { ALTER TABLE t3 ALTER COLUMN y TO y GENERATED ALWAYS AS (2 * x) VIRTUAL; }
+} {1 {error in adding y GENERATED ALWAYS AS (2 * x) VIRTUAL to t3: GENERATED constraint cannot be altered}}
+
+finish_test
+

--- a/libsql-sqlite3/test/rust_suite/src/alter_column.rs
+++ b/libsql-sqlite3/test/rust_suite/src/alter_column.rs
@@ -191,7 +191,7 @@ fn test_comment_in_the_end() {
 
     conn.execute("CREATE TABLE t(id)", ()).unwrap();
     conn.execute(
-        "ALTER TABLE t ALTER COLUMN id TO id CHECK(id < 5) -- explanation for alter command ",
+        "ALTER TABLE t ALTER COLUMN id TO id CHECK(id < 5); -- explanation for alter command ",
         (),
     )
     .unwrap();

--- a/libsql-sqlite3/test/rust_suite/src/alter_column.rs
+++ b/libsql-sqlite3/test/rust_suite/src/alter_column.rs
@@ -184,3 +184,15 @@ fn test_update_view_forbidden() {
         .execute("ALTER TABLE v ALTER COLUMN id TO id", ())
         .is_err());
 }
+
+#[test]
+fn test_comment_in_the_end() {
+    let conn = Connection::open_in_memory().unwrap();
+
+    conn.execute("CREATE TABLE t(id)", ()).unwrap();
+    conn.execute(
+        "ALTER TABLE t ALTER COLUMN id TO id CHECK(id < 5) -- explanation for alter command ",
+        (),
+    )
+    .unwrap();
+}


### PR DESCRIPTION
## Context

Current `LibSQL` code for analyzing `ALTER TABLE t ALTER COLUMN x TO x ...` just takes raw string after second column name and use it as a column definition with only `;` (semicolon) stripped from the end.

This can lead to bad column definition as extra white spaces (like in https://github.com/tursodatabase/libsql/issues/1517) or comments can be prepended to the `ALTER TABLE` command (for example, `ALTER TABLE t4 ALTER COLUMN x TO x INTEGER DEFAULT(-1); -- some explanation` should be valid, but with current approach it will be translated to the incorrect SQL: `CREATE TABLE t ( x  INTEGER DEFAULT(-1); -- some explanation )`; note semicolon in the middle of `CREATE TABLE` expression)

This PR fixes new column sql definition by propagating parsed part of the expression directly from parser

## Changes
- Propagate length of the new column definition from the parser
- Add basic TCL tests for `ALTER COLUMN` feature in `libsql_alter.test`
- Slightly adjust C code formatting around code added by `libsql` for `ALTER COLUMN` feature