### PR TITLE
Update workflow to release a `latest` dev image

### DIFF
--- a/.github/workflows/storage-server-images.yml
+++ b/.github/workflows/storage-server-images.yml
@@ -51,7 +51,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}-${{ steps.get-short-sha.outputs.sha }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}-${{ steps.get-short-sha.outputs.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
forgot this in #1523 

this patch updates the workflow to generate the images with `latest` tag