### PR TITLE
cancel previous running actions if new commits are pushed

### DIFF
--- a/.github/workflows/c-bindings.yml
+++ b/.github/workflows/c-bindings.yml
@@ -7,6 +7,10 @@ on:
   merge_group:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   c-bundle-validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/extensions-test.yml
+++ b/.github/workflows/extensions-test.yml
@@ -11,6 +11,10 @@ env:
   CARGO_TERM_COLOR: always
   PROTOC_VERSION: 3.23.4
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   c-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/golang-bindings.yml
+++ b/.github/workflows/golang-bindings.yml
@@ -7,6 +7,10 @@ on:
   merge_group:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   golang-bindings:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,10 @@ env:
   # we need to fix before we can enable this.
   # RUSTFLAGS: "-D warnings"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/sqlite3.yml
+++ b/.github/workflows/sqlite3.yml
@@ -13,6 +13,10 @@ on:
     paths:
       - "libsql-sqlite3/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   make-sqlite3:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cancel previous run if new commits were pushed to the branch for several long actions which do some testing staff (just to be thoughtful users of GitHub Actions):
- c-bindings.yml
- extensions-test.yml
- golang-bindings.yml
- rust.yml
- sqlite3.yml

Example of how it looks in the UI:
![image](https://github.com/tursodatabase/libsql/assets/1395040/4dbb9840-8b72-4e6c-ab78-6518b8582d0a)
![image](https://github.com/tursodatabase/libsql/assets/1395040/07775421-c98f-41b9-abd9-062a25e53bec)

