### PR TITLE
Improve local cache and prefer local reads

### DIFF
--- a/libsql-storage/src/lib.rs
+++ b/libsql-storage/src/lib.rs
@@ -23,12 +23,7 @@ pub mod rpc {
 // What does (not) work:
 // - there are no read txn locks nor upgrades
 // - no lock stealing
-// - write set is kept in mem
-// - txns don't use max_frame_no yet
 // - no savepoints, yet
-// - no multi tenancy, uses `default` namespace
-// - txn can read new frames after it started (since there are no read locks)
-// - requires huge memory as it assumes all the txn data fits in the memory
 
 #[derive(Clone, Default)]
 pub struct DurableWalConfig {

--- a/libsql-storage/src/lib.rs
+++ b/libsql-storage/src/lib.rs
@@ -199,7 +199,10 @@ impl Wal for DurableWal {
         let remote_frame_no = tokio::task::block_in_place(|| rt.block_on(self.frames_count()));
         let local_frame_no = self.local_cache.get_max_frame_num().unwrap();
         if local_frame_no < remote_frame_no {
-            warn!("cache is lagging behind the remote!")
+            warn!(
+                "cache (max_frame_num = {:?}) is lagging behind the remote(max_frame_num = {:?})!",
+                local_frame_no, remote_frame_no
+            )
             // TODO: replicate data from source
         }
         self.max_frame_no = local_frame_no;

--- a/libsql-storage/src/lib.rs
+++ b/libsql-storage/src/lib.rs
@@ -235,14 +235,6 @@ impl Wal for DurableWal {
         if self.max_frame_no == 0 {
             return Ok(None);
         }
-        let rt = tokio::runtime::Handle::current();
-        // TODO: find_frame should account for `max_frame_no` of this txn
-        let frame_no =
-            tokio::task::block_in_place(|| rt.block_on(self.find_frame_by_page_no(page_no)))
-                .unwrap();
-        if frame_no.is_none() {
-            return Ok(None);
-        }
         return Ok(Some(page_no));
     }
 

--- a/libsql-storage/src/lib.rs
+++ b/libsql-storage/src/lib.rs
@@ -388,7 +388,7 @@ impl Wal for DurableWal {
 
         let req = rpc::InsertFramesRequest {
             namespace: self.namespace.to_string(),
-            frames,
+            frames: frames.clone(),
             max_frame_no: self.max_frame_no,
         };
         let mut binding = self.client.clone();
@@ -401,6 +401,10 @@ impl Wal for DurableWal {
             }
             return Err(rusqlite::ffi::Error::new(SQLITE_ABORT));
         }
+        // TODO: fix parity with storage server frame num with local cache
+        self.local_cache
+            .insert_frames(self.max_frame_no, frames)
+            .unwrap();
         Ok(resp.unwrap().into_inner().num_frames as usize)
     }
 

--- a/libsql-storage/src/local_cache.rs
+++ b/libsql-storage/src/local_cache.rs
@@ -87,17 +87,6 @@ impl LocalCache {
         Ok(())
     }
 
-    pub fn get_frame(&self, frame_no: u64) -> Result<Option<Vec<u8>>> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT data FROM frames WHERE frame_no = ?1")?;
-        match stmt.query_row(params![frame_no], |row| row.get(0)) {
-            Ok(frame_data) => Ok(Some(frame_data)),
-            Err(Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(e),
-        }
-    }
-
     pub fn get_frame_by_page(&self, page_no: u32, max_frame_no: u64) -> Result<Option<Vec<u8>>> {
         let mut stmt = self.conn.prepare(
             "SELECT data FROM frames WHERE page_no=?1 AND frame_no <= ?2

--- a/libsql-storage/src/local_cache.rs
+++ b/libsql-storage/src/local_cache.rs
@@ -77,6 +77,18 @@ impl LocalCache {
         }
     }
 
+    pub fn get_max_frame_num(&self) -> Result<u64> {
+        match self
+            .conn
+            .query_row("select MAX(frame_no) from frames", params![], |row| {
+                row.get(0)
+            }) {
+            Ok(frame_no) => Ok(frame_no),
+            Err(Error::QueryReturnedNoRows) => Ok(0),
+            Err(e) => Err(e),
+        }
+    }
+
     pub fn insert_page(&self, txn_id: &str, page_no: u32, frame_data: &[u8]) -> Result<()> {
         self.conn.execute(
             "INSERT INTO transactions (txn_id, page_no, data) VALUES (?1, ?2, ?3)

--- a/libsql-storage/src/local_cache.rs
+++ b/libsql-storage/src/local_cache.rs
@@ -42,7 +42,7 @@ impl LocalCache {
             [],
         )?;
         self.conn.execute(
-            "CREATE INDEX idx_page_no_frame_no ON frames (page_no, frame_no)",
+            "CREATE INDEX IF NOT EXISTS idx_page_no_frame_no ON frames (page_no, frame_no)",
             [],
         )?;
 
@@ -97,11 +97,11 @@ impl LocalCache {
     pub fn get_max_frame_num(&self) -> Result<u64> {
         match self
             .conn
-            .query_row("select MAX(frame_no) from frames", params![], |row| {
-                row.get(0)
+            .query_row("SELECT MAX(frame_no) from frames", (), |row| {
+                row.get::<_, Option<u64>>(0)
             }) {
-            Ok(frame_no) => Ok(frame_no),
-            Err(Error::QueryReturnedNoRows) => Ok(0),
+            Ok(Some(frame_no)) => Ok(frame_no),
+            Ok(None) | Err(Error::QueryReturnedNoRows) => Ok(0),
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
Till now, `DurableWAL` used Storage Server for finding page versions. If the local cache's `max_frame_no` is same as storage server's and if a txn's `max_frame_no` is less or same as cache's `max_frame_no`, then all reads and writes can proceed using local data itself. Do note that writes from a stale primary will be rejected anyways, since we handle conflicts at Storage Server.

Currently, there is no replication built and it assumes a single primary writer. So, after write, it updates the local cache. In the future PRs, I will add replication. 

What's changed: 
- Update the cache after writes
- Use local cache for most operations

What's next:
- A primary can lag anytime, so we need replication or way to quickly bring up the cache to speed
- If the primary is lagging, we switch to remote mode