### PR TITLE
fix .dump export command

### DIFF
--- a/libsql-server/src/connection/dump/exporter.rs
+++ b/libsql-server/src/connection/dump/exporter.rs
@@ -39,7 +39,7 @@ impl<W: Write> DumpState<W> {
             } else if table.starts_with(b"sqlite_stat") {
                 writeln!(self.writer, "ANALYZE sqlite_schema;")?;
             } else if table.starts_with(b"sqlite_") {
-                return Ok(());
+                continue;
             } else if sql.starts_with(b"CREATE VIRTUAL TABLE") {
                 if !self.writable_schema {
                     writeln!(self.writer, "PRAGMA writable_schema=ON;")?;
@@ -54,7 +54,7 @@ impl<W: Write> DumpState<W> {
                     table_str,
                     std::str::from_utf8(sql)?
                 )?;
-                return Ok(());
+                continue;
             } else {
                 if sql.starts_with(b"CREATE TABLE") {
                     self.writer.write_all(b"CREATE TABLE IF NOT EXISTS ")?;
@@ -106,12 +106,12 @@ impl<W: Write> DumpState<W> {
                         write_value_ref(&mut self.writer, row.get_ref(0)?)?;
                     }
 
-                    let start_index = row_id_col.is_some() as usize;
-                    for i in start_index..colss.len() {
+                    let offset = row_id_col.is_some() as usize;
+                    for i in 0..colss.len() {
                         if i != 0 || row_id_col.is_some() {
                             write!(self.writer, ",")?;
                         }
-                        write_value_ref(&mut self.writer, row.get_ref(i)?)?;
+                        write_value_ref(&mut self.writer, row.get_ref(i + offset)?)?;
                     }
                     writeln!(self.writer, ");")?;
                 }


### PR DESCRIPTION
## Context

There are few minor issues with current implementation of `.dump` command in the `sqld`:

1. It stop after first `VIRTUAL TABLE` or table with `sqlite_` prefix - which is a bug
```sql
$> CREATE VIRTUAL TABLE email USING fts5(sender, title, body);
$> CREATE TABLE t ( value );
$> INSERT INTO t VALUES (1), (2);
$> .dump
PRAGMA foreign_keys=OFF;
BEGIN TRANSACTION;
PRAGMA writable_schema=ON;
INSERT INTO sqlite_schema(type,name,tbl_name,rootpage,sql) VALUES('table','email','email',0,'CREATE VIRTUAL TABLE email USING fts5(sender, title, body)');
PRAGMA writable_schema=OFF;
COMMIT;
```
2. It emit incorrect dump if `sqld` decides to preserve `rowid`:
```sql
$> CREATE TABLE t ( x INTEGER PRIMARY KEY DESC );
$> INSERT INTO t VALUES (1), (2), (10);
$> .dump
PRAGMA foreign_keys=OFF;
BEGIN TRANSACTION;
CREATE TABLE IF NOT EXISTS t ( x INTEGER PRIMARY KEY DESC );
INSERT INTO t(rowid,x) VALUES(1);
INSERT INTO t(rowid,x) VALUES(2);
INSERT INTO t(rowid,x) VALUES(3);
COMMIT;
```