### PR TITLE
Remove Trailing Spaces from Docker Docs

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -3,7 +3,7 @@
 ## Launch a primary instance
 
 ```
-docker run --name some-sqld -p 8080:8080 -ti \ 
+docker run --name some-sqld -p 8080:8080 -ti \
     -e SQLD_NODE=primary \
     ghcr.io/tursodatabase/libsql-server:latest
 ```
@@ -11,7 +11,7 @@ docker run --name some-sqld -p 8080:8080 -ti \
 ## Launch a replica instance
 
 ```
-docker run --name some-sqld-replica -p 8081:8080 -ti 
+docker run --name some-sqld-replica -p 8081:8080 -ti
     -e SQLD_NODE=replica \
     -e SQLD_PRIMARY_URL=https://<host>:<port> \
     ghcr.io/tursodatabase/libsql-server:lastest
@@ -20,7 +20,7 @@ docker run --name some-sqld-replica -p 8081:8080 -ti
 ## Running on Apple Silicon
 
 ```
-docker run --name some-sqld  -p 8080:8080 -ti \ 
+docker run --name some-sqld  -p 8080:8080 -ti \
     -e SQLD_NODE=primary \
     --platform linux/amd64 \
     ghcr.io/tursodatabase/libsql-server:latest
@@ -45,7 +45,7 @@ mount on your local disk.
 ```
 docker run --name some-sqld -ti \
     -v ./.data/libsql \
-    -e SQLD_NODE=primary \ 
+    -e SQLD_NODE=primary \
     ghcr.io/tursodatabase/libsql-server:latest
 ```
 


### PR DESCRIPTION
Was trying to explore LibSQL and run some of the commands that were in the docs. Noticed some strange behavior and found some trailing spaces that were causing issues in my shell.

```sh
➜  ~ docker run --name some-sqld  -p 8080:8080 -ti \ 
    -e SQLD_NODE=primary \
    --platform linux/amd64 \
    ghcr.io/tursodatabase/libsql-server:latest

docker: invalid reference format.
See 'docker run --help'.
zsh: command not found: -e
```

By removing the trailing space, the command works properly