### PR TITLE
libsql: provide more return info for sync

### DIFF
--- a/libsql-server/tests/embedded_replica/mod.rs
+++ b/libsql-server/tests/embedded_replica/mod.rs
@@ -759,7 +759,7 @@ fn replicate_with_snapshots() {
         assert_eq!(stat, 427);
 
         let rep = db.sync().await.unwrap();
-        assert_eq!(rep.frames_synced(), 427);
+        assert_eq!(rep.frames_synced(), 0);
 
         let conn = db.connect().unwrap();
 
@@ -1336,7 +1336,7 @@ fn replicated_return() {
 
         let rep = db.sync().await.unwrap();
         assert_eq!(rep.frame_no(), Some(10));
-        assert_eq!(rep.frames_synced(), 11);
+        assert_eq!(rep.frames_synced(), 9);
 
         // Regenerate log
         notify.notify_waiters();
@@ -1346,7 +1346,7 @@ fn replicated_return() {
 
         let rep = db.sync().await.unwrap();
         assert_eq!(rep.frame_no(), Some(4));
-        assert_eq!(rep.frames_synced(), 16);
+        assert_eq!(rep.frames_synced(), 3);
 
         let mut row = conn.query("select count(*) from user", ()).await.unwrap();
         let count = row.next().await.unwrap().unwrap().get::<u64>(0).unwrap();

--- a/libsql-server/tests/embedded_replica/mod.rs
+++ b/libsql-server/tests/embedded_replica/mod.rs
@@ -1292,7 +1292,7 @@ fn replicated_return() {
 
             drop(fut);
 
-            tokio::fs::File::create(path.join(".sentinel"))
+            tokio::fs::File::create(path.join("dbs").join("default").join(".sentinel"))
                 .await
                 .unwrap();
 
@@ -1305,15 +1305,10 @@ fn replicated_return() {
     });
 
     sim.client("client", async move {
-        let client = Client::new();
-        client
-            .post("http://primary:9090/v1/namespaces/foo/create", json!({}))
-            .await?;
-
         let path = tmp_embedded_path.join("embedded");
         let db = Database::open_with_remote_sync_connector(
             path.to_str().unwrap(),
-            "http://foo.primary:8080",
+            "http://primary:8080",
             "",
             TurmoilConnector,
             false,
@@ -1350,7 +1345,7 @@ fn replicated_return() {
 
         let rep = db.sync().await.unwrap();
         assert_eq!(rep.frame_no(), Some(4));
-        assert_eq!(rep.start_frame_no(), Some(4));
+        assert_eq!(rep.start_frame_no(), Some(1));
 
         Ok(())
     });

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -323,7 +323,7 @@ cfg_replication! {
 
         /// Sync database from remote, and returns the committed frame_no after syncing, if
         /// applicable.
-        pub async fn sync(&self) -> Result<Option<FrameNo>> {
+        pub async fn sync(&self) -> Result<crate::replication::Replicated> {
             if let DbType::Sync { db, encryption_config: _ } = &self.db_type {
                 db.sync().await
             } else {

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -83,7 +83,7 @@ impl Database {
         encryption_config: Option<EncryptionConfig>,
         sync_interval: Option<std::time::Duration>,
         http_request_callback: Option<crate::util::HttpRequestCallback>,
-        namespace: Option<String>
+        namespace: Option<String>,
     ) -> Result<Database> {
         use std::path::PathBuf;
 
@@ -260,7 +260,7 @@ impl Database {
     #[cfg(feature = "replication")]
     /// Perform a sync step, returning the new replication index, or None, if the nothing was
     /// replicated yet
-    pub async fn sync_oneshot(&self) -> Result<Option<FrameNo>> {
+    pub async fn sync_oneshot(&self) -> Result<crate::replication::Replicated> {
         if let Some(ref ctx) = self.replication_ctx {
             ctx.replicator.sync_oneshot().await
         } else {
@@ -273,7 +273,7 @@ impl Database {
 
     #[cfg(feature = "replication")]
     /// Sync with primary
-    pub async fn sync(&self) -> Result<Option<FrameNo>> {
+    pub async fn sync(&self) -> Result<crate::replication::Replicated> {
         Ok(self.sync_oneshot().await?)
     }
 

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -261,7 +261,7 @@ impl Database {
     /// Perform a sync step, returning the new replication index, or None, if the nothing was
     /// replicated yet
     pub async fn sync_oneshot(&self) -> Result<crate::replication::Replicated> {
-        if let Some(ref ctx) = self.replication_ctx {
+        if let Some(ctx) = &self.replication_ctx {
             ctx.replicator.sync_oneshot().await
         } else {
             Err(crate::errors::Error::Misuse(

--- a/libsql/src/replication/mod.rs
+++ b/libsql/src/replication/mod.rs
@@ -255,13 +255,17 @@ impl EmbeddedReplicator {
             }
         }
 
-        let last_frames_synced = self
-            .last_frames_synced
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let last_frames_synced = self.last_frames_synced.fetch_add(
+            replicator.frames_synced(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+
+        let frames_synced =
+            ((replicator.frames_synced() as i64 - last_frames_synced as i64).abs()) as usize;
 
         let replicated = Replicated {
             frame_no: replicator.client_mut().committed_frame_no(),
-            frames_synced: replicator.frames_synced() - last_frames_synced,
+            frames_synced,
         };
 
         Ok(replicated)

--- a/libsql/src/replication/mod.rs
+++ b/libsql/src/replication/mod.rs
@@ -35,7 +35,7 @@ pub(crate) mod remote_client;
 #[derive(Debug)]
 pub struct Replicated {
     frame_no: Option<FrameNo>,
-    start_frame_no: Option<FrameNo>,
+    frames_synced: usize,
 }
 
 impl Replicated {
@@ -43,8 +43,8 @@ impl Replicated {
         self.frame_no
     }
 
-    pub fn start_frame_no(&self) -> Option<FrameNo> {
-        self.start_frame_no
+    pub fn frames_synced(&self) -> usize {
+        self.frames_synced
     }
 }
 
@@ -209,8 +209,6 @@ impl EmbeddedReplicator {
             ));
         }
 
-        let start_frame_no = replicator.client_mut().committed_frame_no();
-
         // we force a handshake to get the most up to date replication index from the primary.
         replicator.force_handshake();
 
@@ -235,7 +233,7 @@ impl EmbeddedReplicator {
                     let Some(primary_index) = client.last_handshake_replication_index() else {
                         return Ok(Replicated {
                             frame_no: None,
-                            start_frame_no: None,
+                            frames_synced: 0,
                         });
                     };
                     if let Some(replica_index) = replicator.client_mut().committed_frame_no() {
@@ -249,7 +247,7 @@ impl EmbeddedReplicator {
 
         let replicated = Replicated {
             frame_no: replicator.client_mut().committed_frame_no(),
-            start_frame_no,
+            frames_synced: replicator.frames_synced(),
         };
 
         Ok(replicated)

--- a/libsql/src/replication/remote_client.rs
+++ b/libsql/src/replication/remote_client.rs
@@ -8,7 +8,9 @@ use futures::StreamExt as _;
 use libsql_replication::frame::{Frame, FrameHeader, FrameNo};
 use libsql_replication::meta::WalIndexMeta;
 use libsql_replication::replicator::{map_frame_err, Error, ReplicatorClient};
-use libsql_replication::rpc::replication::{verify_session_token, Frames, HelloRequest, LogOffset, SESSION_TOKEN_KEY, HelloResponse};
+use libsql_replication::rpc::replication::{
+    verify_session_token, Frames, HelloRequest, HelloResponse, LogOffset, SESSION_TOKEN_KEY,
+};
 use tokio_stream::Stream;
 use tonic::metadata::AsciiMetadataValue;
 use tonic::{Response, Status};
@@ -81,7 +83,10 @@ impl RemoteClient {
         self.last_handshake_replication_index
     }
 
-    async fn handle_handshake_response(&mut self, hello:Result<Response<HelloResponse>, Status>) -> Result<bool, Error> {
+    async fn handle_handshake_response(
+        &mut self,
+        hello: Result<Response<HelloResponse>, Status>,
+    ) -> Result<bool, Error> {
         let hello = hello?.into_inner();
         verify_session_token(&hello.session_token).map_err(Error::Client)?;
         let new_session = self.session_token != Some(hello.session_token.clone());
@@ -130,7 +135,9 @@ impl RemoteClient {
             (hello_fut.await, None)
         };
         self.prefetched_batch_log_entries = if let Ok(true) = hello.0 {
-            tracing::warn!("Frames prefetching failed because of new session token returned by handshake");
+            tracing::warn!(
+                "Frames prefetching failed because of new session token returned by handshake"
+            );
             None
         } else {
             frames
@@ -139,7 +146,10 @@ impl RemoteClient {
         hello
     }
 
-    async fn handle_next_frames_response(&mut self, frames: Result<Response<Frames>, Status>) -> Result<<Self as ReplicatorClient>::FrameStream, Error> {
+    async fn handle_next_frames_response(
+        &mut self,
+        frames: Result<Response<Frames>, Status>,
+    ) -> Result<<Self as ReplicatorClient>::FrameStream, Error> {
         let frames = frames?.into_inner().frames;
 
         if let Some(f) = frames.last() {
@@ -157,7 +167,12 @@ impl RemoteClient {
         Ok(Box::pin(stream))
     }
 
-    async fn do_next_frames(&mut self) -> (Result<<Self as ReplicatorClient>::FrameStream, Error>, Duration) {
+    async fn do_next_frames(
+        &mut self,
+    ) -> (
+        Result<<Self as ReplicatorClient>::FrameStream, Error>,
+        Duration,
+    ) {
         let (frames, time) = match self.prefetched_batch_log_entries.take() {
             Some((result, time)) => (result, time),
             None => {
@@ -197,7 +212,13 @@ impl RemoteClient {
     }
 }
 
-fn maybe_log<T>(time: Duration, sum: &mut Duration, count: &mut u128, result: &Result<T, Error>, op_name: &str) {
+fn maybe_log<T>(
+    time: Duration,
+    sum: &mut Duration,
+    count: &mut u128,
+    result: &Result<T, Error>,
+    op_name: &str,
+) {
     if let Err(e) = &result {
         tracing::warn!("Failed {} in {} ms: {:?}", op_name, time.as_millis(), e);
     } else {
@@ -206,7 +227,12 @@ fn maybe_log<T>(time: Duration, sum: &mut Duration, count: &mut u128, result: &R
         let avg = (*sum).as_millis() / *count;
         let time = time.as_millis();
         if *count > 10 && time > 2 * avg {
-            tracing::warn!("Unusually long {}. Took {} ms, average {} ms", op_name, time, avg);
+            tracing::warn!(
+                "Unusually long {}. Took {} ms, average {} ms",
+                op_name,
+                time,
+                avg
+            );
         }
     }
 }
@@ -218,14 +244,26 @@ impl ReplicatorClient for RemoteClient {
     /// Perform handshake with remote
     async fn handshake(&mut self) -> Result<(), Error> {
         let (result, time) = self.do_handshake_with_prefetch().await;
-        maybe_log(time, &mut self.handshake_latency_sum, &mut self.handshake_latency_count, &result, "handshake");
+        maybe_log(
+            time,
+            &mut self.handshake_latency_sum,
+            &mut self.handshake_latency_count,
+            &result,
+            "handshake",
+        );
         result.map(|_| ())
     }
 
     /// Return a stream of frames to apply to the database
     async fn next_frames(&mut self) -> Result<Self::FrameStream, Error> {
         let (result, time) = self.do_next_frames().await;
-        maybe_log(time, &mut self.frames_latency_sum, &mut self.frames_latency_count, &result, "frames fetch");
+        maybe_log(
+            time,
+            &mut self.frames_latency_sum,
+            &mut self.frames_latency_count,
+            &result,
+            "frames fetch",
+        );
         result
     }
 
@@ -233,7 +271,13 @@ impl ReplicatorClient for RemoteClient {
     /// NeedSnapshot error
     async fn snapshot(&mut self) -> Result<Self::FrameStream, Error> {
         let (snapshot, time) = time(self.do_snapshot()).await;
-        maybe_log(time, &mut self.snapshot_latency_sum, &mut self.snapshot_latency_count, &snapshot, "snapshot fetch");
+        maybe_log(
+            time,
+            &mut self.snapshot_latency_sum,
+            &mut self.snapshot_latency_count,
+            &snapshot,
+            "snapshot fetch",
+        );
         snapshot
     }
 


### PR DESCRIPTION
This PR changes the return type of sync to a struct that provides the current commit fno and how many frames that sync call required. This should give more insight to users to understand how much data has been synced.