### PR TITLE
allow reindex statement in libsql

### DIFF
--- a/libsql-server/src/query_analysis.rs
+++ b/libsql-server/src/query_analysis.rs
@@ -139,6 +139,7 @@ impl StmtKind {
                 ))
             }
             Cmd::Stmt(Stmt::Detach(_)) => Some(Self::Detach),
+            Cmd::Stmt(Stmt::Reindex { .. }) => Some(Self::Write),
             _ => None,
         }
     }

--- a/libsql/src/parser.rs
+++ b/libsql/src/parser.rs
@@ -120,6 +120,7 @@ impl StmtKind {
             }) => Some(Self::Release),
             Cmd::Stmt(Stmt::Attach { .. }) => Some(Self::Attach),
             Cmd::Stmt(Stmt::Detach(_)) => Some(Self::Detach),
+            Cmd::Stmt(Stmt::Reindex { .. }) => Some(Self::Write),
             _ => None,
         }
     }


### PR DESCRIPTION
## Context

`REINDEX` ([native](https://www.sqlite.org/lang_reindex.html) SQLite statement) is not recognized statement by libsql but it's pretty safe and we should support it.

Also, it can be useful for vector indices to rebuild them from scratch.