### PR TITLE
add preserve_rowids query parameter to align with native SQLite shell feature

### DIFF
--- a/libsql-server/src/connection/dump/exporter.rs
+++ b/libsql-server/src/connection/dump/exporter.rs
@@ -68,7 +68,8 @@ impl<W: Write> DumpState<W> {
 
             if ty == b"table" {
                 let table_str = std::str::from_utf8(table)?;
-                let (row_id_col, colss) = self.list_table_columns(txn, table_str, preserve_rowids)?;
+                let (row_id_col, colss) =
+                    self.list_table_columns(txn, table_str, preserve_rowids)?;
                 let mut insert = String::new();
                 write!(&mut insert, "INSERT INTO {}", Quoted(table_str))?;
 
@@ -432,7 +433,11 @@ fn find_unused_str(haystack: &str, needle1: &str, needle2: &str) -> String {
     }
 }
 
-pub fn export_dump(db: &mut rusqlite::Connection, writer: impl Write, preserve_rowids: bool) -> anyhow::Result<()> {
+pub fn export_dump(
+    db: &mut rusqlite::Connection,
+    writer: impl Write,
+    preserve_rowids: bool,
+) -> anyhow::Result<()> {
     let mut txn = db.transaction()?;
     txn.execute("PRAGMA writable_schema=ON", ())?;
     let savepoint = txn.savepoint_with_name("dump")?;
@@ -519,9 +524,12 @@ mod test {
     fn table_preserve_rowids() {
         let tmp = tempdir().unwrap();
         let mut conn = Connection::open(tmp.path().join("data")).unwrap();
-        conn.execute(r#"create table test ( id TEXT PRIMARY KEY )"#, ()).unwrap();
-        conn.execute(r#"insert into test values ( 'a' ), ( 'b' ), ( 'c' )"#, ()).unwrap();
-        conn.execute(r#"delete from test where id = 'a'"#, ()).unwrap();
+        conn.execute(r#"create table test ( id TEXT PRIMARY KEY )"#, ())
+            .unwrap();
+        conn.execute(r#"insert into test values ( 'a' ), ( 'b' ), ( 'c' )"#, ())
+            .unwrap();
+        conn.execute(r#"delete from test where id = 'a'"#, ())
+            .unwrap();
 
         let mut out = Vec::new();
         export_dump(&mut conn, &mut out, true).unwrap();

--- a/libsql-server/src/connection/dump/snapshots/libsql_server__connection__dump__exporter__test__table_preserve_rowids.snap
+++ b/libsql-server/src/connection/dump/snapshots/libsql_server__connection__dump__exporter__test__table_preserve_rowids.snap
@@ -1,0 +1,10 @@
+---
+source: libsql-server/src/connection/dump/exporter.rs
+expression: "std::str::from_utf8(&out).unwrap()"
+---
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+CREATE TABLE IF NOT EXISTS test ( id TEXT PRIMARY KEY );
+INSERT INTO test(rowid,id) VALUES(2,'b');
+INSERT INTO test(rowid,id) VALUES(3,'c');
+COMMIT;

--- a/libsql-server/src/http/user/dump.rs
+++ b/libsql-server/src/http/user/dump.rs
@@ -2,11 +2,11 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task;
 
-use serde::Deserialize;
 use axum::extract::{Query, State as AxumState};
 use futures::StreamExt;
 use hyper::HeaderMap;
 use pin_project_lite::pin_project;
+use serde::Deserialize;
 
 use crate::auth::Authenticated;
 use crate::connection::dump::exporter::export_dump;
@@ -109,7 +109,9 @@ pub(super) async fn handle_dump(
 
     let join_handle = BLOCKING_RT.spawn_blocking(move || {
         let writer = tokio_util::io::SyncIoBridge::new(writer);
-        conn.with_raw(|conn| export_dump(conn, writer, query.preserve_row_ids.unwrap_or(false)).map_err(Into::into))
+        conn.with_raw(|conn| {
+            export_dump(conn, writer, query.preserve_row_ids.unwrap_or(false)).map_err(Into::into)
+        })
     });
 
     let stream = tokio_util::io::ReaderStream::new(reader);


### PR DESCRIPTION
## Context

SQLite support several arguments for `dump` command and `preserve-rowids` is one of them:
```
.help .dump
.dump ?OBJECTS?          Render database content as SQL
   Options:
     --data-only            Output only INSERT statements
     --newlines             Allow unescaped newline characters in output
     --nosys                Omit system tables (ex: "sqlite_stat1")
     --preserve-rowids      Include ROWID values in the output
   OBJECTS is a LIKE pattern for tables, indexes, triggers or views to dump
   Additional LIKE patterns can be given in subsequent arguments
```

It can be particularly useful for vector indices because internally they use `ROWID` by default and internal index on-disk data contains `ROWID` values