### PR TITLE
current segment recovery

### DIFF
--- a/libsql-wal/Cargo.toml
+++ b/libsql-wal/Cargo.toml
@@ -42,6 +42,7 @@ inquire = { version = "0.7.5", optional = true }
 tracing-subscriber = { version = "0.3.18", optional = true }
 aws-credential-types = { version = "1.2.0", optional = true }
 dashmap = "6.0.1"
+rand = "0.8.5"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/libsql-wal/src/error.rs
+++ b/libsql-wal/src/error.rs
@@ -11,6 +11,10 @@ pub enum Error {
     BusySnapshot,
     #[error("invalid segment header checksum")]
     InvalidHeaderChecksum,
+    #[error("invalid segment header magic")]
+    InvalidHeaderMagic,
+    #[error("invalid segment header version")]
+    InvalidHeaderVersion,
 }
 
 impl Into<libsql_sys::ffi::Error> for Error {

--- a/libsql-wal/src/io/file.rs
+++ b/libsql-wal/src/io/file.rs
@@ -214,6 +214,10 @@ impl<W> BufCopy<W> {
         let Self { w, buf } = self;
         (w, buf)
     }
+
+    pub fn get_ref(&self) -> &W {
+        &self.w
+    }
 }
 
 impl<W: Write> Write for BufCopy<W> {

--- a/libsql-wal/src/io/mod.rs
+++ b/libsql-wal/src/io/mod.rs
@@ -33,7 +33,8 @@ pub trait Io: Send + Sync + 'static {
     fn uuid(&self) -> Uuid;
     fn hard_link(&self, src: &Path, dst: &Path) -> io::Result<()>;
     fn with_rng<F, R>(&self, f: F) -> R
-        where F: FnOnce(&mut Self::Rng) -> R;
+    where
+        F: FnOnce(&mut Self::Rng) -> R;
 }
 
 #[derive(Default, Debug, Clone, Copy)]
@@ -79,9 +80,10 @@ impl Io for StdIO {
     }
 
     fn with_rng<F, R>(&self, f: F) -> R
-        where F: FnOnce(&mut Self::Rng) -> R,
-        {
-                  f(&mut thread_rng())
+    where
+        F: FnOnce(&mut Self::Rng) -> R,
+    {
+        f(&mut thread_rng())
     }
 }
 
@@ -121,8 +123,10 @@ impl<T: Io> Io for Arc<T> {
     }
 
     fn with_rng<F, R>(&self, f: F) -> R
-        where F: FnOnce(&mut Self::Rng) -> R {
-            self.as_ref().with_rng(f)
+    where
+        F: FnOnce(&mut Self::Rng) -> R,
+    {
+        self.as_ref().with_rng(f)
     }
 }
 
@@ -145,13 +149,13 @@ impl<W, F> io::Write for Inspect<W, F>
 where
     W: io::Write,
     for<'a> F: FnMut(&'a [u8]),
-    {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            (self.f)(buf);
-            self.inner.write(buf)
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            self.inner.flush()
-        }
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        (self.f)(buf);
+        self.inner.write(buf)
     }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}

--- a/libsql-wal/src/lib.rs
+++ b/libsql-wal/src/lib.rs
@@ -16,12 +16,12 @@ const LIBSQL_MAGIC: u64 = u64::from_be_bytes(*b"LIBSQL\0\0");
 #[cfg(any(debug_assertions, test))]
 pub mod test {
     use std::fs::OpenOptions;
-    use std::path::PathBuf;
     use std::path::Path;
+    use std::path::PathBuf;
     use std::sync::Arc;
 
-    use libsql_sys::rusqlite::OpenFlags;
     use libsql_sys::name::NamespaceName;
+    use libsql_sys::rusqlite::OpenFlags;
     use tempfile::{tempdir, TempDir};
     use tokio::sync::mpsc;
 
@@ -77,10 +77,12 @@ pub mod test {
                 )
                 .unwrap(),
             );
+
             if store {
                 let checkpointer = LibsqlCheckpointer::new(registry.clone(), receiver, 5);
                 tokio::spawn(checkpointer.run());
             }
+
             let wal = LibsqlWalManager::new(registry.clone(), Arc::new(resolver));
 
             Self { tmp, registry, wal }
@@ -97,10 +99,7 @@ pub mod test {
             self.tmp.path().join(namespace)
         }
 
-        pub fn open_conn(
-            &self,
-            namespace: &'static str,
-        ) -> libsql_sys::Connection<LibsqlWal<IO>> {
+        pub fn open_conn(&self, namespace: &'static str) -> libsql_sys::Connection<LibsqlWal<IO>> {
             let path = self.db_path(namespace);
             let wal = self.wal.clone();
             std::fs::create_dir_all(&path).unwrap();

--- a/libsql-wal/src/replication/injector.rs
+++ b/libsql-wal/src/replication/injector.rs
@@ -54,7 +54,7 @@ impl<'a, IO: Io> Injector<'a, IO> {
             self.max_tx_frame_no = 0;
         }
         let buffer = current
-            .insert_frames(buffer, commit_data, &mut self.tx)
+            .insert_frames_inject(buffer, commit_data, &mut self.tx)
             .await?;
         self.buffer = buffer;
 

--- a/libsql-wal/src/replication/injector.rs
+++ b/libsql-wal/src/replication/injector.rs
@@ -54,7 +54,7 @@ impl<'a, IO: Io> Injector<'a, IO> {
             self.max_tx_frame_no = 0;
         }
         let buffer = current
-            .insert_frames_inject(buffer, commit_data, &mut self.tx)
+            .inject_frames(buffer, commit_data, &mut self.tx)
             .await?;
         self.buffer = buffer;
 

--- a/libsql-wal/src/replication/replicator.rs
+++ b/libsql-wal/src/replication/replicator.rs
@@ -299,7 +299,6 @@ mod test {
         let mut replica_content = vec![0u8; db_content.len()];
         while let Some(f) = stream.next().await {
             let frame = f.unwrap();
-            dbg!(frame.header().page_no());
             let offset = (frame.header().page_no() as usize - 1) * 4096;
             tmp.as_file()
                 .write_all_at(frame.data(), offset as u64)

--- a/libsql-wal/src/segment/current.rs
+++ b/libsql-wal/src/segment/current.rs
@@ -823,11 +823,7 @@ mod test {
                     return Ok(0);
                 }
 
-                let read_len = if offset as usize + buf.len() > inner.len() {
-                    offset as usize + buf.len() - inner.len()
-                } else {
-                    buf.len()
-                };
+                let read_len = buf.len().min(inner.len() - offset as usize);
                 buf[..read_len]
                     .copy_from_slice(&inner[offset as usize..offset as usize + read_len]);
                 Ok(read_len)
@@ -960,9 +956,12 @@ mod test {
             }
         }
 
+        dbg!();
         {
             let env = TestEnv::new_io_and_tmp(SyncFailBufferIo::default(), tmp.clone());
+        dbg!();
             let conn = env.open_conn("test");
+        dbg!();
             conn.query_row("select count(*) from test", (), |row| {
                 dbg!(row);
                 Ok(())

--- a/libsql-wal/src/segment/current.rs
+++ b/libsql-wal/src/segment/current.rs
@@ -119,7 +119,7 @@ impl<F> CurrentSegment<F> {
     /// insert a bunch of frames in the Wal. The frames needn't be ordered, therefore, on commit
     /// the last frame no needs to be passed alongside the new size_after.
     #[tracing::instrument(skip_all)]
-    pub async fn insert_frames_inject(
+    pub async fn inject_frames(
         &self,
         frames: Vec<Box<Frame>>,
         // (size_after, last_frame_no)
@@ -520,7 +520,6 @@ impl<F> CurrentSegment<F> {
             self.file.read_exact_at(checked_frame.as_bytes_mut(), frame_offset)?;
             current_checksum = checked_frame.frame.checksum(current_checksum);
             self.file.write_all_at(&current_checksum.to_le_bytes(), frame_offset)?;
-
         }
 
         Ok(())

--- a/libsql-wal/src/segment/current.rs
+++ b/libsql-wal/src/segment/current.rs
@@ -58,6 +58,8 @@ impl<F> CurrentSegment<F> {
             index_size: 0.into(),
             header_cheksum: 0.into(),
             flags: 0.into(),
+            magic: LIBSQL_MAGIC.into(),
+            version: 1.into(),
         };
 
         header.recompute_checksum();

--- a/libsql-wal/src/segment/mod.rs
+++ b/libsql-wal/src/segment/mod.rs
@@ -79,8 +79,8 @@ impl SegmentHeader {
             return Err(Error::InvalidHeaderVersion);
         }
 
-        let computed = dbg!(self.checksum());
-        if computed == dbg!(self.header_cheksum.get()) {
+        let computed = self.checksum();
+        if computed == self.header_cheksum.get() {
             return Ok(());
         } else {
             return Err(Error::InvalidHeaderChecksum);

--- a/libsql-wal/src/segment/mod.rs
+++ b/libsql-wal/src/segment/mod.rs
@@ -255,7 +255,6 @@ impl CheckedFrame {
     pub(crate) const fn offset_of_frame() -> usize {
         offset_of!(Self, frame)
     }
-
 }
 
 #[repr(C)]

--- a/libsql-wal/src/segment/mod.rs
+++ b/libsql-wal/src/segment/mod.rs
@@ -32,6 +32,7 @@ bitflags::bitflags! {
         /// This is true for a segment created by a primary, but a replica may insert frames in any
         /// order, as long as commit boundaries are preserved.
         const FRAME_UNORDERED = 1 << 0;
+        const SEALED          = 1 << 1;
     }
 }
 

--- a/libsql-wal/src/segment/mod.rs
+++ b/libsql-wal/src/segment/mod.rs
@@ -8,18 +8,20 @@
 //! head segment at the moment it was created.
 #![allow(dead_code)]
 use std::future::Future;
+use std::hash::Hasher as _;
 use std::io;
 use std::mem::offset_of;
 use std::mem::size_of;
 use std::num::NonZeroU64;
 use std::sync::Arc;
 
-use zerocopy::byteorder::little_endian::{U32, U64};
+use zerocopy::byteorder::little_endian::{U16, U32, U64};
 use zerocopy::AsBytes;
 
 use crate::error::{Error, Result};
 use crate::io::buf::IoBufMut;
 use crate::io::FileExt;
+use crate::LIBSQL_MAGIC;
 
 pub(crate) mod compacted;
 pub mod current;
@@ -32,6 +34,7 @@ bitflags::bitflags! {
         /// This is true for a segment created by a primary, but a replica may insert frames in any
         /// order, as long as commit boundaries are preserved.
         const FRAME_UNORDERED = 1 << 0;
+        /// The segment is sealed. If this flag is set, then
         const SEALED          = 1 << 1;
     }
 }
@@ -49,21 +52,21 @@ pub struct SegmentHeader {
     pub size_after: U32,
     /// byte offset of the index. If 0, then the index wasn't written, and must be recovered.
     /// If non-0, the segment is sealed, and must not be written to anymore
+    /// the index is followed by its checksum
     pub index_offset: U64,
     pub index_size: U64,
-    /// checksum of the header fields, excluding the checksum itself. This field must be the last
-    pub header_cheksum: U64,
     pub flags: U32,
+    /// salt for the segment checksum
+    pub salt: U32,
+
+    /// checksum of the header fields, excluding the checksum itself. This field must be the last
+    pub header_cheksum: U32,
 }
 
 impl SegmentHeader {
-    fn checksum(&self) -> u64 {
+    fn checksum(&self) -> u32 {
         let field_bytes: &[u8] = &self.as_bytes()[..offset_of!(SegmentHeader, header_cheksum)];
-        let checksum = field_bytes
-            .iter()
-            .map(|x| *x as u64)
-            .reduce(|a, b| a ^ b)
-            .unwrap_or(0);
+        let checksum = crc32fast::hash(field_bytes);
         checksum
     }
 
@@ -231,6 +234,28 @@ impl FrameHeader {
     pub fn set_size_after(&mut self, size_after: u32) {
         self.size_after = size_after.into();
     }
+
+    pub fn is_commit(&self) -> bool {
+        self.size_after() != 0
+    }
+}
+
+/// A page with a running runnign checksum prepended.
+/// `checksum` is computed by taking the checksum of the previous frame and crc32'ing it with frame
+/// data (header and page content). The first page is hashed with the segment header salt.
+#[repr(C)]
+#[derive(Debug, zerocopy::AsBytes, zerocopy::FromBytes, zerocopy::FromZeroes)]
+pub struct CheckedFrame {
+    checksum: U32,
+    // frame should always be the last field
+    frame: Frame,
+}
+
+impl CheckedFrame {
+    pub(crate) const fn offset_of_frame() -> usize {
+        offset_of!(Self, frame)
+    }
+
 }
 
 #[repr(C)]
@@ -241,6 +266,12 @@ pub struct Frame {
 }
 
 impl Frame {
+    pub(crate) fn checksum(&self, previous_checksum: u32) -> u32 {
+        let mut digest = crc32fast::Hasher::new_with_initial(previous_checksum);
+        digest.write(self.as_bytes());
+        digest.finalize()
+    }
+
     pub fn data(&self) -> &[u8] {
         &self.data
     }
@@ -259,10 +290,37 @@ impl Frame {
     }
 }
 
+/// offset of the CheckedFrame in a current of sealed segment
+#[inline]
+fn checked_frame_offset(offset: u32) -> u64 {
+    (size_of::<SegmentHeader>() + (offset as usize) * size_of::<CheckedFrame>()) as u64
+}
+/// offset of a Frame in a current or sealed segment.
+#[inline]
 fn frame_offset(offset: u32) -> u64 {
-    (size_of::<SegmentHeader>() + (offset as usize) * size_of::<Frame>()) as u64
+    checked_frame_offset(offset) + CheckedFrame::offset_of_frame() as u64
 }
 
+/// offset of a frame's page in a current or sealed segment.
+#[inline]
 fn page_offset(offset: u32) -> u64 {
     frame_offset(offset) + size_of::<FrameHeader>() as u64
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn offsets() {
+        assert_eq!(checked_frame_offset(0) as usize, size_of::<SegmentHeader>());
+        assert_eq!(
+            frame_offset(0) as usize,
+            size_of::<SegmentHeader>() + CheckedFrame::offset_of_frame()
+        );
+        assert_eq!(
+            page_offset(0) as usize,
+            size_of::<SegmentHeader>() + CheckedFrame::offset_of_frame() + size_of::<FrameHeader>()
+        );
+    }
 }

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -15,11 +15,12 @@ use zerocopy::{AsBytes, FromZeroes};
 use crate::error::Result;
 use crate::io::buf::{IoBufMut, ZeroCopyBuf};
 use crate::io::file::{BufCopy, FileExt};
-use crate::LIBSQL_MAGIC;
 use crate::io::Inspect;
+use crate::segment::{checked_frame_offset, CheckedFrame};
+use crate::LIBSQL_MAGIC;
 
 use super::compacted::{CompactedSegmentDataFooter, CompactedSegmentDataHeader};
-use super::{frame_offset, page_offset, Frame, FrameHeader, Segment, SegmentHeader, SegmentFlags};
+use super::{frame_offset, page_offset, Frame, Segment, SegmentFlags, SegmentHeader};
 
 /// an immutable, wal segment
 #[derive(Debug)]

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -242,7 +242,7 @@ impl<F: FileExt> SealedSegment<F> {
             match file.read_exact_at(frame.as_bytes_mut(), offset) {
                 Ok(_) => {
                     let new_checksum = frame.frame.checksum(current_checksum);
-                    // this is the first checksum that don't match the checksum chain, drop the
+                    // this is the first checksum that doesn't match the checksum chain, drop the
                     // transaction and any frame after that.
                     if new_checksum != frame.checksum.get() {
                         tracing::warn!(

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -282,14 +282,14 @@ impl<F: FileExt> SealedSegment<F> {
             builder.insert(k.to_be_bytes(), v as u64).unwrap();
         }
         builder.finish().unwrap();
-        let mut writer = writer.into_inner();
+        let writer = writer.into_inner();
         let index_size = writer.get_ref().get_ref().count();
         let index_checksum = digest.finalize();
-        writer.write_all(&index_checksum.to_le_bytes())?;
-        let (_, index_bytes) = writer
+        let (mut cursor, index_bytes) = writer
             .into_inner()
             .map_err(|e| e.into_parts().0)?
             .into_parts();
+        cursor.write_all(&index_checksum.to_le_bytes())?;
         header.index_offset = index_byte_offset.into();
         header.index_size = index_size.into();
         header.last_commited_frame_no = last_committed.into();

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -17,7 +17,7 @@ use crate::io::file::{BufCopy, FileExt};
 use crate::LIBSQL_MAGIC;
 
 use super::compacted::{CompactedSegmentDataFooter, CompactedSegmentDataHeader};
-use super::{frame_offset, page_offset, Frame, FrameHeader, Segment, SegmentHeader};
+use super::{frame_offset, page_offset, Frame, FrameHeader, Segment, SegmentHeader, SegmentFlags};
 
 /// an immutable, wal segment
 #[derive(Debug)]
@@ -190,6 +190,10 @@ impl<F: FileExt> SealedSegment<F> {
 
         let index_offset = header.index_offset.get();
         let index_len = header.index_size.get();
+
+        if !header.flags().contains(SegmentFlags::SEALED) {
+            todo!("recover");
+        }
 
         if header.is_empty() {
             std::fs::remove_file(path)?;

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -191,10 +191,6 @@ impl<F: FileExt> SealedSegment<F> {
         let index_offset = header.index_offset.get();
         let index_len = header.index_size.get();
 
-        if !header.flags().contains(SegmentFlags::SEALED) {
-            todo!("recover");
-        }
-
         if header.is_empty() {
             std::fs::remove_file(path)?;
             return Ok(None);

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -164,18 +164,22 @@ impl<IO: Io> SharedWal<IO> {
         let next_offset = current.count_committed() as u32;
         let next_frame_no = current.next_frame_no().get();
         *tx_id_lock = Some(read_tx.id);
+        let current_checksum = current.current_checksum();
 
         Ok(WriteTransaction {
             wal_lock: self.wal_lock.clone(),
             savepoints: vec![Savepoint {
+                current_checksum,
                 next_offset,
                 next_frame_no,
                 index: BTreeMap::new(),
             }],
             next_frame_no,
             next_offset,
+            current_checksum,
             is_commited: false,
             read_tx: read_tx.clone(),
+            recompute_checksum: None,
         })
     }
 

--- a/libsql-wal/src/storage/mod.rs
+++ b/libsql-wal/src/storage/mod.rs
@@ -339,7 +339,7 @@ impl<IO: Io> Storage for TestStorage<IO> {
                 .entry(namespace.clone())
                 .or_default()
                 .insert(key, (out_path, index));
-            tokio::runtime::Handle::current().block_on(on_store(end_frame_no))
+            tokio::runtime::Handle::current().block_on(on_store(end_frame_no));
         }
     }
 

--- a/libsql-wal/src/wal.rs
+++ b/libsql-wal/src/wal.rs
@@ -13,13 +13,13 @@ use crate::shared_wal::SharedWal;
 use crate::storage::Storage;
 use crate::transaction::Transaction;
 
-pub struct LibsqlWalManager<FS: Io, S> {
-    registry: Arc<WalRegistry<FS, S>>,
+pub struct LibsqlWalManager<IO: Io, S> {
+    registry: Arc<WalRegistry<IO, S>>,
     next_conn_id: Arc<AtomicU64>,
     namespace_resolver: Arc<dyn NamespaceResolver>,
 }
 
-impl<FS: Io, S> Clone for LibsqlWalManager<FS, S> {
+impl<IO: Io, S> Clone for LibsqlWalManager<IO, S> {
     fn clone(&self) -> Self {
         Self {
             registry: self.registry.clone(),

--- a/libsql-wal/tests/flaky_fs.rs
+++ b/libsql-wal/tests/flaky_fs.rs
@@ -153,8 +153,10 @@ impl Io for FlakyIo {
     }
 
     fn with_rng<F, R>(&self, f: F) -> R
-        where F: FnOnce(&mut Self::Rng) -> R {
-            f(&mut self.rng.lock())
+    where
+        F: FnOnce(&mut Self::Rng) -> R,
+    {
+        f(&mut self.rng.lock())
     }
 }
 

--- a/libsql-wal/tests/flaky_fs.rs
+++ b/libsql-wal/tests/flaky_fs.rs
@@ -110,6 +110,7 @@ impl FlakyIo {
 impl Io for FlakyIo {
     type File = FlakyFile;
     type TempFile = FlakyFile;
+    type Rng = rand_chacha::ChaCha8Rng;
 
     fn create_dir_all(&self, path: &std::path::Path) -> std::io::Result<()> {
         self.with_random_failure(|| std::fs::create_dir_all(path))
@@ -149,6 +150,11 @@ impl Io for FlakyIo {
 
     fn hard_link(&self, _src: &Path, _dst: &Path) -> std::io::Result<()> {
         todo!()
+    }
+
+    fn with_rng<F, R>(&self, f: F) -> R
+        where F: FnOnce(&mut Self::Rng) -> R {
+            f(&mut self.rng.lock())
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.80.0"
+channel = "1.78.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.78.0"
+channel = "1.80.0"


### PR DESCRIPTION
The goal of this PR is to make the current segment recoverable in case of a crash. Taking inspiration from SQLite's wal, we introduce a grinning checksum to the current log, where each frame is hashed with the hash of the previous frame. If we find an unsealed segment on startup, we enter recovery mode for that segment, meaning that we iterate over its frames, recomputing the checksums. We stop whenever we hit a checksum that breaks the list invariant and patch the segment. This means that in NORMAL synchronous mode, we can lose committed data on the crash, but this is expected. We'll introduce a more robust sync mode later that flushes on every commit and has stronger guarantees.

This scheme introduces a bit more complexity:
- double flush on seal: on seal, we first flush all data to disk before updating the header and flushing again. This makes the SEALED flag on the segment reliable: if sealed is present, we can guarantee that all data was flushed before that, and therefore we can trust the segment's integrity. Without that, issues could arise on a partial flush where the header was flushed but not the rest of the segment.
- When we overwrite frames in a transaction, we need to recompute checksums.

I have added a test that simulates a crash during flush, where not all pages are flushed to disk, to demonstrate recovery.
