### PR TITLE
add page size to segment header

### DIFF
--- a/libsql-wal/src/error.rs
+++ b/libsql-wal/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     InvalidHeaderMagic,
     #[error("invalid segment header version")]
     InvalidHeaderVersion,
+    #[error("Invalid page size, only 4095 is supported")]
+    InvalidPageSize,
 }
 
 impl Into<libsql_sys::ffi::Error> for Error {

--- a/libsql-wal/src/lib.rs
+++ b/libsql-wal/src/lib.rs
@@ -12,6 +12,8 @@ pub mod transaction;
 pub mod wal;
 
 const LIBSQL_MAGIC: u64 = u64::from_be_bytes(*b"LIBSQL\0\0");
+const LIBSQL_PAGE_SIZE: u16 = 4096;
+const LIBSQL_WAL_VERSION: u16 = 1;
 
 #[cfg(any(debug_assertions, test))]
 pub mod test {

--- a/libsql-wal/src/segment/current.rs
+++ b/libsql-wal/src/segment/current.rs
@@ -23,7 +23,7 @@ use crate::io::Inspect;
 use crate::segment::{checked_frame_offset, SegmentFlags};
 use crate::segment::{frame_offset, page_offset, sealed::SealedSegment};
 use crate::transaction::{Transaction, TxGuard};
-use crate::LIBSQL_MAGIC;
+use crate::{LIBSQL_MAGIC, LIBSQL_PAGE_SIZE, LIBSQL_WAL_VERSION};
 
 use super::list::SegmentList;
 use super::{CheckedFrame, Frame, FrameHeader, SegmentHeader};
@@ -67,8 +67,9 @@ impl<F> CurrentSegment<F> {
             header_cheksum: 0.into(),
             flags: 0.into(),
             magic: LIBSQL_MAGIC.into(),
-            version: 1.into(),
+            version: LIBSQL_WAL_VERSION.into(),
             salt: salt.into(),
+            page_size: LIBSQL_PAGE_SIZE.into(),
         };
 
         header.recompute_checksum();

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -17,7 +17,7 @@ use crate::io::buf::{IoBufMut, ZeroCopyBuf};
 use crate::io::file::{BufCopy, FileExt};
 use crate::io::Inspect;
 use crate::segment::{checked_frame_offset, CheckedFrame};
-use crate::LIBSQL_MAGIC;
+use crate::{LIBSQL_MAGIC, LIBSQL_WAL_VERSION};
 
 use super::compacted::{CompactedSegmentDataFooter, CompactedSegmentDataHeader};
 use super::{frame_offset, page_offset, Frame, Segment, SegmentFlags, SegmentHeader};
@@ -91,8 +91,9 @@ where
             start_frame_no: self.header().start_frame_no,
             end_frame_no: self.header().last_commited_frame_no,
             size_after: self.header.size_after,
-            version: 1.into(),
+            version: LIBSQL_WAL_VERSION.into(),
             magic: LIBSQL_MAGIC.into(),
+            page_size: self.header().page_size,
         };
 
         hasher.update(header.as_bytes());


### PR DESCRIPTION
right now, libsql-wal only support 4096 page size, but if we want to support other page size in the future, this will make it easier
