### PR TITLE
Breaking change: Make Rows and Row API more consistent.

### DIFF
--- a/libsql/src/de.rs
+++ b/libsql/src/de.rs
@@ -68,7 +68,7 @@ impl<'de> Deserializer<'de> for RowDeserializer<'de> {
 
         visitor.visit_map(RowMapAccess {
             row: self.row,
-            idx: 0..self.row.inner.column_count(),
+            idx: 0..(self.row.inner.column_count() as usize),
             value: None,
         })
     }

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -24,7 +24,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use super::rows::{RowInner, RowsInner};
+use super::rows::{ColumnsInner, RowInner, RowsInner};
 
 pub(crate) type Result<T> = std::result::Result<T, HranaError>;
 
@@ -261,7 +261,12 @@ where
     async fn next(&mut self) -> crate::Result<Option<super::Row>> {
         self.next().await
     }
+}
 
+impl<S> ColumnsInner for HranaRows<S>
+where
+    S: Stream<Item = std::io::Result<Bytes>> + Send + Sync + Unpin,
+{
     fn column_count(&self) -> i32 {
         self.column_count()
     }
@@ -303,13 +308,6 @@ impl RowInner for Row {
         Ok(into_value2(v))
     }
 
-    fn column_name(&self, idx: i32) -> Option<&str> {
-        self.cols
-            .get(idx as usize)
-            .and_then(|c| c.name.as_ref())
-            .map(|s| s.as_str())
-    }
-
     fn column_str(&self, idx: i32) -> crate::Result<&str> {
         if let Some(value) = self.inner.get(idx as usize) {
             if let proto::Value::Text { value } = value {
@@ -320,6 +318,15 @@ impl RowInner for Row {
         } else {
             Err(crate::Error::ColumnNotFound(idx))
         }
+    }
+}
+
+impl ColumnsInner for Row {
+    fn column_name(&self, idx: i32) -> Option<&str> {
+        self.cols
+            .get(idx as usize)
+            .and_then(|c| c.name.as_ref())
+            .map(|s| s.as_str())
     }
 
     fn column_type(&self, idx: i32) -> crate::Result<ValueType> {
@@ -337,8 +344,8 @@ impl RowInner for Row {
         }
     }
 
-    fn column_count(&self) -> usize {
-        self.cols.len()
+    fn column_count(&self) -> i32 {
+        self.cols.len() as i32
     }
 }
 
@@ -417,7 +424,9 @@ impl RowsInner for StmtResultRows {
             inner: Box::new(row),
         }))
     }
+}
 
+impl ColumnsInner for StmtResultRows {
     fn column_count(&self) -> i32 {
         self.cols.len() as i32
     }

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -5,7 +5,7 @@ use crate::connection::BatchRows;
 use crate::{
     connection::Conn,
     params::Params,
-    rows::{RowInner, RowsInner},
+    rows::{ColumnsInner, RowInner, RowsInner},
     statement::Stmt,
     transaction::Tx,
     Column, Connection, Result, Row, Rows, Statement, Transaction, TransactionBehavior, Value,
@@ -159,7 +159,9 @@ impl RowsInner for LibsqlRows {
 
         Ok(row)
     }
+}
 
+impl ColumnsInner for LibsqlRows {
     fn column_count(&self) -> i32 {
         self.0.column_count()
     }
@@ -180,20 +182,22 @@ impl RowInner for LibsqlRow {
         self.0.get_value(idx)
     }
 
-    fn column_name(&self, idx: i32) -> Option<&str> {
-        self.0.column_name(idx)
-    }
-
     fn column_str(&self, idx: i32) -> Result<&str> {
         self.0.get::<&str>(idx)
+    }
+}
+
+impl ColumnsInner for LibsqlRow {
+    fn column_name(&self, idx: i32) -> Option<&str> {
+        self.0.column_name(idx)
     }
 
     fn column_type(&self, idx: i32) -> Result<ValueType> {
         self.0.column_type(idx).map(ValueType::from)
     }
 
-    fn column_count(&self) -> usize {
-        self.0.stmt.column_count()
+    fn column_count(&self) -> i32 {
+        self.0.stmt.column_count() as i32
     }
 }
 

--- a/libsql/src/local/rows.rs
+++ b/libsql/src/local/rows.rs
@@ -1,6 +1,6 @@
 use crate::local::{Connection, Statement};
 use crate::params::Params;
-use crate::rows::{RowInner, RowsInner};
+use crate::rows::{ColumnsInner, RowInner, RowsInner};
 use crate::{errors, Error, Result};
 use crate::{Value, ValueRef};
 use libsql_sys::ValueType;
@@ -213,7 +213,9 @@ impl RowsInner for BatchedRows {
             Ok(None)
         }
     }
+}
 
+impl ColumnsInner for BatchedRows {
     fn column_count(&self) -> i32 {
         self.cols.len() as i32
     }
@@ -244,10 +246,6 @@ impl RowInner for BatchedRow {
             .ok_or(Error::InvalidColumnIndex)
     }
 
-    fn column_name(&self, idx: i32) -> Option<&str> {
-        self.cols.get(idx as usize).map(|c| c.0.as_str())
-    }
-
     fn column_str(&self, idx: i32) -> Result<&str> {
         self.row
             .get(idx as usize)
@@ -258,9 +256,15 @@ impl RowInner for BatchedRow {
                     .ok_or(Error::InvalidColumnType)
             })
     }
+}
 
-    fn column_count(&self) -> usize {
-        self.cols.len()
+impl ColumnsInner for BatchedRow {
+    fn column_name(&self, idx: i32) -> Option<&str> {
+        self.cols.get(idx as usize).map(|c| c.0.as_str())
+    }
+
+    fn column_count(&self) -> i32 {
+        self.cols.len() as i32
     }
 
     fn column_type(&self, idx: i32) -> Result<crate::value::ValueType> {

--- a/libsql/src/local/statement.rs
+++ b/libsql/src/local/statement.rs
@@ -250,15 +250,15 @@ impl Statement {
     /// sure that current statement has already been stepped once before
     /// calling this method.
     pub fn column_names(&self) -> Vec<&str> {
-        let n = self.column_count();
-        let mut cols = Vec::with_capacity(n);
-        for i in 0..n {
-            let s = self.column_name(i);
-            if let Some(s) = s {
-                cols.push(s);
-            }
-        }
-        cols
+       let n = self.column_count();
+       let mut cols = Vec::with_capacity(n);
+       for i in 0..n {
+           let s = self.column_name(i);
+           if let Some(s) = s {
+               cols.push(s);
+           }
+       }
+       cols
     }
 
     /// Return the number of columns in the result set returned by the prepared
@@ -314,12 +314,11 @@ impl Statement {
     /// the specified `name`.
     pub fn column_index(&self, name: &str) -> Result<usize> {
         let bytes = name.as_bytes();
-        let n = self.column_count() as i32;
+        let n = self.column_count();
         for i in 0..n {
             // Note: `column_name` is only fallible if `i` is out of bounds,
             // which we've already checked.
             let col_name = self
-                .inner
                 .column_name(i)
                 .ok_or_else(|| Error::InvalidColumnName(name.to_string()))?;
             if bytes.eq_ignore_ascii_case(col_name.as_bytes()) {

--- a/libsql/src/rows.rs
+++ b/libsql/src/rows.rs
@@ -38,14 +38,8 @@ impl Column<'_> {
 }
 
 #[async_trait::async_trait]
-pub(crate) trait RowsInner {
+pub(crate) trait RowsInner: ColumnsInner {
     async fn next(&mut self) -> Result<Option<Row>>;
-
-    fn column_count(&self) -> i32;
-
-    fn column_name(&self, idx: i32) -> Option<&str>;
-
-    fn column_type(&self, idx: i32) -> Result<ValueType>;
 }
 
 /// A set of rows returned from a connection.
@@ -131,7 +125,7 @@ impl Row {
     }
 
     /// Get the count of columns in this set of rows.
-    pub fn column_count(&self) -> usize {
+    pub fn column_count(&self) -> i32 {
         self.inner.column_count()
     }
 
@@ -284,12 +278,15 @@ where
 }
 impl<T> Sealed for Option<T> {}
 
-pub(crate) trait RowInner: fmt::Debug {
-    fn column_value(&self, idx: i32) -> Result<Value>;
-    fn column_str(&self, idx: i32) -> Result<&str>;
+pub(crate) trait ColumnsInner {
     fn column_name(&self, idx: i32) -> Option<&str>;
     fn column_type(&self, idx: i32) -> Result<ValueType>;
-    fn column_count(&self) -> usize;
+    fn column_count(&self) -> i32;
+}
+
+pub(crate) trait RowInner: ColumnsInner + fmt::Debug {
+    fn column_value(&self, idx: i32) -> Result<Value>;
+    fn column_str(&self, idx: i32) -> Result<&str>;
 }
 
 mod sealed {


### PR DESCRIPTION
    A few notes: I went the path of least resistance also assuming it would
    break fewer folks, i.e. make Row more like Rows and thus usize -> i32.
    
    Arguably, an unsigned type might be more appropriate both for length and
    indexes. I understand that the i32 stems from the sqlite bindings, which
    returns/accepts c_ints. Yet, Statement and Row made the jump to an
    unsigned, probably drawing the same conclusion, whereas Rows preserved
    its proximity to the c-bindings. This is probably an artifact?
    
    Also going on a limb, mapping c_int -> i32 is already a non-portable
    choice, with precision for c_int being platform dependent.
