### PR TITLE
Add description for the --enable-http-console cli option

### DIFF
--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -42,6 +42,8 @@ struct Cli {
 
     #[clap(long, default_value = "127.0.0.1:8080", env = "SQLD_HTTP_LISTEN_ADDR")]
     http_listen_addr: SocketAddr,
+
+    /// Enable a web-based http console served at the /console route.
     #[clap(long)]
     enable_http_console: bool,
 


### PR DESCRIPTION
I didn't understand what this option would enable and how to access the console. Only after finding [this commit](https://github.com/tursodatabase/libsql/commit/101115e73e4a0e85163072248837194935b6d6c9) it became clear. With a description already in the cli this is easier to find.