### PR TITLE
c: add replicated data for sync

### DIFF
--- a/bindings/c/include/libsql.h
+++ b/bindings/c/include/libsql.h
@@ -28,8 +28,8 @@ typedef struct libsql_stmt libsql_stmt;
 typedef const libsql_database *libsql_database_t;
 
 typedef struct {
-  uintptr_t frame_no;
-  uintptr_t frames_synced;
+  int frame_no;
+  int frames_synced;
 } replicated;
 
 typedef struct {
@@ -61,7 +61,9 @@ typedef struct {
 extern "C" {
 #endif // __cplusplus
 
-int libsql_sync(libsql_database_t db, replicated *out_replicated, const char **out_err_msg);
+int libsql_sync(libsql_database_t db, const char **out_err_msg);
+
+int libsql_sync2(libsql_database_t db, replicated *out_replicated, const char **out_err_msg);
 
 int libsql_open_sync(const char *db_path,
                      const char *primary_url,

--- a/bindings/c/include/libsql.h
+++ b/bindings/c/include/libsql.h
@@ -28,6 +28,11 @@ typedef struct libsql_stmt libsql_stmt;
 typedef const libsql_database *libsql_database_t;
 
 typedef struct {
+  uintptr_t frame_no;
+  uintptr_t frames_synced;
+} replicated;
+
+typedef struct {
   const char *db_path;
   const char *primary_url;
   const char *auth_token;
@@ -56,7 +61,7 @@ typedef struct {
 extern "C" {
 #endif // __cplusplus
 
-int libsql_sync(libsql_database_t db, const char **out_err_msg);
+int libsql_sync(libsql_database_t db, replicated *out_replicated, const char **out_err_msg);
 
 int libsql_open_sync(const char *db_path,
                      const char *primary_url,

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -115,6 +115,12 @@ impl From<&mut libsql_connection> for libsql_connection_t {
     }
 }
 
+#[repr(C)]
+pub struct replicated {
+    pub frame_no: usize,
+    pub frames_synced: usize,
+}
+
 pub struct stmt {
     pub stmt: libsql::Statement,
     pub params: Vec<libsql::Value>,

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -117,8 +117,8 @@ impl From<&mut libsql_connection> for libsql_connection_t {
 
 #[repr(C)]
 pub struct replicated {
-    pub frame_no: usize,
-    pub frames_synced: usize,
+    pub frame_no: std::ffi::c_int,
+    pub frames_synced: std::ffi::c_int,
 }
 
 pub struct stmt {


### PR DESCRIPTION
This adds a new replicated struct that is output during sync for the C bindings.