### PR TITLE
cancel query when request is dropped

### DIFF
--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -15,7 +15,9 @@ use tokio::sync::watch;
 use tokio::time::{Duration, Instant};
 
 use crate::error::Error;
-use crate::metrics::{DESCRIBE_COUNT, PROGRAM_EXEC_COUNT, VACUUM_COUNT, WAL_CHECKPOINT_COUNT};
+use crate::metrics::{
+    DESCRIBE_COUNT, PROGRAM_EXEC_COUNT, QUERY_CANCELED, VACUUM_COUNT, WAL_CHECKPOINT_COUNT,
+};
 use crate::namespace::broadcasters::BroadcasterHandle;
 use crate::namespace::meta_store::MetaStoreHandle;
 use crate::namespace::ResolveNamespacePathFn;
@@ -512,6 +514,7 @@ impl<W: Wal> Connection<W> {
             Some(move || {
                 let canceled = canceled.load(Ordering::Relaxed);
                 if canceled {
+                    QUERY_CANCELED.increment(1);
                     tracing::trace!("request canceled");
                 }
                 canceled

--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -399,7 +399,7 @@ where
         impl Drop for Bomb {
             fn drop(&mut self) {
                 if !self.defused {
-                    tracing::debug!("cancelling request");
+                    tracing::trace!("cancelling request");
                     self.canceled.store(true, Ordering::Relaxed);
                 }
             }
@@ -512,7 +512,7 @@ impl<W: Wal> Connection<W> {
             Some(move || {
                 let canceled = canceled.load(Ordering::Relaxed);
                 if canceled {
-                    tracing::debug!("request canceled");
+                    tracing::trace!("request canceled");
                 }
                 canceled
             })

--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -413,14 +413,15 @@ where
             cancelled
         };
 
+        PROGRAM_EXEC_COUNT.increment(1);
+
+        check_program_auth(&ctx, &pgm, &self.inner.lock().config_store.get())?;
+
+        // create the bomb right before spawning the blocking task.
         let mut bomb = Bomb {
             canceled,
             defused: false,
         };
-
-        PROGRAM_EXEC_COUNT.increment(1);
-
-        check_program_auth(&ctx, &pgm, &self.inner.lock().config_store.get())?;
         let conn = self.inner.clone();
         let ret = BLOCKING_RT
             .spawn_blocking(move || Connection::run(conn, pgm, builder))

--- a/libsql-server/src/metrics.rs
+++ b/libsql-server/src/metrics.rs
@@ -153,3 +153,8 @@ pub static LISTEN_EVENTS_DROPPED: Lazy<Counter> = Lazy::new(|| {
     describe_counter!(NAME, "Number of listen events dropped");
     register_counter!(NAME)
 });
+pub static QUERY_CANCELED: Lazy<Counter> = Lazy::new(|| {
+    const NAME: &str = "libsql_server_query_canceled";
+    describe_counter!(NAME, "Number of canceled queries");
+    register_counter!(NAME)
+});


### PR DESCRIPTION
This PR implements cancelling a query when the underlying request is dropped. This is done by adding a progress handler to the connection that checks every 100 instruction if the request has been dropped.
