### PR TITLE
libsql: downgrade failed prefetch log to debug

### DIFF
--- a/libsql/src/replication/remote_client.rs
+++ b/libsql/src/replication/remote_client.rs
@@ -135,7 +135,7 @@ impl RemoteClient {
             (hello_fut.await, None)
         };
         self.prefetched_batch_log_entries = if let Ok(true) = hello.0 {
-            tracing::warn!(
+            tracing::debug!(
                 "Frames prefetching failed because of new session token returned by handshake"
             );
             None


### PR DESCRIPTION
Users are seeing a warning message come up when a fresh database client tries to sync. Subsequent calls to sync don't trigger this warning log and in fact there is nothing to be worried about if this log fires because its normal to see this on the first call to sync.

Example logs showing this firing:

```
     Running `target/debug/examples/remote_sync`
2024-08-07T21:39:26.287453Z  INFO libsql::replication::remote_client: Attempting to perform handshake with primary.
[libsql/src/replication/remote_client.rs:92:27] &self.session_token = None
[libsql/src/replication/remote_client.rs:92:56] &Some(hello.session_token.clone()) = Some(
    b"e5c97d87-5ac7-089c-013f-31079f959e84",
)
2024-08-07T21:39:26.786669Z  WARN libsql::replication::remote_client: Frames prefetching failed because of new session token returned by handshake
second sync now
2024-08-07T21:39:29.219577Z  INFO libsql::replication::remote_client: Attempting to perform handshake with primary.
[libsql/src/replication/remote_client.rs:92:27] &self.session_token = Some(
    b"e5c97d87-5ac7-089c-013f-31079f959e84",
)
[libsql/src/replication/remote_client.rs:92:56] &Some(hello.session_token.clone()) = Some(
    b"e5c97d87-5ac7-089c-013f-31079f959e84",
)
```