### PR TITLE
Fix JSON Number(f64) precision

### DIFF
--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -20,7 +20,7 @@ hyper = { workspace = true, features = ["client", "stream"], optional = true }
 hyper-rustls = { version = "0.25", features = ["webpki-roots"], optional = true }
 base64 = { version = "0.21", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", optional = true }
+serde_json = { version = "1", features = ["float_roundtrip"], optional = true }
 async-trait = "0.1"
 bitflags = { version = "2.4.0", optional = true }
 tower = { workspace = true, features = ["util"], optional = true }


### PR DESCRIPTION
```sql
SELECT 0.00000001753244305291446;
```

```bash
# Before
Row: Real(1.7532443052914463e-8)
# After
Row: Real(1.753244305291446e-8)
```

> [!NOTE]
This may incur a 2x performance cost.
https://github.com/serde-rs/json/blob/54381d6fee21cb05439937a0f5f286177c21d3f6/Cargo.toml#L68
