### PR TITLE
publish sqld debug builds to the separate image name

### DIFF
--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -118,7 +118,7 @@ jobs:
           context: .
           platforms: ${{ env.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-debug,push-by-digest=true,name-canonical=true,push=true
           build-args: |
             BUILD_DEBUG=true
       -


### PR DESCRIPTION
## Context

It seems like we are publishing two images (with and without debug symbols) under the same `libsql-server` image name.

This PR put `debug` docker images under `libsql-server-debug` name