### PR TITLE
remove digests artifacts from debug build step

### DIFF
--- a/.github/workflows/publish-server.yml
+++ b/.github/workflows/publish-server.yml
@@ -121,20 +121,6 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-debug,push-by-digest=true,name-canonical=true,push=true
           build-args: |
             BUILD_DEBUG=true
-      -
-        name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"          
-      -
-        name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-debug-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
 
   build-arm64:
     permissions: write-all


### PR DESCRIPTION
## Context

Follow up for #1648 PR where we stopped to produce debug build under `libsql-server` name but forgot to remove digests which used at the merge step