### PR TITLE
vector search: neighbors compression (1bit quantization)

### DIFF
--- a/libsql-sqlite3/Makefile.in
+++ b/libsql-sqlite3/Makefile.in
@@ -195,7 +195,7 @@ LIBOBJS0 = alter.lo analyze.lo attach.lo auth.lo \
          sqlite3session.lo select.lo sqlite3rbu.lo status.lo stmt.lo \
          table.lo threads.lo tokenize.lo treeview.lo trigger.lo \
          update.lo userauth.lo upsert.lo util.lo vacuum.lo \
-         vector.lo vectorfloat32.lo vectorfloat64.lo \
+         vector.lo vectorfloat32.lo vectorfloat64.lo vector1bit.lo \
          vectorIndex.lo vectordiskann.lo vectorvtab.lo \
          vdbe.lo vdbeapi.lo vdbeaux.lo vdbeblob.lo vdbemem.lo vdbesort.lo \
          vdbetrace.lo vdbevtab.lo \
@@ -302,6 +302,7 @@ SRC = \
   $(TOP)/src/util.c \
   $(TOP)/src/vacuum.c \
   $(TOP)/src/vector.c \
+  $(TOP)/src/vector1bit.c \
   $(TOP)/src/vectorInt.h \
   $(TOP)/src/vectorfloat32.c \
   $(TOP)/src/vectorfloat64.c \
@@ -1137,6 +1138,9 @@ vacuum.lo:	$(TOP)/src/vacuum.c $(HDR)
 
 vector.lo:	$(TOP)/src/vector.c $(HDR)
 	$(LTCOMPILE) $(TEMP_STORE) -c $(TOP)/src/vector.c
+
+vector1bit.lo:	$(TOP)/src/vector1bit.c $(HDR)
+	$(LTCOMPILE) $(TEMP_STORE) -c $(TOP)/src/vector1bit.c
 
 vectorfloat32.lo:	$(TOP)/src/vectorfloat32.c $(HDR)
 	$(LTCOMPILE) $(TEMP_STORE) -c $(TOP)/src/vectorfloat32.c

--- a/libsql-sqlite3/src/sqliteInt.h
+++ b/libsql-sqlite3/src/sqliteInt.h
@@ -5321,6 +5321,8 @@ int sqlite3AddInt64(i64*,i64);
 int sqlite3SubInt64(i64*,i64);
 int sqlite3MulInt64(i64*,i64);
 int sqlite3AbsInt32(int);
+int sqlite3PopCount32(u32);
+int sqlite3PopCount64(u64);
 #ifdef SQLITE_ENABLE_8_3_NAMES
 void sqlite3FileSuffix3(const char*, char*);
 #else

--- a/libsql-sqlite3/src/sqliteInt.h
+++ b/libsql-sqlite3/src/sqliteInt.h
@@ -5321,8 +5321,6 @@ int sqlite3AddInt64(i64*,i64);
 int sqlite3SubInt64(i64*,i64);
 int sqlite3MulInt64(i64*,i64);
 int sqlite3AbsInt32(int);
-int sqlite3PopCount32(u32);
-int sqlite3PopCount64(u64);
 #ifdef SQLITE_ENABLE_8_3_NAMES
 void sqlite3FileSuffix3(const char*, char*);
 #else

--- a/libsql-sqlite3/src/util.c
+++ b/libsql-sqlite3/src/util.c
@@ -1542,43 +1542,6 @@ int sqlite3SafetyCheckSickOrOk(sqlite3 *db){
   }
 }
 
-
-// [sum(map(int, bin(i)[2:])) for i in range(256)]
-static int BitsCount[256] = {
-  0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
-  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
-  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
-  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
-  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
-  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
-  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
-  4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8,
-};
-
-int sqlite3PopCount32(u32 a){
-#if GCC_VERSION>=5004000 && !defined(__INTEL_COMPILER)
-  return __builtin_popcount(a);
-#else
-  return BitsCount[a >> 24] + BitsCount[(a >> 16) & 0xff] + BitsCount[(a >> 8) & 0xff] + BitsCount[a & 0xff];
-#endif
-}
-
-int sqlite3PopCount64(u64 a){
-#if GCC_VERSION>=5004000 && !defined(__INTEL_COMPILER)
-  return __builtin_popcountll(a);
-#else
-  return sqlite3PopCount32(a >> 32) + sqlite3PopCount32(a & 0xffffffff);
-#endif
-}
-
 /*
 ** Attempt to add, subtract, or multiply the 64-bit signed value iB against
 ** the other 64-bit signed integer at *pA and store the result in *pA.

--- a/libsql-sqlite3/src/util.c
+++ b/libsql-sqlite3/src/util.c
@@ -1542,6 +1542,43 @@ int sqlite3SafetyCheckSickOrOk(sqlite3 *db){
   }
 }
 
+
+// [sum(map(int, bin(i)[2:])) for i in range(256)]
+static int BitsCount[256] = {
+  0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8,
+};
+
+int sqlite3PopCount32(u32 a){
+#if GCC_VERSION>=5004000 && !defined(__INTEL_COMPILER)
+  return __builtin_popcount(a);
+#else
+  return BitsCount[a >> 24] + BitsCount[(a >> 16) & 0xff] + BitsCount[(a >> 8) & 0xff] + BitsCount[a & 0xff];
+#endif
+}
+
+int sqlite3PopCount64(u64 a){
+#if GCC_VERSION>=5004000 && !defined(__INTEL_COMPILER)
+  return __builtin_popcountll(a);
+#else
+  return sqlite3PopCount32(a >> 32) + sqlite3PopCount32(a & 0xffffffff);
+#endif
+}
+
 /*
 ** Attempt to add, subtract, or multiply the 64-bit signed value iB against
 ** the other 64-bit signed integer at *pA and store the result in *pA.

--- a/libsql-sqlite3/src/vector.c
+++ b/libsql-sqlite3/src/vector.c
@@ -41,6 +41,8 @@ size_t vectorDataSize(VectorType type, VectorDims dims){
       return dims * sizeof(float);
     case VECTOR_TYPE_FLOAT64:
       return dims * sizeof(double);
+    case VECTOR_TYPE_1BIT:
+      return (dims + 7) / 8;
     default:
       assert(0);
   }
@@ -111,6 +113,8 @@ float vectorDistanceCos(const Vector *pVector1, const Vector *pVector2){
       return vectorF32DistanceCos(pVector1, pVector2);
     case VECTOR_TYPE_FLOAT64:
       return vectorF64DistanceCos(pVector1, pVector2);
+    case VECTOR_TYPE_1BIT:
+      return vector1BitDistanceHamming(pVector1, pVector2);
     default:
       assert(0);
   }
@@ -381,6 +385,9 @@ void vectorDump(const Vector *pVector){
     case VECTOR_TYPE_FLOAT64:
       vectorF64Dump(pVector);
       break;
+    case VECTOR_TYPE_1BIT:
+      vector1BitDump(pVector);
+      break;
     default:
       assert(0);
   }
@@ -451,6 +458,8 @@ size_t vectorSerializeToBlob(const Vector *pVector, unsigned char *pBlob, size_t
       return vectorF32SerializeToBlob(pVector, pBlob, nBlobSize);
     case VECTOR_TYPE_FLOAT64:
       return vectorF64SerializeToBlob(pVector, pBlob, nBlobSize);
+    case VECTOR_TYPE_1BIT:
+      return vector1BitSerializeToBlob(pVector, pBlob, nBlobSize);
     default:
       assert(0);
   }

--- a/libsql-sqlite3/src/vector.c
+++ b/libsql-sqlite3/src/vector.c
@@ -494,9 +494,7 @@ void vectorConvert(const Vector *pFrom, Vector *pTo){
       bitData[i / 8] = 0;
     }
     for(i = 0; i < pFrom->dims; i++){
-      if( floatData[i] < 0 ){
-        bitData[i / 8] &= ~(1 << (i & 7));
-      }else{
+      if( floatData[i] > 0 ){
         bitData[i / 8] |= (1 << (i & 7));
       }
     }

--- a/libsql-sqlite3/src/vector1bit.c
+++ b/libsql-sqlite3/src/vector1bit.c
@@ -56,17 +56,16 @@ size_t vector1BitSerializeToBlob(
   unsigned char *pBlob,
   size_t nBlobSize
 ){
-  float *elems = pVector->data;
-  unsigned char *pPtr = pBlob;
-  size_t len = 0;
+  u8 *elems = pVector->data;
+  u8 *pPtr = pBlob;
   unsigned i;
 
   assert( pVector->type == VECTOR_TYPE_1BIT );
   assert( pVector->dims <= MAX_VECTOR_SZ );
   assert( nBlobSize >= (pVector->dims + 7) / 8 );
 
-  for(i = 0; i < pVector->dims; i++){
-    elems[i] = pPtr[i];
+  for(i = 0; i < (pVector->dims + 7) / 8; i++){
+    pPtr[i] = elems[i];
   }
   return (pVector->dims + 7) / 8;
 }
@@ -92,7 +91,7 @@ static int BitsCount[256] = {
 };
 
 int vector1BitDistanceHamming(const Vector *v1, const Vector *v2){
-  int sum = 0;
+  int diff = 0;
   u8 *e1 = v1->data;
   u8 *e2 = v2->data;
   int i;
@@ -101,10 +100,10 @@ int vector1BitDistanceHamming(const Vector *v1, const Vector *v2){
   assert( v1->type == VECTOR_TYPE_1BIT );
   assert( v2->type == VECTOR_TYPE_1BIT );
 
-  for(i = 0; i < v1->dims; i++){
-    sum += BitsCount[e1[i]&e2[i]];
+  for(i = 0; i < v1->dims; i += 8){
+    diff += BitsCount[e1[i/8] ^ e2[i/8]];
   }
-  return sum;
+  return diff;
 }
 
 #endif /* !defined(SQLITE_OMIT_VECTOR) */

--- a/libsql-sqlite3/src/vector1bit.c
+++ b/libsql-sqlite3/src/vector1bit.c
@@ -70,6 +70,34 @@ size_t vector1BitSerializeToBlob(
   return (pVector->dims + 7) / 8;
 }
 
+// [sum(map(int, bin(i)[2:])) for i in range(256)]
+static int BitsCount[256] = {
+  0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8,
+};
+
+static inline int sqlite3PopCount32(u32 a){
+#if GCC_VERSION>=5004000 && !defined(__INTEL_COMPILER)
+  return __builtin_popcount(a);
+#else
+  return BitsCount[a >> 24] + BitsCount[(a >> 16) & 0xff] + BitsCount[(a >> 8) & 0xff] + BitsCount[a & 0xff];
+#endif
+}
+
 int vector1BitDistanceHamming(const Vector *v1, const Vector *v2){
   int diff = 0;
   u8 *e1U8 = v1->data;

--- a/libsql-sqlite3/src/vector1bit.c
+++ b/libsql-sqlite3/src/vector1bit.c
@@ -1,0 +1,110 @@
+/*
+** 2024-07-04
+**
+** Copyright 2024 the libSQL authors
+**
+** Permission is hereby granted, free of charge, to any person obtaining a copy of
+** this software and associated documentation files (the "Software"), to deal in
+** the Software without restriction, including without limitation the rights to
+** use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+** the Software, and to permit persons to whom the Software is furnished to do so,
+** subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in all
+** copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+** FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+** COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+** IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+** CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**
+******************************************************************************
+**
+** 1-bit vector format utilities.
+*/
+#ifndef SQLITE_OMIT_VECTOR
+#include "sqliteInt.h"
+
+#include "vectorInt.h"
+
+#include <math.h>
+
+/**************************************************************************
+** Utility routines for debugging
+**************************************************************************/
+
+void vector1BitDump(const Vector *pVec){
+  u8 *elems = pVec->data;
+  unsigned i;
+
+  assert( pVec->type == VECTOR_TYPE_1BIT );
+
+  for(i = 0; i < pVec->dims; i++){
+    printf("%d ", ((elems[i / 8] >> (i & 7)) & 1) ? +1 : -1);
+  }
+  printf("\n");
+}
+
+/**************************************************************************
+** Utility routines for vector serialization and deserialization
+**************************************************************************/
+
+size_t vector1BitSerializeToBlob(
+  const Vector *pVector,
+  unsigned char *pBlob,
+  size_t nBlobSize
+){
+  float *elems = pVector->data;
+  unsigned char *pPtr = pBlob;
+  size_t len = 0;
+  unsigned i;
+
+  assert( pVector->type == VECTOR_TYPE_1BIT );
+  assert( pVector->dims <= MAX_VECTOR_SZ );
+  assert( nBlobSize >= (pVector->dims + 7) / 8 );
+
+  for(i = 0; i < pVector->dims; i++){
+    elems[i] = pPtr[i];
+  }
+  return (pVector->dims + 7) / 8;
+}
+
+// [sum(map(int, bin(i)[2:])) for i in range(256)]
+static int BitsCount[256] = {
+  0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,
+  4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8,
+};
+
+int vector1BitDistanceHamming(const Vector *v1, const Vector *v2){
+  int sum = 0;
+  u8 *e1 = v1->data;
+  u8 *e2 = v2->data;
+  int i;
+
+  assert( v1->dims == v2->dims );
+  assert( v1->type == VECTOR_TYPE_1BIT );
+  assert( v2->type == VECTOR_TYPE_1BIT );
+
+  for(i = 0; i < v1->dims; i++){
+    sum += BitsCount[e1[i]&e2[i]];
+  }
+  return sum;
+}
+
+#endif /* !defined(SQLITE_OMIT_VECTOR) */

--- a/libsql-sqlite3/src/vector1bit.c
+++ b/libsql-sqlite3/src/vector1bit.c
@@ -41,10 +41,11 @@ void vector1BitDump(const Vector *pVec){
 
   assert( pVec->type == VECTOR_TYPE_1BIT );
 
+  printf("f1bit: [");
   for(i = 0; i < pVec->dims; i++){
-    printf("%d ", ((elems[i / 8] >> (i & 7)) & 1) ? +1 : -1);
+    printf("%s%d", i == 0 ? "" : ", ", ((elems[i / 8] >> (i & 7)) & 1) ? +1 : -1);
   }
-  printf("\n");
+  printf("]\n");
 }
 
 /**************************************************************************

--- a/libsql-sqlite3/src/vectorIndex.c
+++ b/libsql-sqlite3/src/vectorIndex.c
@@ -396,10 +396,10 @@ struct VectorParamName {
 };
 
 static struct VectorParamName VECTOR_PARAM_NAMES[] = {
-  { "type",               VECTOR_INDEX_TYPE_PARAM_ID,    0, "diskann", VECTOR_INDEX_TYPE_DISKANN },
-  { "metric",             VECTOR_METRIC_TYPE_PARAM_ID,   0, "cosine",  VECTOR_METRIC_TYPE_COS },
-  { "metric",             VECTOR_METRIC_TYPE_PARAM_ID,   0, "l2",      VECTOR_METRIC_TYPE_L2 },
-  { "compress_neighbors", VECTOR_METRIC_TYPE_PARAM_ID,   0, "1bit",    VECTOR_TYPE_1BIT },
+  { "type",               VECTOR_INDEX_TYPE_PARAM_ID,         0, "diskann", VECTOR_INDEX_TYPE_DISKANN },
+  { "metric",             VECTOR_METRIC_TYPE_PARAM_ID,        0, "cosine",  VECTOR_METRIC_TYPE_COS },
+  { "metric",             VECTOR_METRIC_TYPE_PARAM_ID,        0, "l2",      VECTOR_METRIC_TYPE_L2 },
+  { "compress_neighbors", VECTOR_COMPRESS_NEIGHBORS_PARAM_ID, 0, "1bit",    VECTOR_TYPE_1BIT },
   { "alpha",              VECTOR_PRUNING_ALPHA_PARAM_ID, 2, 0, 0 },
   { "search_l",           VECTOR_SEARCH_L_PARAM_ID,      1, 0, 0 },
   { "insert_l",           VECTOR_INSERT_L_PARAM_ID,      1, 0, 0 },

--- a/libsql-sqlite3/src/vectorIndex.c
+++ b/libsql-sqlite3/src/vectorIndex.c
@@ -261,7 +261,7 @@ int vectorInRowAlloc(sqlite3 *db, const UnpackedRecord *pRecord, VectorInRow *pV
     vectorInitFromBlob(pVectorInRow->pVector, sqlite3_value_blob(pVectorValue), sqlite3_value_bytes(pVectorValue));
   } else if( sqlite3_value_type(pVectorValue) == SQLITE_TEXT ){
     // users can put strings (e.g. '[1,2,3]') in the table and we should process them correctly
-    if( vectorParse(pVectorValue, pVectorInRow->pVector, pzErrMsg) != 0 ){
+    if( vectorParseWithType(pVectorValue, pVectorInRow->pVector, pzErrMsg) != 0 ){
       rc = SQLITE_ERROR;
       goto out;
     }
@@ -982,7 +982,7 @@ int vectorIndexSearch(
     rc = SQLITE_NOMEM_BKPT;
     goto out;
   }
-  if( vectorParse(argv[1], pVector, pzErrMsg) != 0 ){
+  if( vectorParseWithType(argv[1], pVector, pzErrMsg) != 0 ){
     rc = SQLITE_ERROR;
     goto out;
   }

--- a/libsql-sqlite3/src/vectorIndex.c
+++ b/libsql-sqlite3/src/vectorIndex.c
@@ -396,13 +396,14 @@ struct VectorParamName {
 };
 
 static struct VectorParamName VECTOR_PARAM_NAMES[] = {
-  { "type",          VECTOR_INDEX_TYPE_PARAM_ID,    0, "diskann", VECTOR_INDEX_TYPE_DISKANN },
-  { "metric",        VECTOR_METRIC_TYPE_PARAM_ID,   0, "cosine", VECTOR_METRIC_TYPE_COS },
-  { "metric",        VECTOR_METRIC_TYPE_PARAM_ID,   0, "l2",     VECTOR_METRIC_TYPE_L2 },
-  { "alpha",         VECTOR_PRUNING_ALPHA_PARAM_ID, 2, 0, 0 },
-  { "search_l",      VECTOR_SEARCH_L_PARAM_ID,      1, 0, 0 },
-  { "insert_l",      VECTOR_INSERT_L_PARAM_ID,      1, 0, 0 },
-  { "max_neighbors", VECTOR_MAX_NEIGHBORS_PARAM_ID, 1, 0, 0 },
+  { "type",               VECTOR_INDEX_TYPE_PARAM_ID,    0, "diskann", VECTOR_INDEX_TYPE_DISKANN },
+  { "metric",             VECTOR_METRIC_TYPE_PARAM_ID,   0, "cosine",  VECTOR_METRIC_TYPE_COS },
+  { "metric",             VECTOR_METRIC_TYPE_PARAM_ID,   0, "l2",      VECTOR_METRIC_TYPE_L2 },
+  { "compress_neighbors", VECTOR_METRIC_TYPE_PARAM_ID,   0, "1bit",    VECTOR_TYPE_1BIT },
+  { "alpha",              VECTOR_PRUNING_ALPHA_PARAM_ID, 2, 0, 0 },
+  { "search_l",           VECTOR_SEARCH_L_PARAM_ID,      1, 0, 0 },
+  { "insert_l",           VECTOR_INSERT_L_PARAM_ID,      1, 0, 0 },
+  { "max_neighbors",      VECTOR_MAX_NEIGHBORS_PARAM_ID, 1, 0, 0 },
 };
 
 static int parseVectorIdxParam(const char *zParam, VectorIdxParams *pParams, const char **pErrMsg) {
@@ -802,7 +803,7 @@ int vectorIndexCreate(Parse *pParse, const Index *pIdx, const char *zDbSName, co
   int i, rc = SQLITE_OK;
   int dims, type;
   int hasLibsqlVectorIdxFn = 0, hasCollation = 0;
-  const char *pzErrMsg;
+  const char *pzErrMsg = NULL;
 
   assert( zDbSName != NULL );
 
@@ -914,9 +915,13 @@ int vectorIndexCreate(Parse *pParse, const Index *pIdx, const char *zDbSName, co
     sqlite3ErrorMsg(pParse, "vector index: unsupported for tables without ROWID and composite primary key");
     return CREATE_FAIL;
   }
-  rc = diskAnnCreateIndex(db, zDbSName, pIdx->zName, &idxKey, &idxParams);
+  rc = diskAnnCreateIndex(db, zDbSName, pIdx->zName, &idxKey, &idxParams, &pzErrMsg);
   if( rc != SQLITE_OK ){
-    sqlite3ErrorMsg(pParse, "vector index: unable to initialize diskann");
+    if( pzErrMsg != NULL ){
+      sqlite3ErrorMsg(pParse, "vector index: unable to initialize diskann: %s", pzErrMsg);
+    }else{
+      sqlite3ErrorMsg(pParse, "vector index: unable to initialize diskann");
+    }
     return CREATE_FAIL;
   }
   rc = insertIndexParameters(db, zDbSName, pIdx->zName, &idxParams);

--- a/libsql-sqlite3/src/vectorIndexInt.h
+++ b/libsql-sqlite3/src/vectorIndexInt.h
@@ -100,43 +100,45 @@ typedef u8 MetricType;
 */
 
 /* format version which can help to upgrade vector on-disk format without breaking older version of the db */
-#define VECTOR_FORMAT_PARAM_ID         1
+#define VECTOR_FORMAT_PARAM_ID              1
 /*
  * 1 - initial version
 */
-#define VECTOR_FORMAT_DEFAULT          1
+#define VECTOR_FORMAT_DEFAULT               1
 
 /* type of the vector index */
-#define VECTOR_INDEX_TYPE_PARAM_ID     2
-#define VECTOR_INDEX_TYPE_DISKANN      1
+#define VECTOR_INDEX_TYPE_PARAM_ID          2
+#define VECTOR_INDEX_TYPE_DISKANN           1
 
 /* type of the underlying vector for the vector index */
-#define VECTOR_TYPE_PARAM_ID           3
+#define VECTOR_TYPE_PARAM_ID                3
 /* dimension of the underlying vector for the vector index */
-#define VECTOR_DIM_PARAM_ID            4
+#define VECTOR_DIM_PARAM_ID                 4
 
 /* metric type used for comparing two vectors */
-#define VECTOR_METRIC_TYPE_PARAM_ID    5
-#define VECTOR_METRIC_TYPE_COS         1
-#define VECTOR_METRIC_TYPE_L2          2
+#define VECTOR_METRIC_TYPE_PARAM_ID         5
+#define VECTOR_METRIC_TYPE_COS              1
+#define VECTOR_METRIC_TYPE_L2               2
 
 /* block size */
-#define VECTOR_BLOCK_SIZE_PARAM_ID     6
-#define VECTOR_BLOCK_SIZE_DEFAULT      128
+#define VECTOR_BLOCK_SIZE_PARAM_ID          6
+#define VECTOR_BLOCK_SIZE_DEFAULT           128
 
-#define VECTOR_PRUNING_ALPHA_PARAM_ID  7
-#define VECTOR_PRUNING_ALPHA_DEFAULT   1.2
+#define VECTOR_PRUNING_ALPHA_PARAM_ID       7
+#define VECTOR_PRUNING_ALPHA_DEFAULT        1.2
 
-#define VECTOR_INSERT_L_PARAM_ID       8
-#define VECTOR_INSERT_L_DEFAULT        70
+#define VECTOR_INSERT_L_PARAM_ID            8
+#define VECTOR_INSERT_L_DEFAULT             70
 
-#define VECTOR_SEARCH_L_PARAM_ID       9
-#define VECTOR_SEARCH_L_DEFAULT        200
+#define VECTOR_SEARCH_L_PARAM_ID            9
+#define VECTOR_SEARCH_L_DEFAULT             200
 
-#define VECTOR_MAX_NEIGHBORS_PARAM_ID  10
+#define VECTOR_MAX_NEIGHBORS_PARAM_ID       10
+
+#define VECTOR_COMPRESS_NEIGHBORS_PARAM_ID  11
 
 /* total amount of vector index parameters */
-#define VECTOR_PARAM_IDS_COUNT         9
+#define VECTOR_PARAM_IDS_COUNT              11
 
 /*
  * Vector index parameters are stored in simple binary format (1 byte tag + 8 byte u64 integer / f64 float)
@@ -218,7 +220,7 @@ int vectorOutRowsPut(VectorOutRows *, int, int, const u64 *, sqlite3_value *);
 void vectorOutRowsGet(sqlite3_context *, const VectorOutRows *, int, int);
 void vectorOutRowsFree(sqlite3 *, VectorOutRows *);
 
-int diskAnnCreateIndex(sqlite3 *, const char *, const char *, const VectorIdxKey *, VectorIdxParams *);
+int diskAnnCreateIndex(sqlite3 *, const char *, const char *, const VectorIdxKey *, VectorIdxParams *, const char **);
 int diskAnnClearIndex(sqlite3 *, const char *, const char *);
 int diskAnnDropIndex(sqlite3 *, const char *, const char *);
 int diskAnnOpenIndex(sqlite3 *, const char *, const char *, const VectorIdxParams *, DiskAnnIndex **);

--- a/libsql-sqlite3/src/vectorIndexInt.h
+++ b/libsql-sqlite3/src/vectorIndexInt.h
@@ -73,10 +73,10 @@ int nodeEdgesMetadataOffset(const DiskAnnIndex *pIndex);
 void nodeBinInit(const DiskAnnIndex *pIndex, BlobSpot *pBlobSpot, u64 nRowid, Vector *pVector);
 void nodeBinVector(const DiskAnnIndex *pIndex, const BlobSpot *pBlobSpot, Vector *pVector);
 u16 nodeBinEdges(const DiskAnnIndex *pIndex, const BlobSpot *pBlobSpot);
-void nodeBinEdge(const DiskAnnIndex *pIndex, const BlobSpot *pBlobSpot, int iEdge, u64 *pRowid, Vector *pVector);
+void nodeBinEdge(const DiskAnnIndex *pIndex, const BlobSpot *pBlobSpot, int iEdge, u64 *pRowid, float *distance, Vector *pVector);
 int nodeBinEdgeFindIdx(const DiskAnnIndex *pIndex, const BlobSpot *pBlobSpot, u64 nRowid);
 void nodeBinPruneEdges(const DiskAnnIndex *pIndex, BlobSpot *pBlobSpot, int nPruned);
-void nodeBinReplaceEdge(const DiskAnnIndex *pIndex, BlobSpot *pBlobSpot, int iReplace, u64 nRowid, Vector *pVector);
+void nodeBinReplaceEdge(const DiskAnnIndex *pIndex, BlobSpot *pBlobSpot, int iReplace, u64 nRowid, float distance, Vector *pVector);
 void nodeBinDeleteEdge(const DiskAnnIndex *pIndex, BlobSpot *pBlobSpot, int iDelete);
 void nodeBinDebug(const DiskAnnIndex *pIndex, const BlobSpot *pBlobSpot);
 
@@ -102,9 +102,11 @@ typedef u8 MetricType;
 /* format version which can help to upgrade vector on-disk format without breaking older version of the db */
 #define VECTOR_FORMAT_PARAM_ID              1
 /*
- * 1 - initial version
+ * 1 - v1 version; node block format: [node meta] [node vector] [edge vectors] ... [ [u64 unused               ] [u64 edge rowid] ] ...
+ * 2 - v2 version; node block format: [node meta] [node vector] [edge vectors] ... [ [u32 unused] [f32 distance] [u64 edge rowid] ] ...
 */
-#define VECTOR_FORMAT_DEFAULT               1
+#define VECTOR_FORMAT_V1                    1
+#define VECTOR_FORMAT_DEFAULT               2
 
 /* type of the vector index */
 #define VECTOR_INDEX_TYPE_PARAM_ID          2

--- a/libsql-sqlite3/src/vectorInt.h
+++ b/libsql-sqlite3/src/vectorInt.h
@@ -65,13 +65,6 @@ size_t vectorSerializeToBlob   (const Vector *, unsigned char *, size_t);
 size_t vectorF32SerializeToBlob(const Vector *, unsigned char *, size_t);
 size_t vectorF64SerializeToBlob(const Vector *, unsigned char *, size_t);
 
-/*
- * Deserializes vector from the blob in little-endian format according to the IEEE-754 standard
-*/
-size_t vectorDeserializeFromBlob   (Vector *, const unsigned char *, size_t);
-size_t vectorF32DeserializeFromBlob(Vector *, const unsigned char *, size_t);
-size_t vectorF64DeserializeFromBlob(Vector *, const unsigned char *, size_t);
-
 /* 
  * Calculates cosine distance between two vectors (vector must have same type and same dimensions)
 */
@@ -91,16 +84,15 @@ double vectorF64DistanceL2(const Vector *, const Vector *);
  * LibSQL can append one trailing byte in the end of final blob. This byte will be later used to determine type of the blob
  * By default, blob with even length will be treated as a f32 blob
 */
-void vectorSerialize   (sqlite3_context *, const Vector *);
-void vectorF32Serialize(sqlite3_context *, const Vector *);
-void vectorF64Serialize(sqlite3_context *, const Vector *);
+void vectorSerializeWithType(sqlite3_context *, const Vector *);
 
 /*
  * Parses Vector content from the blob; vector type and dimensions must be filled already
 */
 int vectorParseSqliteBlob   (sqlite3_value *, Vector *, char **);
-int vectorF32ParseSqliteBlob(sqlite3_value *, Vector *, char **);
-int vectorF64ParseSqliteBlob(sqlite3_value *, Vector *, char **);
+
+void vectorF32DeserializeFromBlob(Vector *, const unsigned char *, size_t);
+void vectorF64DeserializeFromBlob(Vector *, const unsigned char *, size_t);
 
 void vectorInitStatic(Vector *, VectorType, const unsigned char *, size_t);
 void vectorInitFromBlob(Vector *, const unsigned char *, size_t);

--- a/libsql-sqlite3/src/vectorInt.h
+++ b/libsql-sqlite3/src/vectorInt.h
@@ -102,10 +102,12 @@ int vectorParseSqliteBlob   (sqlite3_value *, Vector *, char **);
 void vectorF32DeserializeFromBlob(Vector *, const unsigned char *, size_t);
 void vectorF64DeserializeFromBlob(Vector *, const unsigned char *, size_t);
 
-void vectorInitStatic(Vector *, VectorType, const unsigned char *, size_t);
+void vectorInitStatic(Vector *, VectorType, VectorDims, void *);
 void vectorInitFromBlob(Vector *, const unsigned char *, size_t);
 void vectorF32InitFromBlob(Vector *, const unsigned char *, size_t);
 void vectorF64InitFromBlob(Vector *, const unsigned char *, size_t);
+
+void vectorConvert(const Vector *, Vector *);
 
 /* Detect type and dimension of vector provided with first parameter of sqlite3_value * type */
 int detectVectorParameters(sqlite3_value *, int, int *, int *, char **);

--- a/libsql-sqlite3/src/vectorInt.h
+++ b/libsql-sqlite3/src/vectorInt.h
@@ -42,7 +42,7 @@ struct Vector {
 size_t vectorDataSize(VectorType, VectorDims);
 Vector *vectorAlloc(VectorType, VectorDims);
 void vectorFree(Vector *v);
-int vectorParse(sqlite3_value *, Vector *, char **);
+int vectorParseWithType(sqlite3_value *, Vector *, char **);
 void vectorInit(Vector *, VectorType, VectorDims, void *);
 
 /*
@@ -97,7 +97,7 @@ void vectorSerializeWithType(sqlite3_context *, const Vector *);
 /*
  * Parses Vector content from the blob; vector type and dimensions must be filled already
 */
-int vectorParseSqliteBlob   (sqlite3_value *, Vector *, char **);
+int vectorParseSqliteBlobWithType(sqlite3_value *, Vector *, char **);
 
 void vectorF32DeserializeFromBlob(Vector *, const unsigned char *, size_t);
 void vectorF64DeserializeFromBlob(Vector *, const unsigned char *, size_t);

--- a/libsql-sqlite3/src/vectorInt.h
+++ b/libsql-sqlite3/src/vectorInt.h
@@ -24,6 +24,7 @@ typedef u32 VectorDims;
 */
 #define VECTOR_TYPE_FLOAT32 1
 #define VECTOR_TYPE_FLOAT64 2
+#define VECTOR_TYPE_1BIT    3
 
 #define VECTOR_FLAGS_STATIC 1
 
@@ -48,8 +49,9 @@ void vectorInit(Vector *, VectorType, VectorDims, void *);
  * Dumps vector on the console (used only for debugging)
 */
 void vectorDump   (const Vector *v);
-void vectorF32Dump(const Vector *v);
-void vectorF64Dump(const Vector *v);
+void vectorF32Dump (const Vector *v);
+void vectorF64Dump (const Vector *v);
+void vector1BitDump(const Vector *v);
 
 /* 
  * Converts vector to the text representation and write the result to the sqlite3_context
@@ -61,9 +63,10 @@ void vectorF64MarshalToText(sqlite3_context *, const Vector *);
 /* 
  * Serializes vector to the blob in little-endian format according to the IEEE-754 standard
 */
-size_t vectorSerializeToBlob   (const Vector *, unsigned char *, size_t);
-size_t vectorF32SerializeToBlob(const Vector *, unsigned char *, size_t);
-size_t vectorF64SerializeToBlob(const Vector *, unsigned char *, size_t);
+size_t vectorSerializeToBlob    (const Vector *, unsigned char *, size_t);
+size_t vectorF32SerializeToBlob (const Vector *, unsigned char *, size_t);
+size_t vectorF64SerializeToBlob (const Vector *, unsigned char *, size_t);
+size_t vector1BitSerializeToBlob(const Vector *, unsigned char *, size_t);
 
 /* 
  * Calculates cosine distance between two vectors (vector must have same type and same dimensions)
@@ -71,6 +74,11 @@ size_t vectorF64SerializeToBlob(const Vector *, unsigned char *, size_t);
 float vectorDistanceCos    (const Vector *, const Vector *);
 float vectorF32DistanceCos (const Vector *, const Vector *);
 double vectorF64DistanceCos(const Vector *, const Vector *);
+
+/*
+ * Calculates hamming distance between two 1-bit vectors (vector must have same dimensions)
+*/
+int vector1BitDistanceHamming(const Vector *, const Vector *);
 
 /*
  * Calculates L2 distance between two vectors (vector must have same type and same dimensions)

--- a/libsql-sqlite3/src/vectordiskann.c
+++ b/libsql-sqlite3/src/vectordiskann.c
@@ -107,9 +107,9 @@ struct DiskAnnNode {
  * so caller which puts nodes in the context can forget about resource managmenet (context will take care of this)
 */
 struct DiskAnnSearchCtx {
-  VectorPair query;       /* initial query vector; user query for SELECT and row vector for INSERT */
-  DiskAnnNode **aCandidates;    /* array of candidates ordered by distance to the query (ascending) */
-  float *aDistances;            /* array of distances to the query vector */
+  VectorPair query;             /* initial query vector; user query for SELECT and row vector for INSERT */
+  DiskAnnNode **aCandidates;    /* array of unvisited candidates ordered by distance (possibly approximate) to the query (ascending) */
+  float *aDistances;            /* array of distances (possible approximate) to the query vector */
   unsigned int nCandidates;     /* current size of aCandidates/aDistances arrays */
   unsigned int maxCandidates;   /* max size of aCandidates/aDistances arrays */
   DiskAnnNode **aTopCandidates; /* top candidates with exact distance calculated */

--- a/libsql-sqlite3/src/vectordiskann.c
+++ b/libsql-sqlite3/src/vectordiskann.c
@@ -54,7 +54,7 @@
 #include "sqliteInt.h"
 #include "vectorIndexInt.h"
 
-#define SQLITE_VECTOR_TRACE
+// #define SQLITE_VECTOR_TRACE
 #if defined(SQLITE_DEBUG) && defined(SQLITE_VECTOR_TRACE)
 #define DiskAnnTrace(X) sqlite3DebugPrintf X;
 #else

--- a/libsql-sqlite3/src/vectordiskann.c
+++ b/libsql-sqlite3/src/vectordiskann.c
@@ -954,6 +954,11 @@ static void diskAnnNodeFree(DiskAnnNode *pNode){
 }
 
 static int diskAnnSearchCtxInit(const DiskAnnIndex *pIndex, DiskAnnSearchCtx *pCtx, const Vector* pQuery, int maxCandidates, int topCandidates, int blobMode){
+  if( initVectorPair(pIndex->nNodeVectorType, pIndex->nEdgeVectorType, pIndex->nVectorDims, &pCtx->query) != 0 ){
+    return SQLITE_NOMEM_BKPT;
+  }
+  loadVectorPair(&pCtx->query, pQuery);
+
   pCtx->aDistances = sqlite3_malloc(maxCandidates * sizeof(double));
   pCtx->aCandidates = sqlite3_malloc(maxCandidates * sizeof(DiskAnnNode*));
   pCtx->nCandidates = 0;
@@ -965,10 +970,6 @@ static int diskAnnSearchCtxInit(const DiskAnnIndex *pIndex, DiskAnnSearchCtx *pC
   pCtx->visitedList = NULL;
   pCtx->nUnvisited = 0;
   pCtx->blobMode = blobMode;
-  if( initVectorPair(pIndex->nNodeVectorType, pIndex->nEdgeVectorType, pIndex->nVectorDims, &pCtx->query) != 0 ){
-    return SQLITE_NOMEM_BKPT;
-  }
-  loadVectorPair(&pCtx->query, pQuery);
 
   if( pCtx->aDistances != NULL && pCtx->aCandidates != NULL && pCtx->aTopDistances != NULL && pCtx->aTopCandidates != NULL ){
     return SQLITE_OK;

--- a/libsql-sqlite3/src/vectorfloat32.c
+++ b/libsql-sqlite3/src/vectorfloat32.c
@@ -41,10 +41,11 @@ void vectorF32Dump(const Vector *pVec){
 
   assert( pVec->type == VECTOR_TYPE_FLOAT32 );
 
+  printf("f32: [");
   for(i = 0; i < pVec->dims; i++){
-    printf("%f ", elems[i]);
+    printf("%s%f", i == 0 ? "" : ", ", elems[i]);
   }
-  printf("\n");
+  printf("]\n");
 }
 
 /**************************************************************************
@@ -92,34 +93,6 @@ size_t vectorF32SerializeToBlob(
     pPtr += serializeF32(pPtr, elems[i]);
   }
   return sizeof(float) * pVector->dims;
-}
-
-void vectorF32Serialize(
-  sqlite3_context *context,
-  const Vector *pVector
-){
-  float *elems = pVector->data;
-  unsigned char *pBlob;
-  size_t nBlobSize;
-
-  assert( pVector->type == VECTOR_TYPE_FLOAT32 );
-  assert( pVector->dims <= MAX_VECTOR_SZ );
-
-  nBlobSize = vectorDataSize(pVector->type, pVector->dims);
-
-  if( nBlobSize == 0 ){
-    sqlite3_result_zeroblob(context, 0);
-    return;
-  }
-
-  pBlob = sqlite3_malloc64(nBlobSize);
-  if( pBlob == NULL ){
-    sqlite3_result_error_nomem(context);
-    return;
-  }
-
-  vectorF32SerializeToBlob(pVector, pBlob, nBlobSize);
-  sqlite3_result_blob(context, (char*)pBlob, nBlobSize, sqlite3_free);
 }
 
 #define SINGLE_FLOAT_CHAR_LIMIT 32

--- a/libsql-sqlite3/src/vectorfloat32.c
+++ b/libsql-sqlite3/src/vectorfloat32.c
@@ -94,26 +94,6 @@ size_t vectorF32SerializeToBlob(
   return sizeof(float) * pVector->dims;
 }
 
-size_t vectorF32DeserializeFromBlob(
-  Vector *pVector,
-  const unsigned char *pBlob,
-  size_t nBlobSize
-){
-  float *elems = pVector->data;
-  unsigned i;
-  pVector->type = VECTOR_TYPE_FLOAT32;
-  pVector->dims = nBlobSize / sizeof(float);
-
-  assert( pVector->dims <= MAX_VECTOR_SZ );
-  assert( nBlobSize % 2 == 0 || pBlob[nBlobSize - 1] == VECTOR_TYPE_FLOAT32 );
-
-  for(i = 0; i < pVector->dims; i++){
-    elems[i] = deserializeF32(pBlob);
-    pBlob += sizeof(float);
-  }
-  return vectorDataSize(pVector->type, pVector->dims);
-}
-
 void vectorF32Serialize(
   sqlite3_context *context,
   const Vector *pVector
@@ -220,32 +200,22 @@ void vectorF32InitFromBlob(Vector *pVector, const unsigned char *pBlob, size_t n
   pVector->data = (void*)pBlob;
 }
 
-int vectorF32ParseSqliteBlob(
-  sqlite3_value *arg,
+void vectorF32DeserializeFromBlob(
   Vector *pVector,
-  char **pzErr
+  const unsigned char *pBlob,
+  size_t nBlobSize
 ){
-  const unsigned char *pBlob;
   float *elems = pVector->data;
   unsigned i;
 
   assert( pVector->type == VECTOR_TYPE_FLOAT32 );
   assert( 0 <= pVector->dims && pVector->dims <= MAX_VECTOR_SZ );
-  assert( sqlite3_value_type(arg) == SQLITE_BLOB );
-
-  pBlob = sqlite3_value_blob(arg);
-  if( sqlite3_value_bytes(arg) < sizeof(float) * pVector->dims ){
-    *pzErr = sqlite3_mprintf("invalid f32 vector: not enough bytes for all dimensions");
-    goto error;
-  }
+  assert( nBlobSize >= pVector->dims * sizeof(float) );
 
   for(i = 0; i < pVector->dims; i++){
     elems[i] = deserializeF32(pBlob);
     pBlob += sizeof(float);
   }
-  return 0;
-error:
-  return -1;
 }
 
 #endif /* !defined(SQLITE_OMIT_VECTOR) */

--- a/libsql-sqlite3/src/vectorfloat64.c
+++ b/libsql-sqlite3/src/vectorfloat64.c
@@ -38,10 +38,14 @@
 void vectorF64Dump(const Vector *pVec){
   double *elems = pVec->data;
   unsigned i;
+
+  assert( pVec->type == VECTOR_TYPE_FLOAT64 );
+
+  printf("f64: [");
   for(i = 0; i < pVec->dims; i++){
-    printf("%lf ", elems[i]);
+    printf("%s%lf", i == 0 ? "" : ", ", elems[i]);
   }
-  printf("\n");
+  printf("]\n");
 }
 
 /**************************************************************************

--- a/libsql-sqlite3/test/libsql_vector_index.test
+++ b/libsql-sqlite3/test/libsql_vector_index.test
@@ -268,9 +268,19 @@ do_execsql_test vector-transaction {
   SELECT * FROM vector_top_k('t_transaction_idx', vector('[1,2]'), 2);
 } {3 4 1 2}
 
+do_execsql_test vector-1bit {
+  CREATE TABLE t_1bit( v FLOAT32(3) );
+  CREATE INDEX t_1bit_idx ON t_1bit( libsql_vector_idx(v, 'compress_neighbors=1bit') );
+  INSERT INTO t_1bit VALUES (vector('[-1,-1,1]'));
+  INSERT INTO t_1bit VALUES (vector('[-1,1,-1.5]'));
+  INSERT INTO t_1bit VALUES (vector('[1,-1,-1]'));
+  INSERT INTO t_1bit VALUES (vector('[-1,-1,-1]'));
+  SELECT rowid FROM vector_top_k('t_1bit_idx', vector('[1,-1,-1]'), 4);
+} {3 4 2 1}
+
 do_execsql_test vector-all-params {
   CREATE TABLE t_all_params ( emb FLOAT32(2) );
-  CREATE INDEX t_all_params_idx ON t_all_params(libsql_vector_idx(emb, 'type=diskann', 'metric=cos', 'alpha=1.2', 'search_l=200', 'insert_l=70', 'max_neighbors=6'));
+  CREATE INDEX t_all_params_idx ON t_all_params(libsql_vector_idx(emb, 'type=diskann', 'metric=cos', 'alpha=1.2', 'search_l=200', 'insert_l=70', 'max_neighbors=6', 'compress_neighbors=1bit'));
   INSERT INTO t_all_params VALUES (vector('[1,2]')), (vector('[3,4]'));
   SELECT * FROM vector_top_k('t_all_params_idx', vector('[1,2]'), 2);
 } {1 2}

--- a/libsql-sqlite3/tool/mksqlite3c.tcl
+++ b/libsql-sqlite3/tool/mksqlite3c.tcl
@@ -468,6 +468,7 @@ set flist {
 
    json.c
    vector.c
+   vector1bit.c
    vectordiskann.c
    vectorfloat32.c
    vectorfloat64.c


### PR DESCRIPTION
## Context

This PR introduces support for compressed edges representation in DiskANN implementation. For now, only `1bit` quantization is supported with the corresponding index parameter: `libsql_vector_idx(e, 'compress_neighbors=1bit')`.

In order to support compressed representation `DiskANN` search procedure were changed and now it supports 2 list of nodes:
1. `aCandidates` - list of **unvisited** candidates ordered by distance calculated with edge vector type (it will be compressed if index uses compression of edges)
2. `aTopCandidates` - list of top **visited** candidates ordered by the exact distance calculated with node vector type

This was done in order to always compare distances produced by the same vector representation: `aCandidates` ordered by distance between vector of "edge type" (potentially compressed, but not always) while `aTopCandidates` ordered by distance between vector of "node type" (exact)

## Changes

- Introduce vector index parameter: `compress_neighbors=1bit`
- Implement basic `vector1bit` functions
    * For now 1BIT vectors is not exposed internally and can be used only inside the diskann
- Extended `DiskAnnSearchCtx` with `aTopCandidates` list
- Extend binary on-disk format to `v2` to store distance from node to edges
```
v1 version: [node meta] [node vector] [edge vectors] ... [ [u64 unused               ] [u64 edge rowid] ] ...
v2 version: [node meta] [node vector] [edge vectors] ... [ [u32 unused] [f32 distance] [u64 edge rowid] ] ...
```