### PR TITLE
libsql: add `tls` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6251,7 +6251,6 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls-native-certs 0.7.1",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "tokio",
@@ -6261,7 +6260,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 0.26.3",
 ]
 
 [[package]]

--- a/libsql-replication/Cargo.toml
+++ b/libsql-replication/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic = { version = "0.11", features = ["tls"] }
+tonic = { version = "0.11", default-features = false, features = ["codegen", "prost"] }
 prost = "0.12"
 libsql-sys = { version = "0.7", path = "../libsql-sys", default-features = false, features = ["wal", "rusqlite", "api"] }
 libsql-wal = { path = "../libsql-wal/", optional = true }

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -16,7 +16,7 @@ libsql-hrana = { version = "0.2", path = "../libsql-hrana", optional = true }
 tokio = { version = "1.29.1", features = ["sync"], optional = true }
 tokio-util = { version = "0.7", features = ["io-util", "codec"], optional = true }
 parking_lot = { version = "0.12.1", optional = true }
-hyper = { workspace = true, features = ["client", "stream"], optional = true }
+hyper = { version = "0.14", features = ["client", "http1", "http2", "stream", "runtime"], optional = true }
 hyper-rustls = { version = "0.25", features = ["webpki-roots"], optional = true }
 base64 = { version = "0.21", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
@@ -31,7 +31,7 @@ anyhow = { version = "1.0.71", optional = true }
 bytes = { version = "1.4.0", features = ["serde"], optional = true }
 uuid = { version = "1.4.0", features = ["v4", "serde"], optional = true }
 tokio-stream = { version = "0.1.14", optional = true }
-tonic = { version = "0.11", features = ["tls", "tls-roots", "tls-webpki-roots"], optional = true}
+tonic = { version = "0.11", optional = true}
 tonic-web = { version = "0.11", optional = true }
 tower-http = { version = "0.4.4", features = ["trace", "set-header", "util"], optional = true }
 http = { version = "0.2", optional = true }
@@ -53,7 +53,7 @@ tempfile = { version = "3.7.0" }
 rand = "0.8.5"
 
 [features]
-default = ["core", "replication", "remote"]
+default = ["core", "replication", "remote", "tls"]
 core = [
   "libsql-sys",
   "dep:bitflags",
@@ -88,7 +88,6 @@ replication = [
   "dep:tonic",
   "dep:tonic-web",
   "dep:tower-http",
-  "dep:hyper-rustls",
   "dep:futures",
   "dep:libsql_replication",
 ]
@@ -109,11 +108,11 @@ remote = [
   "hrana",
   "dep:tower",
   "dep:hyper",
+  "dep:hyper",
   "dep:http",
   "dep:tokio",
   "dep:futures",
   "dep:bitflags",
-  "dep:hyper-rustls",
 ]
 wasm = ["hrana"]
 cloudflare = [
@@ -121,6 +120,7 @@ cloudflare = [
   "dep:worker"
 ]
 encryption = ["core", "libsql-sys/encryption", "dep:bytes"]
+tls = ["dep:hyper-rustls"]
 
 [[bench]]
 name = "benchmark"
@@ -128,3 +128,6 @@ harness = false
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["hyper-rustls"]

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -582,7 +582,10 @@ impl Database {
     }
 }
 
-#[cfg(any(feature = "replication", feature = "remote"))]
+#[cfg(any(
+    all(feature = "tls", feature = "replication"),
+    all(feature = "tls", feature = "remote")
+))]
 fn connector() -> Result<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>> {
     let mut http = hyper::client::HttpConnector::new();
     http.enforce_http(false);
@@ -594,6 +597,14 @@ fn connector() -> Result<hyper_rustls::HttpsConnector<hyper::client::HttpConnect
         .https_or_http()
         .enable_http1()
         .wrap_connector(http))
+}
+
+#[cfg(any(
+    all(not(feature = "tls"), feature = "replication"),
+    all(not(feature = "tls"), feature = "remote")
+))]
+fn connector() -> Result<hyper::client::HttpConnector> {
+    panic!("The `tls` feature is disabled, you must provide your own http connector");
 }
 
 impl std::fmt::Debug for Database {

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -88,8 +88,32 @@
 //! that will allow you to sync you remote database locally.
 //! - `remote` this feature flag only includes HTTP code that will allow you to run queries against
 //! a remote database.
+//! - `tls` this feature flag disables the builtin TLS connector and instead requires that you pass
+//! your own connector for any of the features that require HTTP.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(
+    all(
+        any(
+            not(feature = "remote"),
+            not(feature = "replication"),
+            not(feature = "core")
+        ),
+        feature = "tls"
+    ),
+    allow(unused_imports)
+)]
+#![cfg_attr(
+    all(
+        any(
+            not(feature = "remote"),
+            not(feature = "replication"),
+            not(feature = "core")
+        ),
+        feature = "tls"
+    ),
+    allow(dead_code)
+)]
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
This adds a new `tls` feature that is enabled by default, if this feature is disabled building a libsql connection will panic with a message asking you to configure a http connector. This allows users to bring their own http connector and more importantly their own TLS lib with their own versions without needing to compile rustls which we use by default.

This resolves solana-sdk >2 build issues with uses an older version of `curve25519-dalek` that pings `zeroize` to `<1.4`. New versions of `rustls` require `1.7` of `zeroize` thus causing issues when building `rustls` for libsql with the `tls` feature.