### PR TITLE
libsql: Add max_write_replication_index and sync_until in Database

### DIFF
--- a/libsql-server/tests/embedded_replica/mod.rs
+++ b/libsql-server/tests/embedded_replica/mod.rs
@@ -179,6 +179,8 @@ fn execute_batch() {
         conn.execute("CREATE TABLE user (id INTEGER NOT NULL PRIMARY KEY)", ())
             .await?;
 
+        assert_eq!(db.max_write_replication_index(), Some(1));
+
         let n = db.sync().await?.frame_no();
         assert_eq!(n, Some(1));
 
@@ -231,6 +233,7 @@ fn stream() {
 
         conn.execute("CREATE TABLE user (id INTEGER NOT NULL PRIMARY KEY)", ())
             .await?;
+        assert_eq!(db.max_write_replication_index(), Some(1));
 
         let n = db.sync().await?.frame_no();
         assert_eq!(n, Some(1));
@@ -244,8 +247,10 @@ fn stream() {
             ",
         )
         .await?;
+        let replication_index = db.max_write_replication_index();
 
-        db.sync().await.unwrap();
+        let synced_replication_index = db.sync().await.unwrap().frame_no();
+        assert_eq!(synced_replication_index, replication_index);
 
         let rows = conn.query("select * from user", ()).await.unwrap();
 

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -575,7 +575,11 @@ impl Database {
 
                 let local = LibsqlConnection { conn };
                 let writer = local.conn.new_connection_writer();
-                let remote = crate::replication::RemoteConnection::new(local, writer);
+                let remote = crate::replication::RemoteConnection::new(
+                    local,
+                    writer,
+                    self.max_write_replication_index.clone(),
+                );
                 let conn = std::sync::Arc::new(remote);
 
                 Ok(Connection { conn })

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -388,6 +388,18 @@ cfg_replication! {
                t => Err(Error::FreezeNotSupported(format!("{:?}", t)))
            }
         }
+
+        /// Get the maximum replication index returned from a write performed using any connection created using this Database object.
+        pub fn max_write_replication_index(&self) -> Option<FrameNo> {
+            let index = self
+                .max_write_replication_index
+                .load(std::sync::atomic::Ordering::SeqCst);
+            if index == 0 {
+                None
+            } else {
+                Some(index)
+            }
+        }
     }
 }
 

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -340,6 +340,16 @@ cfg_replication! {
             }
         }
 
+        /// Sync database from remote until it gets to a given replication_index or further,
+        /// and returns the committed frame_no after syncing, if applicable.
+        pub async fn sync_until(&self, replication_index: FrameNo) -> Result<crate::replication::Replicated> {
+            if let DbType::Sync { db, encryption_config: _ } = &self.db_type {
+                db.sync_until(replication_index).await
+            } else {
+                Err(Error::SyncNotSupported(format!("{:?}", self.db_type)))
+            }
+        }
+
         /// Apply a set of frames to the database and returns the committed frame_no after syncing, if
         /// applicable.
         pub async fn sync_frames(&self, frames: crate::replication::Frames) -> Result<Option<FrameNo>> {

--- a/libsql/src/database/builder.rs
+++ b/libsql/src/database/builder.rs
@@ -135,6 +135,7 @@ cfg_core! {
                 let db = crate::local::Database::open(":memory:", crate::OpenFlags::default())?;
                 Database {
                     db_type: DbType::Memory { db } ,
+                    max_write_replication_index: Default::default(),
                 }
             } else {
                 let path = self
@@ -150,6 +151,7 @@ cfg_core! {
                         flags: self.inner.flags,
                         encryption_config: self.inner.encryption_config,
                     },
+                    max_write_replication_index: Default::default(),
                 }
             };
 
@@ -291,6 +293,7 @@ cfg_replication! {
 
             Ok(Database {
                 db_type: DbType::Sync { db, encryption_config },
+                max_write_replication_index: Default::default(),
             })
         }
     }
@@ -360,6 +363,7 @@ cfg_replication! {
 
             Ok(Database {
                 db_type: DbType::Sync { db, encryption_config },
+                max_write_replication_index: Default::default(),
             })
         }
     }
@@ -414,6 +418,7 @@ cfg_remote! {
                     connector,
                     version,
                 },
+                max_write_replication_index: Default::default(),
             })
         }
     }

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -2,7 +2,7 @@
 
 use std::str::FromStr;
 use std::sync::Arc;
-
+use std::sync::atomic::AtomicU64;
 use libsql_replication::rpc::proxy::{
     describe_result, query_result::RowResult, Cond, DescribeResult, ExecuteResults, NotCond,
     OkCond, Positional, Query, ResultRows, State as RemoteState, Step,
@@ -28,6 +28,8 @@ pub struct RemoteConnection {
     pub(self) local: LibsqlConnection,
     writer: Option<Writer>,
     inner: Arc<Mutex<Inner>>,
+    #[allow(dead_code)]
+    max_write_replication_index: Arc<AtomicU64>,
 }
 
 #[derive(Default, Debug)]
@@ -166,12 +168,13 @@ impl From<RemoteState> for State {
 }
 
 impl RemoteConnection {
-    pub(crate) fn new(local: LibsqlConnection, writer: Option<Writer>) -> Self {
+    pub(crate) fn new(local: LibsqlConnection, writer: Option<Writer>, max_write_replication_index: Arc<AtomicU64>) -> Self {
         let state = Arc::new(Mutex::new(Inner::default()));
         Self {
             local,
             writer,
             inner: state,
+            max_write_replication_index,
         }
     }
 

--- a/libsql/src/replication/mod.rs
+++ b/libsql/src/replication/mod.rs
@@ -36,8 +36,8 @@ pub(crate) mod remote_client;
 
 #[derive(Debug)]
 pub struct Replicated {
-    frame_no: Option<FrameNo>,
-    frames_synced: usize,
+    pub(crate) frame_no: Option<FrameNo>,
+    pub(crate) frames_synced: usize,
 }
 
 impl Replicated {


### PR DESCRIPTION
`Database::max_write_replication_index` can be used by the client to keep track of the lowest replication index that guarantees seeing all the writes done by this client. `Database::sync_until` can be then used to sync the embedded replica at least to the replication index given by the client.

That way a client can:
1. Do a bunch of operations on one embedded replica
2. Fetch the max_write_replication index I
3. Run sync_until with a given replication index I on a different embedded replica and be sure that they see all the operations they've done on the first embedded replica.