### PR TITLE
replace parking_lot with tokio::sync::Mutex in some places

### DIFF
--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -415,7 +415,8 @@ where
 
         PROGRAM_EXEC_COUNT.increment(1);
 
-        check_program_auth(&ctx, &pgm, &self.inner.lock().config_store.get())?;
+        let config = self.inner.lock().config_store.get();
+        check_program_auth(&ctx, &pgm, &config).await?;
 
         // create the bomb right before spawning the blocking task.
         let mut bomb = Bomb {

--- a/libsql-server/src/connection/program.rs
+++ b/libsql-server/src/connection/program.rs
@@ -363,11 +363,15 @@ pub fn check_program_auth(
             }
             StmtKind::Attach(ref ns) => {
                 ctx.auth.has_right(ns, Permission::AttachRead)?;
-                if !ctx.meta_store.handle(ns.clone()).get().allow_attach {
-                    return Err(Error::NotAuthorized(format!(
-                        "Namespace `{ns}` doesn't allow attach"
-                    )));
-                }
+                return tokio::runtime::Handle::current().block_on(async {
+                    if !ctx.meta_store.handle(ns.clone()).await.get().allow_attach {
+                        return Err(Error::NotAuthorized(format!(
+                            "Namespace `{ns}` doesn't allow attach"
+                        )));
+                    } else {
+                        Ok(())
+                    }
+                });
             }
             StmtKind::Detach => (),
         }

--- a/libsql-server/src/connection/program.rs
+++ b/libsql-server/src/connection/program.rs
@@ -341,7 +341,7 @@ fn value_size(val: &rusqlite::types::ValueRef) -> usize {
     }
 }
 
-pub fn check_program_auth(
+pub async fn check_program_auth(
     ctx: &RequestContext,
     pgm: &Program,
     config: &DatabaseConfig,
@@ -363,15 +363,11 @@ pub fn check_program_auth(
             }
             StmtKind::Attach(ref ns) => {
                 ctx.auth.has_right(ns, Permission::AttachRead)?;
-                return tokio::runtime::Handle::current().block_on(async {
-                    if !ctx.meta_store.handle(ns.clone()).await.get().allow_attach {
-                        return Err(Error::NotAuthorized(format!(
-                            "Namespace `{ns}` doesn't allow attach"
-                        )));
-                    } else {
-                        Ok(())
-                    }
-                });
+                if !ctx.meta_store.handle(ns.clone()).await.get().allow_attach {
+                    return Err(Error::NotAuthorized(format!(
+                        "Namespace `{ns}` doesn't allow attach"
+                    )));
+                }
             }
             StmtKind::Detach => (),
         }

--- a/libsql-server/src/database/schema.rs
+++ b/libsql-server/src/database/schema.rs
@@ -50,7 +50,7 @@ impl crate::connection::Connection for SchemaConnection {
 
             res
         } else {
-            check_program_auth(&ctx, &migration, &self.config.get())?;
+            check_program_auth(&ctx, &migration, &self.config.get()).await?;
             let connection = self.connection.clone();
             validate_migration(&mut migration)?;
             let migration = Arc::new(migration);

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -331,7 +331,7 @@ async fn handle_create_namespace<C: Connector>(
             ));
         }
         // TODO: move this check into meta store
-        if !app_state.namespaces.exists(&ns) {
+        if !app_state.namespaces.exists(&ns).await {
             return Err(Error::NamespaceDoesntExist(ns.to_string()));
         }
 

--- a/libsql-server/src/schema/db.rs
+++ b/libsql-server/src/schema/db.rs
@@ -482,6 +482,7 @@ mod test {
     async fn register_schema(meta_store: &MetaStore, schema: &'static str) {
         meta_store
             .handle(schema.into())
+            .await
             .store(DatabaseConfig {
                 is_shared_schema: true,
                 ..Default::default()
@@ -497,6 +498,7 @@ mod test {
     ) -> crate::Result<()> {
         meta_store
             .handle(name.into())
+            .await
             .store(DatabaseConfig {
                 shared_schema_name: Some(schema.into()),
                 ..Default::default()
@@ -561,6 +563,7 @@ mod test {
         // necessary checks beforehand, and return a nice error message.
         assert!(meta_store
             .handle("ns1".into())
+            .await
             .store(DatabaseConfig {
                 shared_schema_name: Some("schema1".into()),
                 ..Default::default()


### PR DESCRIPTION
## Context

Current `sqld` code abuses tokio runtime which can lead to complete deadlock of the server.

One issue which got triggered pretty frequently relying on the following facts about `sqld` internals:
1. Many **async** request handlers in `sqld` checks that metadata has namespace in it with sync lock `metadata.inner.configs` (see `MetaStore::exists` method)
2. Metastore remove operation take `metadata.inner.configs` lock first and then try to take `inner.conn` lock
3. Background checkpoint operation which run on blocking thread take `inner.conn` lock for the time of the checkpoint process

So, if (2) took `metadata.inner.configs` lock while (3) is in process, then all request **tasks** which hits (1) will be **blocked** on the **parking_lot** mutex until (3) released the lock and (2) finished. This can easily block all tokio worker threads and lead to complete server deadlock.

This PR mitigate this specific scenario by introducing 2 fixes:
1. `MetaStoreInner.configs` and `MetaStoreInner.conn` now uses `tokio::sync::Mutex` instead of `parking_lot::Mutex`. This will prevent scenario from above as **async** tasks now will be blocked on **async** lock and runtime will be able to switch them from worker threads and put some other workload on them
2. Metastore remove operation now take `inner.conn` lock first and then take `inner.configs` lock. This will prevent the cases where `inner.configs` lock is taken for too long by remove operation while awaiting next `inner.conn` lock. As we are using `configs` lock in both async & sync context and also this lock required for quick checks in metastore - it's better to not hold it for too long.

