### PR TITLE
remove unused section from cargo.toml

### DIFF
--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -8,9 +8,6 @@ default-run = "sqld"
 name = "sqld"
 path = "src/main.rs"
 
-[build]
-rustflags = ["--cfg", "tokio_unstable"]
-
 [dependencies]
 anyhow = "1.0.66"
 async-lock = "2.6.0"


### PR DESCRIPTION
## Context

`[build]` section must be in the `config.toml` (not in the `Cargo.toml`!) - but we already have it in the workspace config

Now build produces warnings:
```
$> cargo build
warning: /home/sivukhin/turso/libsql/libsql-server/Cargo.toml: unused manifest key: build
...
```