### PR TITLE
update nemesis github action

### DIFF
--- a/.github/workflows/nemesis.yml
+++ b/.github/workflows/nemesis.yml
@@ -75,9 +75,9 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN_TURSO_TEST }}
 
       - name: Build nemesis test
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '>=1.21.4'
+          go-version-file: nemesis-tests/go.mod
       - run: |
           cd nemesis-tests
           go build -o ../tursotests cmd/tursotest/main.go


### PR DESCRIPTION
## Context

Force nemesis tests to use toolchain specified in the repository

Now action is working: https://github.com/tursodatabase/libsql/actions/runs/10467236343