### PR TITLE
bump sqld version to 0.24.20 to create new release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-server"
-version = "0.24.19"
+version = "0.24.20"
 dependencies = [
  "aes",
  "anyhow",

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-server"
-version = "0.24.19"
+version = "0.24.20"
 edition = "2021"
 default-run = "sqld"
 repository = "https://github.com/tursodatabase/libsql"


### PR DESCRIPTION
## Context

Previous (0.24.19) release partially failed (artifacts were not published) - so let's not override it and just create new one