### PR TITLE
disable foreign keys in schema migration

### DIFF
--- a/libsql-server/src/query_analysis.rs
+++ b/libsql-server/src/query_analysis.rs
@@ -406,6 +406,14 @@ impl Statement {
             StmtKind::Read | StmtKind::TxnEnd | StmtKind::TxnBegin
         )
     }
+
+    pub(crate) fn is_pragma(&self) -> bool {
+        // adding a flag to the program would break the serialization, so we do that instead
+        match self.stmt.split_whitespace().next() {
+            Some(s) => s.trim().eq_ignore_ascii_case("pragma"),
+            None => false,
+        }
+    }
 }
 
 /// Given a an initial state and an array of queries, attempts to predict what the final state will

--- a/libsql-server/src/schema/snapshots/libsql_server__schema__db__test__pending_job-3.snap
+++ b/libsql-server/src/schema/snapshots/libsql_server__schema__db__test__pending_job-3.snap
@@ -35,4 +35,5 @@ MigrationJob {
         0,
     ],
     task_error: None,
+    disable_foreign_key: false,
 }

--- a/libsql-server/src/schema/snapshots/libsql_server__schema__db__test__pending_job.snap
+++ b/libsql-server/src/schema/snapshots/libsql_server__schema__db__test__pending_job.snap
@@ -35,4 +35,5 @@ MigrationJob {
         0,
     ],
     task_error: None,
+    disable_foreign_key: false,
 }

--- a/libsql-server/src/schema/status.rs
+++ b/libsql-server/src/schema/status.rs
@@ -45,6 +45,7 @@ pub struct MigrationJob {
     pub(super) progress: MigrationProgress,
     /// error info for the task that failed the job
     pub(super) task_error: Option<(i64, String, NamespaceName)>,
+    pub(super) disable_foreign_key: bool,
 }
 
 impl MigrationJob {

--- a/libsql-server/tests/namespaces/shared_schema.rs
+++ b/libsql-server/tests/namespaces/shared_schema.rs
@@ -217,53 +217,6 @@ fn no_job_created_when_migration_job_is_invalid() {
 }
 
 #[test]
-fn migration_contains_txn_statements() {
-    let mut sim = Builder::new()
-        .simulation_duration(Duration::from_secs(100000))
-        .build();
-    let tmp = tempdir().unwrap();
-    make_primary(&mut sim, tmp.path().to_path_buf());
-
-    sim.client("client", async {
-        let client = Client::new();
-        client
-            .post(
-                "http://primary:9090/v1/namespaces/schema/create",
-                json!({"shared_schema": true }),
-            )
-            .await
-            .unwrap();
-
-        let schema_db = Database::open_remote_with_connector(
-            "http://schema.primary:8080",
-            String::new(),
-            TurmoilConnector,
-        )
-        .unwrap();
-        let schema_conn = schema_db.connect().unwrap();
-        schema_conn
-            .execute_batch("begin; create table test1 (c);commit")
-            .await
-            .unwrap();
-        assert_debug_snapshot!(schema_conn
-            .execute_batch("begin; create table test (c)")
-            .await
-            .unwrap_err());
-
-        let resp = client
-            .get("http://schema.primary:8080/v1/jobs/2")
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-        assert_debug_snapshot!(resp.json_value().await.unwrap());
-
-        Ok(())
-    });
-
-    sim.run().unwrap();
-}
-
-#[test]
 fn dry_run_failure() {
     let mut sim = Builder::new()
         .simulation_duration(Duration::from_secs(100000))


### PR DESCRIPTION
This PR works around disabling foreign_keys being a noop in schema migrations. During the validation of the migration script we allows a prologue and an epilogue of pragmas. If such a prologue is present, we assume that foreign_keys must be disabled for the migration. This is a bit hacky since we don't really validate what pragma is actually being used, but disabling foreign_keys is such a common pattern that assuming it should be ok