### PR TITLE
bottomless: do not skip frames even if there is a temporary issue with S3

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -446,7 +446,11 @@ impl Replicator {
                                 .await;
                             Self::record_s3_write_time(&db_name, start_time.elapsed());
                             if let Err(e) = response {
-                                tracing::error!("Failed to send {} to S3: {}, will retry after 1 second", fpath, e);
+                                tracing::error!(
+                                    "Failed to send {} to S3: {}, will retry after 1 second",
+                                    fpath,
+                                    e
+                                );
                                 tokio::time::sleep(Duration::from_millis(1000)).await;
                             } else {
                                 break;

--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -528,6 +528,10 @@ impl Replicator {
         tracing::info!("bottomless replicator: shutting down...");
         // 1. wait for all committed WAL frames to be committed locally
         let last_frame_no = self.last_known_frame();
+// force flush in order to not wait for periodic wake up of local back up process
+        if let Some(tx) = &self.flush_trigger {
+            let _ = tx.send(());
+        }
         self.wait_until_committed(last_frame_no).await?;
         // 2. wait for snapshot upload to S3 to finish
         self.wait_until_snapshotted().await?;


### PR DESCRIPTION
## Context

Current implementation of `bottomless` skip frames which were failed during upload to S3. This create significant issue with restore process from such backup as `bottomless` can restore DB only from consecutive frames and first gap in frames will just stop restore process.

So, in case of slight fluctuation in S3 (like sqld network issue or just some degradation of S3) the backup will be "frozen" in time and all changes in the DB made after that fluctuation will not be restore from current generation (but next generation will have full snapshot and issue will disappear after generate bump will happen).

This PR addresses this nuance of `bottomless` implementation: now instead of bounded queue with frames for upload and fail-fast logic in case of S3 upload failure it has unbounded channel (in order to not block local backup process) with frames for S3 upload and retry logic in case of failure. In case of shutdown `bottomless` will try to finish all attempts for S3 upload but will not perform any retries (so, in case of shutdown `bottomless` will work in a "best-effort" mode and can skip some frames in case of S3 issues)
