### PR TITLE
fix bug for case when S3 has more than 1 page of data

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -1467,6 +1467,7 @@ impl Replicator {
         };
         let mut next_marker = None;
         let mut applied_wal_frame = false;
+        let mut last_injected_frame_no = 0;
         'restore_wal: loop {
             let mut list_request = self.list_objects().prefix(&prefix);
             if let Some(marker) = next_marker {
@@ -1481,7 +1482,6 @@ impl Replicator {
                 break;
             }
 
-            let mut last_received_frame_no = 0;
             for obj in objs {
                 let key = obj
                     .key()
@@ -1504,9 +1504,9 @@ impl Replicator {
                             continue;
                         }
                     };
-                if first_frame_no != last_received_frame_no + 1 {
+                if first_frame_no != last_injected_frame_no + 1 {
                     tracing::warn!("Missing series of consecutive frames. Last applied frame: {}, next found: {}. Stopping the restoration process",
-                            last_received_frame_no, first_frame_no);
+                            last_injected_frame_no, first_frame_no);
                     break;
                 }
                 if let Some(frame) = last_consistent_frame {
@@ -1539,7 +1539,7 @@ impl Replicator {
                 );
 
                 while let Some(frame) = reader.next_frame_header().await? {
-                    last_received_frame_no = reader.next_frame_no();
+                    last_injected_frame_no = reader.next_frame_no();
                     reader.next_page(&mut page_buf).await?;
                     if self.verify_crc {
                         checksum = frame.verify(checksum, &page_buf)?;
@@ -1548,7 +1548,7 @@ impl Replicator {
                     let checksum = (crc1 as u64) << 32 | crc2 as u64;
                     let frame_to_inject = libsql_replication::frame::Frame::from_parts(
                         &libsql_replication::frame::FrameHeader {
-                            frame_no: (last_received_frame_no as u64).into(),
+                            frame_no: (last_injected_frame_no as u64).into(),
                             checksum: checksum.into(),
                             page_no: frame.pgno().into(),
                             size_after: frame.size_after().into(),


### PR DESCRIPTION
## Context

During recovery from WAL `bottomless` has bug in case when S3 has more than 1 page of frames. 

The code is written in such a way that it tracks last injected frame number and abort recovery process of frame range from S3 doesn't match current next expected frame. This procedure is OK but the code reset `last_injected_frame_no` to zero for every S3 page which will lead to mismatch between expected and real frame number for every second page (if it will be) from S3.

This PR fixes this issue and just preserve frame number across S3 pages.