### PR TITLE
fix libsql-wal https connector

### DIFF
--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -169,7 +169,7 @@ pub struct Server<C = HttpConnector, A = AddrIncoming, D = HttpsConnector<HttpCo
     pub shutdown_timeout: std::time::Duration,
     pub use_custom_wal: Option<CustomWAL>,
     pub storage_server_address: String,
-    pub connector: Option<C>,
+    pub connector: Option<D>,
 }
 
 impl<C, A, D> Default for Server<C, A, D> {
@@ -821,13 +821,7 @@ where
 
             let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
 
-            let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
-                .with_native_roots()
-                .https_or_http()
-                .enable_all_versions()
-                .wrap_connector(self.connector.clone().unwrap());
-
-            let http_client = HyperClientBuilder::new().build(https_connector);
+            let http_client = HyperClientBuilder::new().build(self.connector.clone().unwrap());
             let mut builder = config.into_builder();
             builder.set_http_client(Some(http_client));
             builder.set_endpoint_url(opt.aws_endpoint.clone());

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -627,6 +627,16 @@ async fn build_server(config: &Cli) -> anyhow::Result<Server> {
         }
     });
 
+    let mut http = HttpConnector::new();
+    http.enforce_http(false);
+    http.set_nodelay(true);
+
+    let https = hyper_rustls::HttpsConnectorBuilder::new()
+        .with_native_roots()
+        .https_or_http()
+        .enable_all_versions()
+        .wrap_connector(http);
+
     Ok(Server {
         path: config.db_path.clone().into(),
         db_config,
@@ -651,7 +661,7 @@ async fn build_server(config: &Cli) -> anyhow::Result<Server> {
             .unwrap_or(Duration::from_secs(30)),
         use_custom_wal: config.use_custom_wal,
         storage_server_address: config.storage_server_address.clone(),
-        connector: Some(HttpConnector::new()),
+        connector: Some(https),
     })
 }
 


### PR DESCRIPTION
third time's the charm?

I forgot to not enforce HTTP scheme on the base HTTP connector