### PR TITLE
implement create and copy bottomless-cli commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,6 +973,7 @@ dependencies = [
  "chrono",
  "clap 4.5.9",
  "libsql-rusqlite",
+ "libsql-sys",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN if [ "$ENABLE_FEATURES" == "" ]; then \
     else \
         cargo build -p libsql-server --features "$ENABLE_FEATURES" --release ; \
     fi
+RUN cargo build -p bottomless-cli --release
 
 # official gosu install instruction (https://github.com/tianon/gosu/blob/master/INSTALL.md)
 FROM debian:bullseye-slim as gosu
@@ -86,6 +87,7 @@ COPY docker-wrapper.sh /usr/local/bin
 COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /target/release/sqld /bin/sqld
+COPY --from=builder /target/release/bottomless-cli /bin/bottomless-cli
 
 USER root
 

--- a/bottomless-cli/Cargo.toml
+++ b/bottomless-cli/Cargo.toml
@@ -19,6 +19,7 @@ bottomless = { version = "0", path = "../bottomless" }
 bytes = "1"
 chrono = "0.4.23"
 clap = { version = "4.0.29", features = ["derive"] }
+libsql-sys = { path = "../libsql-sys" }
 tokio = { version = "1.23.0", features = ["macros", "rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -125,7 +125,7 @@ pub async fn metastore_connection_maker(
                 bucket_name: config.bucket_name,
                 max_frames_per_batch: 10_000,
                 max_batch_interval: config.backup_interval,
-                s3_upload_max_parallelism: 32,
+                s3_max_parallelism: 32,
                 s3_max_retries: 10,
                 skip_snapshot: false,
             };


### PR DESCRIPTION
## Context

This PR implements two simple commands for `bottomless-cli`:
1. `bottomless-cli -n "ns-xxx:yyy" copy --to-dir local-directory -g generation` - copy specified (or latest if omitted) generation S3 content to the local directory
2. `bottomless-cli -n "ns-xxx:yyy" -d temp create --source-db-path dbs/xxx/data` - create new generation (with fresh timestamp) in the S3 from database file and upload single snapshot to the S3 with all necessary metadata for bottomless (`.changecounter`)

Create command opens DB at the path provided by `--source-db-path` in read-only mode and execute `VACUUM INTO ?` query to initialize fresh DB at the path provided by `-d`. After that DB without any changes in WAL will be sent as a single snapshot to the S3.

Also, CLI arguments structure a bit reworked in order to make it more easy to use:
1. Now more command can be run without `-d` argument: `ls`, `copy`, `verify` do not require this param
2. Now you can provide `--db-name` argument which will be used to form whole namespace name if `LIBSQL_BOTTOMLESS_DATABASE_ID` env var is set (if not - then there is a misuse of `bottomless-cli` and command will return an error). See an example:
```
$> bottomless-cli --db-name "b7698553-676c-4e75-a449-791764e0f0e5" ls
2024-08-26T13:27:08.054032Z  INFO bottomless_cli: LIBSQL_BOTTOMLESS_DATABASE_ID env var were updated: '47a3d201-c415-48b5-83c3-a456a617adf4' -> 'ns-47a3d201-c415-48b5-83c3-a456a617adf4:b7698553-676c-4e75-a449-791764e0f0e5'
2024-08-26T13:27:08.832453Z  INFO bottomless::replicator: Bucket bottomless exists and is accessible
...
# but if no env var set
$> bottomless-cli --db-name "b7698553-676c-4e75-a449-791764e0f0e5" ls
Error: db_name can be set only if LIBSQL_BOTTOMLESS_DATABASE_ID env var has namespace ID
```

Plus, bottomless-cli now shipped as a part of docker image (it's `15M` - so I think it's ok to include it by default)