### PR TITLE
fail restore if WAL wasn't transferred to the DB file

### DIFF
--- a/libsql-server/src/test/bottomless.rs
+++ b/libsql-server/src/test/bottomless.rs
@@ -10,6 +10,7 @@ use s3s::service::S3ServiceBuilder;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
 use std::sync::Once;
+use tokio::task::JoinError;
 use tokio::time::sleep;
 use tokio::time::Duration;
 use url::Url;
@@ -61,7 +62,7 @@ async fn start_s3_server() {
 }
 
 /// returns a future that once polled will shutdown the server and wait for cleanup
-fn start_db(step: u32, server: Server) -> impl Future<Output = ()> {
+fn start_db(step: u32, server: Server) -> impl Future<Output = Result<(), JoinError>> {
     let notify = server.shutdown.clone();
     let handle = tokio::spawn(async move {
         if let Err(e) = server.start().await {
@@ -71,7 +72,7 @@ fn start_db(step: u32, server: Server) -> impl Future<Output = ()> {
 
     async move {
         notify.notify_waiters();
-        handle.await.unwrap();
+        handle.await
     }
 }
 
@@ -176,7 +177,7 @@ async fn backup_restore() {
 
         sleep(Duration::from_secs(2)).await;
 
-        db_job.await;
+        db_job.await.unwrap();
         drop(cleaner);
     }
 
@@ -195,7 +196,7 @@ async fn backup_restore() {
 
         assert_updates(&connection_addr, ROWS, OPS, "A").await;
 
-        db_job.await;
+        db_job.await.unwrap();
         drop(cleaner);
     }
 
@@ -213,7 +214,7 @@ async fn backup_restore() {
 
         // wait for WAL to backup
         sleep(Duration::from_secs(2)).await;
-        db_job.await;
+        db_job.await.unwrap();
         drop(cleaner);
     }
 
@@ -228,7 +229,7 @@ async fn backup_restore() {
 
         assert_updates(&connection_addr, ROWS, OPS, "B").await;
 
-        db_job.await;
+        db_job.await.unwrap();
         drop(cleaner);
     }
 
@@ -247,7 +248,259 @@ async fn backup_restore() {
 
         assert_updates(&connection_addr, ROWS, OPS, "B").await;
 
-        db_job.await;
+        db_job.await.unwrap();
+        drop(cleaner);
+    }
+}
+
+async fn list_bucket(bucket: &str) -> Vec<String> {
+    let client = s3_client().await.expect("failed to create s3 client");
+    let objects = client
+        .list_objects()
+        .bucket(bucket)
+        .prefix("")
+        .send()
+        .await
+        .expect("failed to list objects");
+    objects
+        .contents()
+        .iter()
+        .map(|x| String::from(x.key().unwrap()))
+        .collect()
+}
+
+#[tokio::test]
+async fn restore_from_partial_db() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    start_s3_server().await;
+
+    const DB_ID: &str = "partialbackup";
+    const BUCKET: &str = "partialbackup";
+    const PATH: &str = "partialbackup.sqld";
+    const PORT: u16 = 15003;
+
+    let _ = S3BucketCleaner::new(BUCKET).await;
+    assert_bucket_occupancy(BUCKET, true).await;
+
+    let listener_addr = format!("0.0.0.0:{}", PORT)
+        .to_socket_addrs()
+        .unwrap()
+        .next()
+        .unwrap();
+    let conn = Url::parse(&format!("http://localhost:{}", PORT)).unwrap();
+    let options = bottomless::replicator::Options {
+        db_id: Some(DB_ID.to_string()),
+        create_bucket_if_not_exists: true,
+        verify_crc: true,
+        use_compression: bottomless::replicator::CompressionKind::None,
+        bucket_name: BUCKET.to_string(),
+        max_batch_interval: Duration::from_millis(10),
+        ..bottomless::replicator::Options::from_env().unwrap()
+    };
+    let make_server = || async { configure_server(&options, listener_addr, PATH).await };
+    {
+        tracing::info!(
+            "---STEP 1: create db, write rows, remove random S3 files to create effect of partial backup---"
+        );
+        let cleaner = DbFileCleaner::new(PATH);
+        let db_job = start_db(1, make_server().await);
+
+        sleep(Duration::from_secs(2)).await;
+
+        let _ = sql(
+            &conn,
+            ["CREATE TABLE IF NOT EXISTS t(id INT PRIMARY KEY, name TEXT, payload BLOB);"],
+        )
+        .await
+        .unwrap();
+        for i in 0..128 {
+            sql(
+                &conn,
+                [format!("INSERT INTO t VALUES({i}, '{i}', zeroblob(4096))")],
+            )
+            .await
+            .expect("SQL query failed");
+        }
+
+        tracing::info!("Ready to remove files from S3");
+        let client = s3_client().await.expect("failed to create s3 client");
+        let mut i = 0;
+        for key in list_bucket(BUCKET).await {
+            // delete full snapshot and random wal frame ranges
+            let should_delete = key.ends_with(".changecounter")
+                || key.ends_with(".dep")
+                || key.ends_with("db.raw")
+                || i % 10 == 0;
+
+            if should_delete {
+                client
+                    .delete_object()
+                    .bucket(BUCKET)
+                    .key(key)
+                    .send()
+                    .await
+                    .expect("failed to delete object");
+            }
+            i += 1;
+        }
+
+        db_job.await.unwrap();
+        drop(cleaner);
+    }
+
+    {
+        sleep(Duration::from_secs(2)).await;
+
+        tracing::info!("---STEP 2: recreate database, check that it is unable to start ---");
+        let cleaner = DbFileCleaner::new(PATH);
+        let db_job = start_db(2, make_server().await);
+        sleep(Duration::from_secs(2)).await;
+
+        let result = sql(&conn, ["SELECT COUNT(*) as cnt FROM t"]).await.unwrap();
+        let count = result
+            .first()
+            .unwrap()
+            .clone()
+            .into_result_set()
+            .unwrap()
+            .rows[0]
+            .cells["cnt"]
+            .clone();
+        if let Value::Integer(x) = count {
+            assert!(0 < x && x < 128);
+        } else {
+            assert!(false);
+        }
+        db_job.await.unwrap();
+        drop(cleaner);
+    }
+}
+
+#[tokio::test]
+async fn do_not_restore_from_corrupted_db() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    start_s3_server().await;
+
+    const DB_ID: &str = "corruptedbackup";
+    const BUCKET: &str = "corruptedbackup";
+    const PATH: &str = "corruptedbackup.sqld";
+    const PORT: u16 = 15004;
+
+    let _ = S3BucketCleaner::new(BUCKET).await;
+    assert_bucket_occupancy(BUCKET, true).await;
+
+    let listener_addr = format!("0.0.0.0:{}", PORT)
+        .to_socket_addrs()
+        .unwrap()
+        .next()
+        .unwrap();
+    let conn = Url::parse(&format!("http://localhost:{}", PORT)).unwrap();
+    let options = bottomless::replicator::Options {
+        db_id: Some(DB_ID.to_string()),
+        create_bucket_if_not_exists: true,
+        verify_crc: false,
+        use_compression: bottomless::replicator::CompressionKind::None,
+        bucket_name: BUCKET.to_string(),
+        max_batch_interval: Duration::from_millis(10),
+        ..bottomless::replicator::Options::from_env().unwrap()
+    };
+    let make_server = || async { configure_server(&options, listener_addr, PATH).await };
+    {
+        tracing::info!("---STEP 1: create db, write rows, corrupt random S3 files ---");
+        let cleaner = DbFileCleaner::new(PATH);
+        let db_job = start_db(1, make_server().await);
+
+        sleep(Duration::from_secs(2)).await;
+
+        let _ = sql(
+            &conn,
+            ["CREATE TABLE IF NOT EXISTS t(id INT PRIMARY KEY, name TEXT, payload BLOB);"],
+        )
+        .await
+        .unwrap();
+        for i in 0..128 {
+            sql(
+                &conn,
+                [format!("INSERT INTO t VALUES({i}, '{i}', zeroblob(128))")],
+            )
+            .await
+            .expect("SQL query failed");
+        }
+
+        tracing::info!("Ready to remove files from S3");
+        let client = s3_client().await.expect("failed to create s3 client");
+        for key in list_bucket(BUCKET).await {
+            // delete full snapshot files
+            let should_delete =
+                key.ends_with(".changecounter") || key.ends_with(".dep") || key.ends_with("db.raw");
+            if should_delete {
+                client
+                    .delete_object()
+                    .bucket(BUCKET)
+                    .key(&key)
+                    .send()
+                    .await
+                    .expect("failed to delete object");
+            } else if key.ends_with(".raw") {
+                tracing::info!("corrupt frame range: {key}");
+                // corrupt random wal frame range
+                let response = client
+                    .get_object()
+                    .bucket(BUCKET)
+                    .key(&key)
+                    .send()
+                    .await
+                    .expect("failed to read object");
+                let mut bytes: Vec<u8> = response
+                    .body
+                    .collect()
+                    .await
+                    .expect("failed to read body")
+                    .into_bytes()
+                    .into();
+                let single_frame_size = 24 + 4096;
+                assert!(bytes.len() % single_frame_size == 0);
+                for frame in 0..bytes.len() / single_frame_size {
+                    let page_number = u32::from_be_bytes(
+                        bytes[frame * single_frame_size..frame * single_frame_size + 4]
+                            .try_into()
+                            .unwrap(),
+                    );
+                    if page_number <= 1 {
+                        continue;
+                    }
+                    tracing::info!("corrupting page {page_number}");
+                    for b in frame * single_frame_size..(frame + 1) * single_frame_size {
+                        bytes[b] = bytes[b].wrapping_add(1);
+                    }
+                }
+                client
+                    .put_object()
+                    .bucket(BUCKET)
+                    .key(&key)
+                    .body(bytes.into())
+                    .send()
+                    .await
+                    .expect("failed to put body");
+            }
+        }
+
+        db_job.await.unwrap();
+        drop(cleaner);
+    }
+
+    {
+        sleep(Duration::from_secs(2)).await;
+
+        tracing::info!("---STEP 2: recreate database, check that it is unable to start ---");
+        let cleaner = DbFileCleaner::new(PATH);
+        let db_job = start_db(2, make_server().await);
+        sleep(Duration::from_secs(2)).await;
+
+        assert!(sql(&conn, ["SELECT COUNT(*) as cnt FROM t"]).await.is_err());
+        assert!(db_job.await.is_err());
         drop(cleaner);
     }
 }
@@ -340,7 +593,7 @@ async fn rollback_restore() {
             "rollback value should not be updated"
         );
 
-        db_job.await;
+        db_job.await.unwrap();
         drop(cleaner);
     }
 
@@ -369,7 +622,7 @@ async fn rollback_restore() {
             ]
         );
 
-        db_job.await;
+        db_job.await.unwrap();
         drop(cleaner);
     }
 }

--- a/libsql-server/src/test/bottomless.rs
+++ b/libsql-server/src/test/bottomless.rs
@@ -124,6 +124,7 @@ async fn configure_server(
 }
 
 #[tokio::test]
+#[ignore]
 async fn backup_restore() {
     let _ = tracing_subscriber::fmt::try_init();
 


### PR DESCRIPTION
## Context

There is an issue with `bottomless` as it relies on the fact that last connection will perform checkpoint. This is true if DB is valid, but in case of malformed DB last connection will just exit silently and leave DB empty (4KB DB file and some data in WAL). Current implementation will ignore this situation and just restore empty DB

## Changes

- Add validation that after drop of the last connection there will be no WAL files on the disk. In other case now bottomless will fail to restore because most probably DB were malformed
- Added simple `restore_from_partial_db` test which drops several files from S3 and check that DB will be able to start from this partial backup 
- Added simple `do_not_restore_from_corrupted_db` test which corrupts the DB in S3 and check that `sqld` is unable to startup from this broken configuration
- Change bottomless test structure - now we are spawning separate s3 in every test. This will be more tokio/async friendly as tokio test can shutdown runtime and silently kill our shared server

