### PR TITLE
Extension loading support for embedded replicas

### DIFF
--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -520,6 +520,14 @@ impl Conn for RemoteConnection {
     }
 
     async fn reset(&self) {}
+
+    fn enable_load_extension(&self, onoff: bool) -> Result<()> {
+        self.local.enable_load_extension(onoff)
+    }
+
+    fn load_extension(&self, dylib_path: &Path, entry_point: Option<&str>) -> Result<()> {
+        self.local.load_extension(dylib_path, entry_point)
+    }
 }
 
 pub struct ColumnMeta {


### PR DESCRIPTION
Added extension loading support for embedded replicas, by implementing enable_load_extension & load_extension for RemoteConnection. This simply runs the related functions on the local connection.