### PR TITLE
Extension loading support for embedded replicas

### DIFF
--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -520,6 +520,14 @@ impl Conn for RemoteConnection {
     }
 
     async fn reset(&self) {}
+
+    fn enable_load_extension(&self, onoff: bool) -> Result<()> {
+        self.local.enable_load_extension(onoff)
+    }
+
+    fn load_extension(&self, dylib_path: &Path, entry_point: Option<&str>) -> Result<()> {
+        self.local.load_extension(dylib_path, entry_point)
+    }
 }
 
 pub struct ColumnMeta {

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -1,5 +1,6 @@
 // TODO(lucio): Move this to `remote/mod.rs`
 
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;


### PR DESCRIPTION
Added extension loading support for embedded replicas, by implementing enable_load_extension & load_extension for RemoteConnection. This simply runs the related functions on the local connection.