### PR TITLE
libsql-wal: Sync dbs from remote storage on startup

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -1652,6 +1652,7 @@ impl Replicator {
                     let frame = RpcFrame {
                         data: frame_to_inject.bytes(),
                         timestamp: None,
+                        durable_frame_no: None,
                     };
                     injector.inject_frame(frame).await?;
                     applied_wal_frame = true;

--- a/libsql-replication/proto/replication_log.proto
+++ b/libsql-replication/proto/replication_log.proto
@@ -36,6 +36,7 @@ message Frame {
     // if this frames is a commit frame, then this can be set
     // to the time when the transaction was commited
     optional int64 timestamp = 2;
+    optional int64 durable_frame_no = 3;
 }
 
 message Frames {

--- a/libsql-replication/proto/replication_log.proto
+++ b/libsql-replication/proto/replication_log.proto
@@ -36,7 +36,7 @@ message Frame {
     // if this frames is a commit frame, then this can be set
     // to the time when the transaction was commited
     optional int64 timestamp = 2;
-    optional int64 durable_frame_no = 3;
+    optional uint64 durable_frame_no = 3;
 }
 
 message Frames {

--- a/libsql-replication/src/generated/wal_log.rs
+++ b/libsql-replication/src/generated/wal_log.rs
@@ -83,6 +83,8 @@ pub struct Frame {
     /// to the time when the transaction was commited
     #[prost(int64, optional, tag = "2")]
     pub timestamp: ::core::option::Option<i64>,
+    #[prost(int64, optional, tag = "3")]
+    pub durable_frame_no: ::core::option::Option<i64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/libsql-replication/src/generated/wal_log.rs
+++ b/libsql-replication/src/generated/wal_log.rs
@@ -83,8 +83,8 @@ pub struct Frame {
     /// to the time when the transaction was commited
     #[prost(int64, optional, tag = "2")]
     pub timestamp: ::core::option::Option<i64>,
-    #[prost(int64, optional, tag = "3")]
-    pub durable_frame_no: ::core::option::Option<i64>,
+    #[prost(uint64, optional, tag = "3")]
+    pub durable_frame_no: ::core::option::Option<u64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/libsql-replication/src/injector/libsql_injector.rs
+++ b/libsql-replication/src/injector/libsql_injector.rs
@@ -49,4 +49,8 @@ impl super::Injector for LibsqlInjector {
             .map_err(|e| Error::FatalInjectError(e.into()))?;
         Ok(None)
     }
+
+    fn durable_frame_no(&mut self, frame_no: u64) {
+        self.injector.set_durable(frame_no);
+    }
 }

--- a/libsql-replication/src/injector/mod.rs
+++ b/libsql-replication/src/injector/mod.rs
@@ -29,4 +29,6 @@ pub trait Injector {
     /// Trigger a dummy write, and flush the cache to trigger a call to xFrame. The buffer's frame
     /// are then injected into the wal.
     fn flush(&mut self) -> impl Future<Output = Result<Option<FrameNo>>> + Send;
+
+    fn durable_frame_no(&mut self, frame_no: u64);
 }

--- a/libsql-replication/src/injector/sqlite_injector/mod.rs
+++ b/libsql-replication/src/injector/sqlite_injector/mod.rs
@@ -48,7 +48,7 @@ impl Injector for SqliteInjector {
     }
 
     #[inline]
-    fn durable_frame_no(&mut self, _frame_no: u64) { }
+    fn durable_frame_no(&mut self, _frame_no: u64) {}
 }
 
 impl SqliteInjector {

--- a/libsql-replication/src/injector/sqlite_injector/mod.rs
+++ b/libsql-replication/src/injector/sqlite_injector/mod.rs
@@ -46,6 +46,9 @@ impl Injector for SqliteInjector {
         let inner = self.inner.clone();
         spawn_blocking(move || inner.lock().flush()).await.unwrap()
     }
+
+    #[inline]
+    fn durable_frame_no(&mut self, _frame_no: u64) { }
 }
 
 impl SqliteInjector {

--- a/libsql-replication/src/replicator.rs
+++ b/libsql-replication/src/replicator.rs
@@ -772,6 +772,7 @@ mod test {
                         .map(|f| RpcFrame {
                             data: f.bytes(),
                             timestamp: None,
+                            durable_frame_no: None,
                         })
                         .take(2)
                         .map(Ok)
@@ -785,6 +786,7 @@ mod test {
                         .map(|f| RpcFrame {
                             data: f.bytes(),
                             timestamp: None,
+                            durable_frame_no: None,
                         })
                         .map(Ok)
                         .collect::<Vec<_>>();

--- a/libsql-replication/src/replicator.rs
+++ b/libsql-replication/src/replicator.rs
@@ -328,6 +328,10 @@ where
     async fn inject_frame(&mut self, frame: RpcFrame) -> Result<(), Error> {
         self.frames_synced += 1;
 
+        if let Some(frame_no) = frame.durable_frame_no {
+            self.injector.durable_frame_no(frame_no);
+        }
+
         match self.injector.inject_frame(frame).await? {
             Some(commit_fno) => {
                 self.client.commit_frame_no(commit_fno).await?;

--- a/libsql-server/src/bottomless_migrate.rs
+++ b/libsql-server/src/bottomless_migrate.rs
@@ -162,13 +162,7 @@ async fn migrate_one(
     .await
     .unwrap()?;
 
-    let mut tx = shared.begin_read(0).into();
-    shared.upgrade(&mut tx).unwrap();
-    let guard = tx
-        .into_write()
-        .unwrap_or_else(|_| panic!("should be a write txn"))
-        .into_lock_owned();
-    let mut injector = Injector::new(shared.clone(), guard, 10)?;
+    let mut injector = Injector::new(shared.clone(), 10)?;
     let orig_db_path = base_path
         .join("dbs")
         .join(config.namespace().as_str())

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -787,10 +787,10 @@ where
         tokio::select! {
             _ = shutdown.notified() => {
                 let shutdown = async {
+                    namespace_store.shutdown().await?;
                     task_manager.shutdown().await?;
                     // join_set.shutdown().await;
                     service_shutdown.notify_waiters();
-                    namespace_store.shutdown().await?;
 
                     Ok::<_, crate::Error>(())
                 };

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -285,14 +285,13 @@ struct Cli {
     #[clap(
         long,
         env = "LIBSQL_SYNC_FROM_STORAGE",
-        requires = "enable_bottomless_replication",
+        requires = "enable_bottomless_replication"
     )]
     sync_from_storage: bool,
     /// Whether to force loading all WAL at startup, with libsql-wal
     /// By default, WALs are loaded lazily, as the databases are openned.
-    #[clap(
-        long,
-    )]
+    /// Whether to force loading all wal at startup
+    #[clap(long)]
     force_load_wals: bool,
     /// Sync conccurency
     #[clap(

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -298,7 +298,7 @@ struct Cli {
         long,
         env = "LIBSQL_SYNC_CONCCURENCY",
         requires = "sync_from_storage",
-        default_value = "8",
+        default_value = "8"
     )]
     sync_conccurency: usize,
 }

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -280,6 +280,28 @@ struct Cli {
     /// Auth key for the admin API
     #[clap(long, env = "LIBSQL_ADMIN_AUTH_KEY", requires = "admin_listen_addr")]
     admin_auth_key: Option<String>,
+
+    /// Whether to perform a sync of all namespaces with remote on startup
+    #[clap(
+        long,
+        env = "LIBSQL_SYNC_FROM_STORAGE",
+        requires = "enable_bottomless_replication",
+    )]
+    sync_from_storage: bool,
+    /// Whether to force loading all WAL at startup, with libsql-wal
+    /// By default, WALs are loaded lazily, as the databases are openned.
+    #[clap(
+        long,
+    )]
+    force_load_wals: bool,
+    /// Sync conccurency
+    #[clap(
+        long,
+        env = "LIBSQL_SYNC_CONCCURENCY",
+        requires = "sync_from_storage",
+        default_value = "8",
+    )]
+    sync_conccurency: usize,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -681,6 +703,9 @@ async fn build_server(config: &Cli) -> anyhow::Result<Server> {
         connector: Some(https),
         migrate_bottomless: config.migrate_bottomless,
         enable_deadlock_monitor: config.enable_deadlock_monitor,
+        should_sync_from_storage: config.sync_from_storage,
+        force_load_wals: config.force_load_wals,
+        sync_conccurency: config.sync_conccurency,
     })
 }
 

--- a/libsql-server/src/namespace/configurator/helpers.rs
+++ b/libsql-server/src/namespace/configurator/helpers.rs
@@ -417,7 +417,7 @@ pub(crate) async fn run_storage_monitor<M: MakeConnection>(
                     .await;
             }
             Err(e) => {
-                tracing::warn!("failed to open connection for storager monitor: {e}, trying again in {duration:?}");
+                tracing::warn!("failed to open connection for storage monitor: {e}, trying again in {duration:?}");
             }
         }
 

--- a/libsql-server/src/namespace/configurator/libsql_replica.rs
+++ b/libsql-server/src/namespace/configurator/libsql_replica.rs
@@ -11,7 +11,6 @@ use libsql_sys::name::NamespaceResolver;
 use libsql_wal::io::StdIO;
 use libsql_wal::registry::WalRegistry;
 use libsql_wal::replication::injector::Injector;
-use libsql_wal::transaction::Transaction;
 use libsql_wal::wal::LibsqlWalManager;
 use tokio::task::JoinSet;
 use tonic::transport::Channel;
@@ -151,13 +150,7 @@ impl ConfigureNamespace for LibsqlReplicaConfigurator {
                 .await
                 .unwrap();
 
-            let mut tx = Transaction::Read(shared.begin_read(u64::MAX));
-            shared.upgrade(&mut tx).unwrap();
-            let guard = tx
-                .into_write()
-                .unwrap_or_else(|_| panic!())
-                .into_lock_owned();
-            let injector = Injector::new(shared, guard, 10).unwrap();
+            let injector = Injector::new(shared, 10).unwrap();
             let injector = LibsqlInjector::new(injector);
             let mut replicator = Replicator::new(client, injector);
 

--- a/libsql-server/src/rpc/replication/libsql_replicator.rs
+++ b/libsql-server/src/rpc/replication/libsql_replicator.rs
@@ -79,7 +79,11 @@ pin_project_lite::pin_project! {
 
 impl<S> FrameStreamAdapter<S> {
     fn new(inner: S, flavor: WalFlavor, shared: Arc<SharedWal<StdIO>>) -> Self {
-        Self { inner, flavor, shared }
+        Self {
+            inner,
+            flavor,
+            shared,
+        }
     }
 }
 
@@ -150,8 +154,10 @@ impl ReplicationLog for LibsqlReplicationService {
         let shared = self.registry.get_async(&namespace.into()).await.unwrap();
         let req = req.into_inner();
         // TODO: replicator should only accecpt NonZero
-        let replicator =
-            libsql_wal::replication::replicator::Replicator::new(shared.clone(), req.next_offset.max(1));
+        let replicator = libsql_wal::replication::replicator::Replicator::new(
+            shared.clone(),
+            req.next_offset.max(1),
+        );
 
         let flavor = req.wal_flavor();
         let stream = FrameStreamAdapter::new(replicator.into_frame_stream(), flavor, shared);

--- a/libsql-server/src/rpc/replication/libsql_replicator.rs
+++ b/libsql-server/src/rpc/replication/libsql_replicator.rs
@@ -102,6 +102,7 @@ where
                         Poll::Ready(Some(Ok(RpcFrame {
                             data,
                             timestamp: None,
+                            durable_frame_no: None,
                         })))
                     }
                     WalFlavor::Sqlite => {
@@ -116,6 +117,7 @@ where
                         Poll::Ready(Some(Ok(RpcFrame {
                             data: frame.bytes(),
                             timestamp: None,
+                            durable_frame_no: None,
                         })))
                     }
                 }

--- a/libsql-server/src/rpc/replication/libsql_replicator.rs
+++ b/libsql-server/src/rpc/replication/libsql_replicator.rs
@@ -13,6 +13,7 @@ use libsql_replication::rpc::replication::{
 use libsql_wal::io::StdIO;
 use libsql_wal::registry::WalRegistry;
 use libsql_wal::segment::Frame;
+use libsql_wal::shared_wal::SharedWal;
 use md5::{Digest as _, Md5};
 use tokio_stream::Stream;
 use tonic::Status;
@@ -72,12 +73,13 @@ pin_project_lite::pin_project! {
         #[pin]
         inner: S,
         flavor: WalFlavor,
+        shared: Arc<SharedWal<StdIO>>,
     }
 }
 
 impl<S> FrameStreamAdapter<S> {
-    fn new(inner: S, flavor: WalFlavor) -> Self {
-        Self { inner, flavor }
+    fn new(inner: S, flavor: WalFlavor, shared: Arc<SharedWal<StdIO>>) -> Self {
+        Self { inner, flavor, shared }
     }
 }
 
@@ -93,6 +95,11 @@ where
             Some(Ok(f)) => {
                 match this.flavor {
                     WalFlavor::Libsql => {
+                        let durable_frame_no = if f.header().is_commit() {
+                            Some(this.shared.durable_frame_no())
+                        } else {
+                            None
+                        };
                         // safety: frame implemements zerocopy traits, so it can safely be interpreted as a
                         // byte slize of the same size
                         let bytes: Box<[u8; size_of::<Frame>()]> =
@@ -102,7 +109,7 @@ where
                         Poll::Ready(Some(Ok(RpcFrame {
                             data,
                             timestamp: None,
-                            durable_frame_no: None,
+                            durable_frame_no,
                         })))
                     }
                     WalFlavor::Sqlite => {
@@ -133,6 +140,7 @@ impl ReplicationLog for LibsqlReplicationService {
     type LogEntriesStream = BoxStream<'static, Result<RpcFrame, Status>>;
     type SnapshotStream = BoxStream<'static, Result<RpcFrame, Status>>;
 
+    #[tracing::instrument(skip_all, fields(namespace))]
     async fn log_entries(
         &self,
         req: tonic::Request<LogOffset>,
@@ -143,10 +151,10 @@ impl ReplicationLog for LibsqlReplicationService {
         let req = req.into_inner();
         // TODO: replicator should only accecpt NonZero
         let replicator =
-            libsql_wal::replication::replicator::Replicator::new(shared, req.next_offset.max(1));
+            libsql_wal::replication::replicator::Replicator::new(shared.clone(), req.next_offset.max(1));
 
         let flavor = req.wal_flavor();
-        let stream = FrameStreamAdapter::new(replicator.into_frame_stream(), flavor);
+        let stream = FrameStreamAdapter::new(replicator.into_frame_stream(), flavor, shared);
         Ok(tonic::Response::new(Box::pin(stream)))
     }
 

--- a/libsql-server/src/rpc/replication/replication_log.rs
+++ b/libsql-server/src/rpc/replication/replication_log.rs
@@ -187,6 +187,7 @@ fn map_frame_stream_output(
         Ok((frame, ts)) => Ok(Frame {
             data: frame.bytes(),
             timestamp: ts.map(|ts| ts.timestamp_millis()),
+            durable_frame_no: None,
         }),
         Err(LogReadError::SnapshotRequired) => Err(Status::new(
             tonic::Code::FailedPrecondition,
@@ -431,6 +432,7 @@ mod snapshot_stream {
                         yield Ok(Frame {
                             data: libsql_replication::frame::Frame::from(frame).bytes(),
                             timestamp: None,
+                            durable_frame_no: None,
                         });
                     }
                     Err(e) => {

--- a/libsql-wal/src/bins/shell/main.rs
+++ b/libsql-wal/src/bins/shell/main.rs
@@ -143,7 +143,7 @@ where
     S: Storage,
 {
     let namespace = NamespaceName::from_string(namespace.to_owned());
-    let durable = storage.durable_frame_no(&namespace, None).await;
+    let durable = storage.durable_frame_no(&namespace, None).await.unwrap();
     println!("namespace: {namespace}");
     println!("max durable frame: {durable}");
 }

--- a/libsql-wal/src/checkpointer.rs
+++ b/libsql-wal/src/checkpointer.rs
@@ -52,6 +52,7 @@ where
     IO: Io,
     S: Sync + Send + 'static,
 {
+    #[tracing::instrument(skip(self))]
     fn checkpoint(
         &self,
         namespace: &NamespaceName,

--- a/libsql-wal/src/checkpointer.rs
+++ b/libsql-wal/src/checkpointer.rs
@@ -144,16 +144,21 @@ where
     async fn step(&mut self) {
         tokio::select! {
             biased;
-            // fixme: we should probably handle a panic in the checkpointing task somehow
-            Some(Ok((namespace, result))) = self.join_set.join_next(), if !self.join_set.is_empty() => {
-                self.checkpointing.remove(&namespace);
-                if let Err(e) = result {
-                    self.errors += 1;
-                    tracing::error!("error checkpointing ns {namespace}: {e}, rescheduling");
-                    // reschedule
-                    self.scheduled.insert(namespace);
-                } else {
-                    self.errors = 0;
+            result = self.join_set.join_next(), if !self.join_set.is_empty() => {
+                match result {
+                    Some(Ok((namespace, result))) => {
+                        self.checkpointing.remove(&namespace);
+                        if let Err(e) = result {
+                            self.errors += 1;
+                            tracing::error!("error checkpointing ns {namespace}: {e}, rescheduling");
+                            // reschedule
+                            self.scheduled.insert(namespace);
+                        } else {
+                            self.errors = 0;
+                        }
+                    }
+                    Some(Err(e)) => panic!("checkoint task panicked: {e}"),
+                    None => unreachable!("got None, but join set is not empty")
                 }
             }
             notified = self.recv.recv(), if !self.shutting_down => {

--- a/libsql-wal/src/checkpointer.rs
+++ b/libsql-wal/src/checkpointer.rs
@@ -158,7 +158,7 @@ where
                             self.errors = 0;
                         }
                     }
-                    Some(Err(e)) => panic!("checkoint task panicked: {e}"),
+                    Some(Err(e)) => panic!("checkpoint task panicked: {e}"),
                     None => unreachable!("got None, but join set is not empty")
                 }
             }

--- a/libsql-wal/src/error.rs
+++ b/libsql-wal/src/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
     InvalidFooterVersion,
 
     #[error("storage error: {0}")]
-    Storage(#[from] crate::storage::Error),
+    Storage(#[from] Box<crate::storage::Error>),
 }
 
 impl Into<libsql_sys::ffi::Error> for Error {

--- a/libsql-wal/src/error.rs
+++ b/libsql-wal/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
     InvalidFooterMagic,
     #[error("invalid db footer version")]
     InvalidFooterVersion,
+
+    #[error("storage error: {0}")]
+    Storage(#[from] crate::storage::Error),
 }
 
 impl Into<libsql_sys::ffi::Error> for Error {

--- a/libsql-wal/src/io/buf.rs
+++ b/libsql-wal/src/io/buf.rs
@@ -201,6 +201,11 @@ impl<T> ZeroCopyBuf<T> {
         unsafe { self.inner.assume_init_ref() }
     }
 
+    pub fn get_mut(&mut self) -> &mut T {
+        assert!(self.is_init());
+        unsafe { self.inner.assume_init_mut() }
+    }
+
     pub fn into_inner(self) -> T {
         assert!(self.is_init());
         unsafe { self.inner.assume_init() }

--- a/libsql-wal/src/io/compat.rs
+++ b/libsql-wal/src/io/compat.rs
@@ -14,7 +14,7 @@ where
     R: AsyncRead + Unpin,
 {
     let mut dst_offset = 0u64;
-    let mut buffer = BytesMut::zeroed(4096);
+    let mut buffer = BytesMut::with_capacity(4096);
     loop {
         let n = src.read_buf(&mut buffer).await?;
         if n == 0 {
@@ -22,7 +22,7 @@ where
         }
         let (b, ret) = dst.write_all_at_async(buffer, dst_offset).await;
         ret?;
-        dst_offset += b.len() as u64;
+        dst_offset += n as u64;
         buffer = b;
         buffer.clear();
     }

--- a/libsql-wal/src/lib.rs
+++ b/libsql-wal/src/lib.rs
@@ -179,7 +179,7 @@ pub mod test {
         loop {
             {
                 if *shared.durable_frame_no.lock() >= current {
-                    break
+                    break;
                 }
             }
 

--- a/libsql-wal/src/lib.rs
+++ b/libsql-wal/src/lib.rs
@@ -58,6 +58,7 @@ pub mod test {
     use std::path::Path;
     use std::path::PathBuf;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use libsql_sys::name::NamespaceName;
     use libsql_sys::rusqlite::OpenFlags;
@@ -171,5 +172,18 @@ pub mod test {
             shared.swap_current(&mut guard).unwrap();
         }
         tx.end();
+    }
+
+    pub async fn wait_current_durable<IO: Io>(shared: &SharedWal<IO>) {
+        let current = shared.current.load().next_frame_no().get() - 1;
+        loop {
+            {
+                if *shared.durable_frame_no.lock() >= current {
+                    break
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
     }
 }

--- a/libsql-wal/src/registry.rs
+++ b/libsql-wal/src/registry.rs
@@ -131,6 +131,8 @@ fn maybe_store_segment<S: Storage>(
         });
         storage.store(namespace, seg, None, cb);
     } else {
+        // segment can be checkpointed right away.
+        let _ = notifier.blocking_send(CheckpointMessage::Namespace(namespace.clone()));
         tracing::debug!("segment marked as not storable; skipping");
     }
 }

--- a/libsql-wal/src/registry.rs
+++ b/libsql-wal/src/registry.rs
@@ -384,6 +384,7 @@ where
     pub async fn sync_all(&self) -> Result<()>
         where S: Storage,
     {
+        tracing::info!("syncing {} namespaces", self.opened.len());
         for entry in self.opened.iter() {
             let Slot::Wal(shared) = entry.value() else { panic!("all wals should already be opened") };
             sync_one(shared, self.storage.as_ref()).await?;

--- a/libsql-wal/src/registry.rs
+++ b/libsql-wal/src/registry.rs
@@ -521,7 +521,7 @@ where
         let mut seen = RoaringBitmap::new();
         let replicator = StorageReplicator::new(storage, shared.namespace().clone());
         let stream = replicator
-            .stream(&mut seen, local_current_frame_no, 1)
+            .stream(&mut seen, remote_durable_frame_no, 1)
             .peekable();
         let mut injector = Injector::new(shared.clone(), 10)?;
         // use pin to the heap so that we can drop the stream in the loop, and count `seen`.

--- a/libsql-wal/src/registry.rs
+++ b/libsql-wal/src/registry.rs
@@ -533,6 +533,9 @@ where
             .stream(&mut seen, remote_durable_frame_no, 1)
             .peekable();
         let mut injector = Injector::new(shared.clone(), 10)?;
+        // we set the durable frame_no before we start injecting, because the wal may want to
+        // checkpoint on commit.
+        injector.set_durable(remote_durable_frame_no);
         // use pin to the heap so that we can drop the stream in the loop, and count `seen`.
         let mut stream = Box::pin(stream);
         loop {

--- a/libsql-wal/src/registry.rs
+++ b/libsql-wal/src/registry.rs
@@ -543,7 +543,6 @@ where
                 Some(Ok(mut frame)) => {
                     if stream.peek().await.is_none() {
                         drop(stream);
-                        frame.header_mut().frame_no();
                         frame.header_mut().set_size_after(seen.len() as _);
                         injector.insert_frame(frame).await?;
                         break;

--- a/libsql-wal/src/registry.rs
+++ b/libsql-wal/src/registry.rs
@@ -552,18 +552,6 @@ where
                 None => break,
             }
         }
-
-        let mut tx = Transaction::Write(injector.into_guard().into_inner());
-        let ret = {
-            let mut guard = tx.as_write_mut().unwrap().lock();
-            guard.commit();
-            // the current segment it unordered, no new frames should be appended to it, seal it and
-            // open a new segment
-            shared.swap_current(&guard)
-        };
-        // make sure the tx is always ended before it's dropped!
-        tx.end();
-        ret?;
     }
 
     tracing::info!("local database is up to date");

--- a/libsql-wal/src/replication/injector.rs
+++ b/libsql-wal/src/replication/injector.rs
@@ -68,6 +68,10 @@ impl<IO: Io> Injector<IO> {
         self.buffer.clear();
         self.tx.reset(0);
     }
+
+    pub(crate) fn into_guard(self) -> TxGuardOwned<IO::File> {
+        self.tx
+    }
 }
 
 #[cfg(test)]

--- a/libsql-wal/src/replication/injector.rs
+++ b/libsql-wal/src/replication/injector.rs
@@ -28,7 +28,7 @@ impl<IO: Io> Injector<IO> {
             capacity: buffer_capacity,
             tx: None,
             max_tx_frame_no: 0,
-            previous_durable_frame_no: 0, 
+            previous_durable_frame_no: 0,
         })
     }
 
@@ -84,25 +84,29 @@ impl<IO: Io> Injector<IO> {
                 if commit_data.is_some() {
                     self.max_tx_frame_no = 0;
                 }
-                let buffer = current
-                    .inject_frames(buffer, commit_data, tx)
-                .await?;
+                let buffer = current.inject_frames(buffer, commit_data, tx).await?;
                 self.buffer = buffer;
                 self.buffer.clear();
             }
 
             if size_after.is_some() {
                 let mut tx = self.tx.take().unwrap();
-                self.wal.new_frame_notifier.send_replace(last_committed_frame_no);
+                self.wal
+                    .new_frame_notifier
+                    .send_replace(last_committed_frame_no);
                 // the strategy to swap the current log is to do it on change of durable boundary,
                 // when we have caught up with the current durable frame_no
-                if self.current_durable() != self.previous_durable_frame_no && self.current_durable() >= self.max_tx_frame_no {
+                if self.current_durable() != self.previous_durable_frame_no
+                    && self.current_durable() >= self.max_tx_frame_no
+                {
                     let wal = self.wal.clone();
                     // FIXME: tokio dependency here is annoying, we need an async version of swap_current.
                     tokio::task::spawn_blocking(move || {
                         tx.commit();
                         wal.swap_current(&tx)
-                    }).await.unwrap()?
+                    })
+                    .await
+                    .unwrap()?
                 }
             }
         }

--- a/libsql-wal/src/replication/injector.rs
+++ b/libsql-wal/src/replication/injector.rs
@@ -20,13 +20,13 @@ pub struct Injector<IO: Io> {
 }
 
 impl<IO: Io> Injector<IO> {
-    pub fn new(
-        wal: Arc<SharedWal<IO>>,
-        buffer_capacity: usize,
-    ) -> Result<Self> {
+    pub fn new(wal: Arc<SharedWal<IO>>, buffer_capacity: usize) -> Result<Self> {
         let mut tx = Transaction::Read(wal.begin_read(u64::MAX));
         wal.upgrade(&mut tx)?;
-        let tx = tx.into_write().unwrap_or_else(|_| unreachable!()).into_lock_owned();
+        let tx = tx
+            .into_write()
+            .unwrap_or_else(|_| unreachable!())
+            .into_lock_owned();
         Ok(Self {
             wal,
             buffer: Vec::with_capacity(buffer_capacity),

--- a/libsql-wal/src/replication/injector.rs
+++ b/libsql-wal/src/replication/injector.rs
@@ -1,5 +1,6 @@
 //! The injector is the module in charge of injecting frames into a replica database.
 
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use crate::error::Result;
@@ -36,6 +37,14 @@ impl<IO: Io> Injector<IO> {
         })
     }
 
+    pub fn set_durable(&self, durable_frame_no: u64) {
+        let mut old = self.wal.durable_frame_no.lock();
+        if *old < durable_frame_no {
+            *old = durable_frame_no
+        } {
+            todo!("primary reported older frameno than current");
+        }
+    }
     pub async fn insert_frame(&mut self, frame: Box<Frame>) -> Result<Option<u64>> {
         let size_after = frame.size_after();
         self.max_tx_frame_no = self.max_tx_frame_no.max(frame.header().frame_no());

--- a/libsql-wal/src/replication/injector.rs
+++ b/libsql-wal/src/replication/injector.rs
@@ -2,8 +2,6 @@
 
 use std::sync::Arc;
 
-use tokio_stream::{Stream, StreamExt};
-
 use crate::error::Result;
 use crate::io::Io;
 use crate::segment::Frame;
@@ -36,19 +34,6 @@ impl<IO: Io> Injector<IO> {
             tx,
             max_tx_frame_no: 0,
         })
-    }
-
-    pub async fn inject_stream(&mut self, stream: impl Stream<Item = Result<Box<Frame>>>) -> Result<()> {
-        tokio::pin!(stream);
-        loop {
-            match stream.next().await {
-                Some(Ok(frame)) => {
-                    self.insert_frame(frame).await?;
-                },
-                Some(Err(e)) => return Err(e),
-                None => return Ok(()),
-            }
-        }
     }
 
     pub async fn insert_frame(&mut self, frame: Box<Frame>) -> Result<Option<u64>> {

--- a/libsql-wal/src/replication/storage.rs
+++ b/libsql-wal/src/replication/storage.rs
@@ -63,6 +63,7 @@ where
 
                         let (frame, ret) = segment.read_frame(Frame::new_box_zeroed(), offset as u32).await;
                         ret?;
+                        debug_assert_eq!(frame.header().size_after(), 0, "all frames in a compacted segment should have size_after set to 0");
                         if frame.header().frame_no() >= until {
                             yield frame;
                         }

--- a/libsql-wal/src/segment/compacted.rs
+++ b/libsql-wal/src/segment/compacted.rs
@@ -39,6 +39,10 @@ impl CompactedSegmentDataHeader {
 
         Ok(())
     }
+
+    pub fn size_after(&self) -> u32 {
+        self.size_after.get()
+    }
 }
 
 #[derive(Debug, AsBytes, FromZeroes, FromBytes)]
@@ -61,6 +65,10 @@ impl<F> CompactedSegment<F> {
             header: self.header,
             file: f(self.file),
         }
+    }
+
+    pub fn header(&self) -> &CompactedSegmentDataHeader {
+        &self.header
     }
 }
 

--- a/libsql-wal/src/segment/current.rs
+++ b/libsql-wal/src/segment/current.rs
@@ -23,7 +23,7 @@ use crate::io::file::FileExt;
 use crate::io::Inspect;
 use crate::segment::{checked_frame_offset, SegmentFlags};
 use crate::segment::{frame_offset, page_offset, sealed::SealedSegment};
-use crate::transaction::{Transaction, TxGuard, TxGuardOwned};
+use crate::transaction::{Transaction, TxGuardShared, TxGuardOwned};
 use crate::{LIBSQL_MAGIC, LIBSQL_PAGE_SIZE, LIBSQL_WAL_VERSION};
 
 use super::list::SegmentList;
@@ -231,7 +231,7 @@ impl<F> CurrentSegment<F> {
         &self,
         pages: impl Iterator<Item = (u32, &'a [u8])>,
         size_after: Option<u32>,
-        tx: &mut TxGuard<F>,
+        tx: &mut TxGuardShared<F>,
     ) -> Result<Option<u64>>
     where
         F: FileExt,

--- a/libsql-wal/src/segment/current.rs
+++ b/libsql-wal/src/segment/current.rs
@@ -23,7 +23,7 @@ use crate::io::file::FileExt;
 use crate::io::Inspect;
 use crate::segment::{checked_frame_offset, SegmentFlags};
 use crate::segment::{frame_offset, page_offset, sealed::SealedSegment};
-use crate::transaction::{Transaction, TxGuardShared, TxGuardOwned};
+use crate::transaction::{Transaction, TxGuardOwned, TxGuardShared};
 use crate::{LIBSQL_MAGIC, LIBSQL_PAGE_SIZE, LIBSQL_WAL_VERSION};
 
 use super::list::SegmentList;

--- a/libsql-wal/src/segment/current.rs
+++ b/libsql-wal/src/segment/current.rs
@@ -195,7 +195,9 @@ impl<F> CurrentSegment<F> {
                     header.set_flags(header.flags().union(SegmentFlags::FRAME_UNORDERED));
                     {
                         let savepoint = tx.savepoints.first().unwrap();
-                        header.frame_count = (header.frame_count.get() + (tx.next_offset - savepoint.next_offset) as u64).into();
+                        header.frame_count = (header.frame_count.get()
+                            + (tx.next_offset - savepoint.next_offset) as u64)
+                            .into();
                     }
                     header.recompute_checksum();
 
@@ -335,7 +337,9 @@ impl<F> CurrentSegment<F> {
                 // offset
                 let tx = tx.deref_mut();
                 let savepoint = tx.savepoints.first().unwrap();
-                header.frame_count = (header.frame_count.get() + (tx.next_offset - savepoint.next_offset) as u64).into();
+                header.frame_count = (header.frame_count.get()
+                    + (tx.next_offset - savepoint.next_offset) as u64)
+                    .into();
                 header.recompute_checksum();
 
                 self.file.write_all_at(header.as_bytes(), 0)?;

--- a/libsql-wal/src/segment/list.rs
+++ b/libsql-wal/src/segment/list.rs
@@ -109,7 +109,10 @@ where
         // readers pointing to them
         while let Some(segment) = &*current {
             // skip any segment more recent than until_frame_no
-            tracing::debug!(last_committed = segment.last_committed(), until = until_frame_no);
+            tracing::debug!(
+                last_committed = segment.last_committed(),
+                until = until_frame_no
+            );
             if segment.last_committed() <= until_frame_no {
                 if !segment.is_checkpointable() {
                     segs.clear();

--- a/libsql-wal/src/segment/list.rs
+++ b/libsql-wal/src/segment/list.rs
@@ -136,7 +136,7 @@ where
         let mut last_replication_index = 0;
         while let Some((k, v)) = union.next() {
             let page_no = u32::from_be_bytes(k.try_into().unwrap());
-            tracing::debug!(page_no);
+            tracing::trace!(page_no);
             let v = v.iter().min_by_key(|i| i.index).unwrap();
             let offset = v.value as u32;
 
@@ -197,6 +197,8 @@ where
         }
 
         self.len.fetch_sub(segs.len(), Ordering::Relaxed);
+
+        tracing::debug!(until = last_replication_index, "checkpointed");
 
         Ok(Some(last_replication_index))
     }

--- a/libsql-wal/src/segment/mod.rs
+++ b/libsql-wal/src/segment/mod.rs
@@ -160,6 +160,7 @@ pub trait Segment: Send + Sync + 'static {
     fn start_frame_no(&self) -> u64;
     fn last_committed(&self) -> u64;
     fn index(&self) -> &fst::Map<Arc<[u8]>>;
+    fn is_storable(&self) -> bool;
     fn read_page(&self, page_no: u32, max_frame_no: u64, buf: &mut [u8]) -> io::Result<bool>;
     /// returns the number of readers currently holding a reference to this log.
     /// The read count must monotonically decrease.
@@ -215,6 +216,10 @@ impl<T: Segment> Segment for Arc<T> {
 
     fn destroy<IO: Io>(&self, io: &IO) -> impl Future<Output = ()> {
         self.as_ref().destroy(io)
+    }
+
+    fn is_storable(&self) -> bool {
+        self.as_ref().is_storable()
     }
 }
 

--- a/libsql-wal/src/segment/mod.rs
+++ b/libsql-wal/src/segment/mod.rs
@@ -99,7 +99,7 @@ impl SegmentHeader {
         }
     }
 
-    fn flags(&self) -> SegmentFlags {
+    pub fn flags(&self) -> SegmentFlags {
         SegmentFlags::from_bits(self.flags.get()).unwrap()
     }
 

--- a/libsql-wal/src/segment/mod.rs
+++ b/libsql-wal/src/segment/mod.rs
@@ -50,6 +50,8 @@ pub struct SegmentHeader {
     pub version: U16,
     pub start_frame_no: U64,
     pub last_commited_frame_no: U64,
+    /// number of frames in the segment
+    pub frame_count: U64,
     /// size of the database in pages, after applying the segment.
     pub size_after: U32,
     /// byte offset of the index. If 0, then the index wasn't written, and must be recovered.
@@ -120,14 +122,11 @@ impl SegmentHeader {
     }
 
     fn is_empty(&self) -> bool {
-        self.last_commited_frame_no.get() == 0
+        self.frame_count() == 0
     }
 
-    fn count_committed(&self) -> usize {
-        self.last_commited_frame_no
-            .get()
-            .checked_sub(self.start_frame_no.get() - 1)
-            .unwrap_or(0) as usize
+    pub fn frame_count(&self) -> usize {
+        self.frame_count.get() as usize
     }
 
     pub fn last_committed(&self) -> u64 {

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -108,8 +108,12 @@ where
         let mut current_offset = 0;
 
         while let Some((page_no_bytes, offset)) = pages.next() {
-            let (b, ret) = self.read_frame_offset_async(offset as _, buffer).await;
-            ret.unwrap();
+            let (mut b, ret) = self.read_frame_offset_async(offset as _, buffer).await;
+            ret?;
+            // transaction boundaries in a segment are completely erased. The responsibility in on
+            // the user of the segment to place the transaction boundary such that all frames from
+            // the segment are applied within the same transaction.
+            b.get_mut().header_mut().set_size_after(0);
             hasher.update(&b.get_ref().as_bytes());
             let dest_offset =
                 size_of::<CompactedSegmentDataHeader>() + current_offset * size_of::<Frame>();
@@ -191,6 +195,14 @@ where
             }
         }
     }
+
+    fn is_storable(&self) -> bool {
+        // we don't store unordered segments, since they only happen in two cases:
+        // - in a replica: no need for storage
+        // - in a primary, on recovery from storage: we don't want to override remote
+        // segment.
+        !self.header().flags().contains(SegmentFlags::FRAME_UNORDERED)
+    }
 }
 
 impl<F: FileExt> SealedSegment<F> {
@@ -211,7 +223,7 @@ impl<F: FileExt> SealedSegment<F> {
         // This happens in case of crash: the segment is not empty, but it wasn't sealed. We need to
         // recover the index, and seal the segment.
         if !header.flags().contains(SegmentFlags::SEALED) {
-            assert_eq!(header.index_offset.get(), 0);
+            assert_eq!(header.index_offset.get(), 0, "{header:?}");
             return Self::recover(file, path, header).map(Some);
         }
 
@@ -235,8 +247,6 @@ impl<F: FileExt> SealedSegment<F> {
         assert_eq!(header.index_size.get(), 0);
         assert_eq!(header.index_offset.get(), 0);
         assert!(!header.flags().contains(SegmentFlags::SEALED));
-        // recovery for replica log should take a different path (i.e: resync with primary)
-        assert!(!header.flags().contains(SegmentFlags::FRAME_UNORDERED));
 
         let mut current_checksum = header.salt.get();
         tracing::trace!("recovering unsealed segment at {path:?}");
@@ -246,6 +256,11 @@ impl<F: FileExt> SealedSegment<F> {
         let mut last_committed = 0;
         let mut size_after = 0;
         let mut frame_count = 0;
+        // When the segment is ordered, then the biggest frame_no is the last commited
+        // frame. This is not the case for an unordered segment (in case of recovery or
+        // a replica), so we track the biggest frame_no and set last_commited to that
+        // value on a commit frame
+        let mut max_seen_frame_no = 0;
         for i in 0.. {
             let offset = checked_frame_offset(i as u32);
             match file.read_exact_at(frame.as_bytes_mut(), offset) {
@@ -263,9 +278,19 @@ impl<F: FileExt> SealedSegment<F> {
                     current_checksum = new_checksum;
                     frame_count += 1;
 
+                    // this must always hold for a ordered segment.
+                    #[cfg(debug_assertions)]
+                    {
+                        if !header.flags().contains(SegmentFlags::FRAME_UNORDERED) {
+                            assert!(frame.frame.header().frame_no() > max_seen_frame_no);
+                        }
+                    }
+
+                    max_seen_frame_no = max_seen_frame_no.max(frame.frame.header.frame_no());
+
                     current_tx.push(frame.frame.header().page_no());
                     if frame.frame.header.is_commit() {
-                        last_committed = frame.frame.header().frame_no();
+                        last_committed = max_seen_frame_no;
                         size_after = frame.frame.header().size_after();
                         let base_offset = (i + 1) - current_tx.len();
                         for (frame_offset, page_no) in current_tx.drain(..).enumerate() {

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -201,7 +201,10 @@ where
         // - in a replica: no need for storage
         // - in a primary, on recovery from storage: we don't want to override remote
         // segment.
-        !self.header().flags().contains(SegmentFlags::FRAME_UNORDERED)
+        !self
+            .header()
+            .flags()
+            .contains(SegmentFlags::FRAME_UNORDERED)
     }
 }
 

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -304,6 +304,8 @@ impl<F: FileExt> SealedSegment<F> {
         header.index_size = index_size.into();
         header.last_commited_frame_no = last_committed.into();
         header.size_after = size_after.into();
+        let flags = header.flags();
+        header.set_flags(flags | SegmentFlags::SEALED);
         header.recompute_checksum();
         file.write_all_at(header.as_bytes(), 0)?;
         let index = Map::new(index_bytes.into()).unwrap();

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -110,8 +110,8 @@ where
         while let Some((page_no_bytes, offset)) = pages.next() {
             let (mut b, ret) = self.read_frame_offset_async(offset as _, buffer).await;
             ret?;
-            // transaction boundaries in a segment are completely erased. The responsibility in on
-            // the user of the segment to place the transaction boundary such that all frames from
+            // transaction boundaries in a segment are completely erased. The responsibility is on
+            // the consumer of the segment to place the transaction boundary such that all frames from
             // the segment are applied within the same transaction.
             b.get_mut().header_mut().set_size_after(0);
             hasher.update(&b.get_ref().as_bytes());

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -181,7 +181,9 @@ where
     }
 
     fn is_checkpointable(&self) -> bool {
-        self.read_locks.load(Ordering::Relaxed) == 0
+        let read_locks = self.read_locks.load(Ordering::Relaxed);
+        tracing::debug!(read_locks);
+        read_locks == 0
     }
 
     fn size_after(&self) -> u32 {

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -99,7 +99,7 @@ impl<IO: Io> SharedWal<IO> {
     pub fn durable_frame_no(&self) -> u64 {
         *self.durable_frame_no.lock()
     }
-    
+
     #[tracing::instrument(skip_all)]
     pub fn begin_read(&self, conn_id: u64) -> ReadTransaction<IO::File> {
         // FIXME: this is not enough to just increment the counter, we must make sure that the segment

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -35,7 +35,7 @@ pub struct WalLock {
 }
 
 pub(crate) trait SwapLog<IO: Io>: Sync + Send + 'static {
-    fn swap_current(&self, shared: &SharedWal<IO>, tx: &TxGuard<IO::File>) -> Result<()>;
+    fn swap_current(&self, shared: &SharedWal<IO>, tx: &dyn TxGuard<IO::File>) -> Result<()>;
 }
 
 pub struct SharedWal<IO: Io> {
@@ -300,7 +300,7 @@ impl<IO: Io> SharedWal<IO> {
     }
 
     /// Swap the current log. A write lock must be held, but the transaction must be must be committed already.
-    pub(crate) fn swap_current(&self, tx: &TxGuard<IO::File>) -> Result<()> {
+    pub(crate) fn swap_current(&self, tx: &impl TxGuard<IO::File>) -> Result<()> {
         self.registry.swap_current(self, tx)?;
         Ok(())
     }

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -274,7 +274,6 @@ impl<IO: Io> SharedWal<IO> {
             self.new_frame_notifier.send_replace(last_committed);
         }
 
-        // TODO: use config for max log size
         if tx.is_commited()
             && current.count_committed() > self.max_segment_size.load(Ordering::Relaxed)
         {

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -96,6 +96,10 @@ impl<IO: Io> SharedWal<IO> {
         self.current.load().log_id()
     }
 
+    pub fn durable_frame_no(&self) -> u64 {
+        *self.durable_frame_no.lock()
+    }
+    
     #[tracing::instrument(skip_all)]
     pub fn begin_read(&self, conn_id: u64) -> ReadTransaction<IO::File> {
         // FIXME: this is not enough to just increment the counter, we must make sure that the segment

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -305,6 +305,7 @@ impl<IO: Io> SharedWal<IO> {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn checkpoint(&self) -> Result<Option<u64>> {
         let durable_frame_no = *self.durable_frame_no.lock();
         let checkpointed_frame_no = self

--- a/libsql-wal/src/storage/async_storage.rs
+++ b/libsql-wal/src/storage/async_storage.rs
@@ -205,10 +205,10 @@ where
         &self,
         namespace: &NamespaceName,
         config_override: Option<Self::Config>,
-    ) -> u64 {
+    ) -> super::Result<u64> {
         let config = config_override.unwrap_or_else(|| self.backend.default_config());
-        let meta = self.backend.meta(&config, namespace).await.unwrap();
-        meta.max_frame_no
+        let meta = self.backend.meta(&config, namespace).await?;
+        Ok(meta.max_frame_no)
     }
 
     async fn restore(
@@ -230,7 +230,7 @@ where
         config_override: Option<Self::Config>,
     ) -> u64 {
         tokio::runtime::Handle::current()
-            .block_on(self.durable_frame_no(namespace, config_override))
+            .block_on(self.durable_frame_no(namespace, config_override)).unwrap()
     }
 
     async fn find_segment(

--- a/libsql-wal/src/storage/async_storage.rs
+++ b/libsql-wal/src/storage/async_storage.rs
@@ -224,15 +224,6 @@ where
             .await
     }
 
-    fn durable_frame_no_sync(
-        &self,
-        namespace: &NamespaceName,
-        config_override: Option<Self::Config>,
-    ) -> u64 {
-        tokio::runtime::Handle::current()
-            .block_on(self.durable_frame_no(namespace, config_override)).unwrap()
-    }
-
     async fn find_segment(
         &self,
         namespace: &NamespaceName,

--- a/libsql-wal/src/storage/job.rs
+++ b/libsql-wal/src/storage/job.rs
@@ -423,6 +423,10 @@ mod test {
             fn destroy<IO: Io>(&self, _io: &IO) -> impl std::future::Future<Output = ()> {
                 async move { todo!() }
             }
+
+            fn is_storable(&self) -> bool {
+                true
+            }
         }
 
         struct TestBackend;

--- a/libsql-wal/src/storage/mod.rs
+++ b/libsql-wal/src/storage/mod.rs
@@ -473,6 +473,12 @@ impl<IO: Io> Storage for TestStorage<IO> {
                 .or_default()
                 .insert(key, (out_path, index));
             tokio::runtime::Handle::current().block_on(on_store(end_frame_no));
+        } else {
+            // HACK: we need to spawn because many tests just call this method indirectly in
+            // async context. That makes tests easier to write.
+            tokio::task::spawn_blocking(move || {
+                tokio::runtime::Handle::current().block_on(on_store(u64::MAX));
+            });
         }
     }
 

--- a/libsql-wal/src/storage/mod.rs
+++ b/libsql-wal/src/storage/mod.rs
@@ -155,7 +155,7 @@ pub trait Storage: Send + Sync + 'static {
         &self,
         namespace: &NamespaceName,
         config_override: Option<Self::Config>,
-    ) -> u64;
+    ) -> Result<u64>;
 
     async fn restore(
         &self,
@@ -242,7 +242,7 @@ where
         &self,
         namespace: &NamespaceName,
         config_override: Option<Self::Config>,
-    ) -> u64 {
+    ) -> Result<u64> {
         match zip(self, config_override) {
             Either::A((s, c)) => s.durable_frame_no(namespace, c).await,
             Either::B((s, c)) => s.durable_frame_no(namespace, c).await,
@@ -341,8 +341,8 @@ impl Storage for NoStorage {
         &self,
         namespace: &NamespaceName,
         config: Option<Self::Config>,
-    ) -> u64 {
-        self.durable_frame_no_sync(namespace, config)
+    ) -> Result<u64> {
+        Ok(self.durable_frame_no_sync(namespace, config))
     }
 
     async fn restore(
@@ -486,8 +486,8 @@ impl<IO: Io> Storage for TestStorage<IO> {
         &self,
         namespace: &NamespaceName,
         config: Option<Self::Config>,
-    ) -> u64 {
-        self.durable_frame_no_sync(namespace, config)
+    ) -> Result<u64> {
+        Ok(self.durable_frame_no_sync(namespace, config))
     }
 
     async fn restore(

--- a/libsql-wal/src/storage/mod.rs
+++ b/libsql-wal/src/storage/mod.rs
@@ -52,12 +52,12 @@ pub enum RestoreOptions {
 /// let meta = SegmentMeta { start_frame_no: 101, end_frame_no: 1000 };
 /// map.insert(SegmentKey(&meta).to_string(), meta);
 ///
-/// map.range(format!("{:019}", u64::MAX - 50)..).next();
-/// map.range(format!("{:019}", u64::MAX - 0)..).next();
-/// map.range(format!("{:019}", u64::MAX - 1)..).next();
-/// map.range(format!("{:019}", u64::MAX - 100)..).next();
-/// map.range(format!("{:019}", u64::MAX - 101)..).next();
-/// map.range(format!("{:019}", u64::MAX - 5000)..).next();
+/// map.range(format!("{:020}", u64::MAX - 50)..).next();
+/// map.range(format!("{:020}", u64::MAX - 0)..).next();
+/// map.range(format!("{:020}", u64::MAX - 1)..).next();
+/// map.range(format!("{:020}", u64::MAX - 100)..).next();
+/// map.range(format!("{:020}", u64::MAX - 101)..).next();
+/// map.range(format!("{:020}", u64::MAX - 5000)..).next();
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SegmentKey {
@@ -137,7 +137,7 @@ impl fmt::Display for SegmentKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{:019}-{:019}",
+            "{:020}-{:020}",
             u64::MAX - self.start_frame_no,
             u64::MAX - self.end_frame_no,
         )

--- a/libsql-wal/src/transaction.rs
+++ b/libsql-wal/src/transaction.rs
@@ -189,10 +189,10 @@ impl<F> DerefMut for TxGuardOwned<F> {
     }
 }
 
-pub trait TxGuard<F>: Deref<Target = WriteTransaction<F>> + DerefMut + Send + Sync { }
+pub trait TxGuard<F>: Deref<Target = WriteTransaction<F>> + DerefMut + Send + Sync {}
 
-impl<'a, F: Send + Sync> TxGuard<F> for TxGuardShared<'a, F> { }
-impl<F: Send + Sync> TxGuard<F> for TxGuardOwned<F> { }
+impl<'a, F: Send + Sync> TxGuard<F> for TxGuardShared<'a, F> {}
+impl<F: Send + Sync> TxGuard<F> for TxGuardOwned<F> {}
 
 pub struct TxGuardShared<'a, F> {
     _lock: async_lock::MutexGuardArc<Option<u64>>,

--- a/libsql-wal/src/transaction.rs
+++ b/libsql-wal/src/transaction.rs
@@ -318,7 +318,7 @@ impl<F> WriteTransaction<F> {
             }
         }
 
-        tracing::debug!(id = read_tx.id, "lock released");
+        tracing::trace!(id = read_tx.id, "lock released");
 
         read_tx
     }

--- a/libsql-wal/src/wal.rs
+++ b/libsql-wal/src/wal.rs
@@ -131,7 +131,7 @@ impl<FS: Io> Wal for LibsqlWal<FS> {
         self.last_read_frame_no = Some(tx.max_frame_no);
         self.tx = Some(Transaction::Read(tx));
 
-        tracing::debug!(invalidate_cache, "read started");
+        tracing::trace!(invalidate_cache, "read started");
         Ok(invalidate_cache)
     }
 
@@ -182,9 +182,9 @@ impl<FS: Io> Wal for LibsqlWal<FS> {
         match self.tx.as_mut() {
             Some(tx) => {
                 self.shared.upgrade(tx).map_err(Into::into)?;
-                tracing::debug!("write lock acquired");
+                tracing::trace!("write lock acquired");
             }
-            None => todo!("should acquire read txn first"),
+            None => panic!("should acquire read txn first"),
         }
 
         Ok(())

--- a/libsql-wal/tests/oracle.rs
+++ b/libsql-wal/tests/oracle.rs
@@ -15,7 +15,7 @@ use libsql_sys::wal::{Sqlite3WalManager, Wal};
 use libsql_sys::Connection;
 use libsql_wal::registry::WalRegistry;
 use libsql_wal::storage::TestStorage;
-use libsql_wal::test::seal_current_segment;
+use libsql_wal::test::{seal_current_segment, wait_current_durable};
 use libsql_wal::wal::LibsqlWalManager;
 use once_cell::sync::Lazy;
 use rand::Rng;
@@ -130,6 +130,7 @@ async fn run_test_sample(path: &Path) -> Result {
 
     let shared = registry.clone().open(&db_path, &"test".into()).unwrap();
     seal_current_segment(&shared);
+    wait_current_durable(&shared).await;
     shared.checkpoint().await.unwrap();
 
     std::env::set_current_dir(curdir).unwrap();

--- a/libsql/src/replication/local_client.rs
+++ b/libsql/src/replication/local_client.rs
@@ -47,7 +47,7 @@ impl ReplicatorClient for LocalClient {
     async fn next_frames(&mut self) -> Result<Self::FrameStream, Error> {
         match self.frames.take() {
             Some(Frames::Vec(f)) => {
-                let iter = f.into_iter().map(|f| RpcFrame { data: f.bytes(), timestamp: None }).map(Ok);
+                let iter = f.into_iter().map(|f| RpcFrame { data: f.bytes(), timestamp: None, durable_frame_no: None }).map(Ok);
                 Ok(Box::pin(tokio_stream::iter(iter)))
             }
             Some(f @ Frames::Snapshot(_)) => {
@@ -72,7 +72,7 @@ impl ReplicatorClient for LocalClient {
                             next.header_mut().size_after = size_after.into();
                         }
                         let frame = Frame::from(next);
-                        yield RpcFrame { data: frame.bytes(), timestamp: None };
+                        yield RpcFrame { data: frame.bytes(), timestamp: None, durable_frame_no: None };
                     }
                 };
 


### PR DESCRIPTION
This PR implements syncing dbs from remote storage on startup, and fix bugs found along the way.

if the `--sync-from-storage` flag is passed, then all dbs will be synced with remote storage. The `--sync-conccurency <num>` flag control how many dbs are restored conccurently.
