### PR TITLE
add libsql_enable_tracing to the libsql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5366,6 +5366,8 @@ dependencies = [
  "lazy_static",
  "libsql",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -15,6 +15,8 @@ bytes = "1.5.0"
 lazy_static = "1.4.0"
 tokio = { version = "1.29.1", features = [ "rt-multi-thread" ] }
 hyper-rustls = { version = "0.25", features = ["webpki-roots"]}
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 
 [target.'cfg(not(any(target_os = "ios", target_os = "android")))'.dependencies]
 libsql = { path = "../../libsql", features = ["encryption"] }

--- a/bindings/c/include/libsql.h
+++ b/bindings/c/include/libsql.h
@@ -61,7 +61,7 @@ typedef struct {
 extern "C" {
 #endif // __cplusplus
 
-void libsql_enable_tracing(void);
+int libsql_enable_tracing(void);
 
 int libsql_sync(libsql_database_t db, const char **out_err_msg);
 

--- a/bindings/c/include/libsql.h
+++ b/bindings/c/include/libsql.h
@@ -61,7 +61,7 @@ typedef struct {
 extern "C" {
 #endif // __cplusplus
 
-int libsql_enable_tracing(void);
+int libsql_enable_internal_tracing(void);
 
 int libsql_sync(libsql_database_t db, const char **out_err_msg);
 

--- a/bindings/c/include/libsql.h
+++ b/bindings/c/include/libsql.h
@@ -61,6 +61,8 @@ typedef struct {
 extern "C" {
 #endif // __cplusplus
 
+void libsql_enable_tracing(void);
+
 int libsql_sync(libsql_database_t db, const char **out_err_msg);
 
 int libsql_sync2(libsql_database_t db, replicated *out_replicated, const char **out_err_msg);

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -32,7 +32,7 @@ unsafe fn set_err_msg(msg: String, output: *mut *const std::ffi::c_char) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn libsql_enable_tracing() -> std::ffi::c_int {
+pub unsafe extern "C" fn libsql_enable_internal_tracing() -> std::ffi::c_int {
     if tracing_subscriber::fmt::try_init().is_ok() {
         1
     } else {

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -32,8 +32,12 @@ unsafe fn set_err_msg(msg: String, output: *mut *const std::ffi::c_char) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn libsql_enable_tracing() {
-    tracing_subscriber::fmt::init();
+pub unsafe extern "C" fn libsql_enable_tracing() -> std::ffi::c_int {
+    if tracing_subscriber::fmt::try_init().is_ok() {
+        1
+    } else {
+        0
+    }
 }
 
 #[no_mangle]

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -32,6 +32,11 @@ unsafe fn set_err_msg(msg: String, output: *mut *const std::ffi::c_char) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn libsql_enable_tracing() {
+    tracing_subscriber::fmt::init();
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn libsql_sync(
     db: libsql_database_t,
     out_err_msg: *mut *const std::ffi::c_char,


### PR DESCRIPTION
## Context

LibSQL is used from multiple SDK. In order to simplify debugging of issues with these SDKs we can expose `libsql_enable_tracing` method which will print rust logs to the stdout (if `RUST_LOG` env var set properly)