### PR TITLE
Add call to statement reset to libsql_reset_stmt C binding

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -627,6 +627,7 @@ pub unsafe extern "C" fn libsql_reset_stmt(
     }
     let stmt = stmt.get_ref_mut();
     stmt.params.clear();
+    stmt.stmt.reset();
     0
 }
 


### PR DESCRIPTION
Without this call to stmt.reset(), the prepared statement is not correctly reset and the same values are read back despite having new bindings.

Fixes #1481