### PR TITLE
Fix schema db bug with replicas

### DIFF
--- a/libsql-server/src/connection/connection_core.rs
+++ b/libsql-server/src/connection/connection_core.rs
@@ -659,7 +659,7 @@ mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager)
+            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
                 .await
                 .unwrap(),
         );

--- a/libsql-server/src/connection/connection_core.rs
+++ b/libsql-server/src/connection/connection_core.rs
@@ -659,9 +659,15 @@ mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
-                .await
-                .unwrap(),
+            MetaStore::new(
+                Default::default(),
+                tmp.path(),
+                maker().unwrap(),
+                manager,
+                crate::database::DatabaseKind::Primary,
+            )
+            .await
+            .unwrap(),
         );
         conn.execute_program(
             Program::seq(&["CREATE TABLE test (x)"]),

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -570,6 +570,7 @@ where
             &self.path,
             meta_conn,
             meta_store_wal_manager,
+            db_kind,
         )
         .await?;
 

--- a/libsql-server/src/namespace/configurator/replica.rs
+++ b/libsql-server/src/namespace/configurator/replica.rs
@@ -66,7 +66,6 @@ impl ConfigureNamespace for ReplicaConfigurator {
             let channel = self.channel.clone();
             let uri = self.uri.clone();
 
-            dbg!(&name);
             let rpc_client = ReplicationLogClient::with_origin(channel.clone(), uri.clone());
             let client = crate::replication::replicator_client::Client::new(
                 name.clone(),
@@ -88,7 +87,7 @@ impl ConfigureNamespace for ReplicaConfigurator {
 
             tracing::debug!("try perform handshake");
             // force a handshake now, to retrieve the primary's current replication index
-            match replicator.try_perform_handshake().await.map_err(|e| dbg!(e)) {
+            match replicator.try_perform_handshake().await {
                 Err(libsql_replication::replicator::Error::Meta(
                     libsql_replication::meta::Error::LogIncompatible,
                 )) => {
@@ -112,7 +111,6 @@ impl ConfigureNamespace for ReplicaConfigurator {
                 Ok(_) => (),
             }
 
-            dbg!(&name);
             tracing::debug!("done performing handshake");
 
             let primary_current_replicatio_index =
@@ -170,7 +168,6 @@ impl ConfigureNamespace for ReplicaConfigurator {
                 }
             });
 
-            dbg!(&name);
             let stats = make_stats(
                 &db_path,
                 &mut join_set,
@@ -181,7 +178,6 @@ impl ConfigureNamespace for ReplicaConfigurator {
             )
             .await?;
 
-            dbg!(&name);
             let connection_maker = MakeLegacyConnection::new(
                 db_path.clone(),
                 PassthroughWalWrapper,
@@ -200,7 +196,6 @@ impl ConfigureNamespace for ReplicaConfigurator {
             )
             .await?;
 
-            dbg!(&name);
             let connection_maker = Arc::new(
                 MakeWriteProxyConn::new(
                     channel.clone(),
@@ -221,13 +216,11 @@ impl ConfigureNamespace for ReplicaConfigurator {
                 ),
             );
 
-            dbg!(&name);
             join_set.spawn(run_storage_monitor(
                 Arc::downgrade(&stats),
                 connection_maker.clone(),
             ));
 
-            dbg!(&name);
             Ok(Namespace {
                 tasks: join_set,
                 db: Database::Replica(ReplicaDatabase { connection_maker }),

--- a/libsql-server/src/namespace/store.rs
+++ b/libsql-server/src/namespace/store.rs
@@ -398,7 +398,7 @@ impl NamespaceStore {
         let init = async {
             let ns = self
                 .make_namespace(namespace, db_config, restore_option)
-                .await.map_err(|e| dbg!(e))?;
+                .await?;
             Ok(Some(ns))
         };
 
@@ -516,7 +516,6 @@ impl NamespaceStore {
     }
 
     fn get_configurator(&self, db_config: &DatabaseConfig) -> &DynConfigurator {
-        dbg!(self.inner.db_kind);
         match self.inner.db_kind {
             DatabaseKind::Primary if db_config.is_shared_schema => {
                 self.inner.configurators.configure_schema().unwrap()

--- a/libsql-server/src/namespace/store.rs
+++ b/libsql-server/src/namespace/store.rs
@@ -398,7 +398,7 @@ impl NamespaceStore {
         let init = async {
             let ns = self
                 .make_namespace(namespace, db_config, restore_option)
-                .await?;
+                .await.map_err(|e| dbg!(e))?;
             Ok(Some(ns))
         };
 
@@ -516,6 +516,7 @@ impl NamespaceStore {
     }
 
     fn get_configurator(&self, db_config: &DatabaseConfig) -> &DynConfigurator {
+        dbg!(self.inner.db_kind);
         match self.inner.db_kind {
             DatabaseKind::Primary if db_config.is_shared_schema => {
                 self.inner.configurators.configure_schema().unwrap()

--- a/libsql-server/src/replication/replicator_client.rs
+++ b/libsql-server/src/replication/replicator_client.rs
@@ -108,7 +108,6 @@ impl ReplicatorClient for Client {
         self.primary_replication_index = hello.current_replication_index;
         self.session_token.replace(hello.session_token.clone());
 
-        dbg!();
         if let Some(config) = &hello.config {
             // HACK: if we load a shared schema db before the main schema is replicated,
             // inserting the new database in the meta store will cause a foreign constraint Error
@@ -117,7 +116,6 @@ impl ReplicatorClient for Client {
             if let Some(ref name) = config.shared_schema_name {
                 let name = NamespaceName::from_string(name.clone())
                     .map_err(|_| Status::new(Code::InvalidArgument, "invalid namespace name"))?;
-                dbg!(&name);
                 self.store
                     .with(name, |_| ())
                     .await
@@ -127,7 +125,7 @@ impl ReplicatorClient for Client {
             self.meta_store_handle
                 .store(DatabaseConfig::from(config))
                 .await
-                .map_err(|e| dbg!(Error::Internal(e.into())))?;
+                .map_err(|e| Error::Internal(e.into()))?;
 
             tracing::debug!("replica config has been updated");
         } else {

--- a/libsql-server/src/replication/replicator_client.rs
+++ b/libsql-server/src/replication/replicator_client.rs
@@ -108,6 +108,7 @@ impl ReplicatorClient for Client {
         self.primary_replication_index = hello.current_replication_index;
         self.session_token.replace(hello.session_token.clone());
 
+        dbg!();
         if let Some(config) = &hello.config {
             // HACK: if we load a shared schema db before the main schema is replicated,
             // inserting the new database in the meta store will cause a foreign constraint Error
@@ -116,15 +117,17 @@ impl ReplicatorClient for Client {
             if let Some(ref name) = config.shared_schema_name {
                 let name = NamespaceName::from_string(name.clone())
                     .map_err(|_| Status::new(Code::InvalidArgument, "invalid namespace name"))?;
+                dbg!(&name);
                 self.store
                     .with(name, |_| ())
                     .await
                     .map_err(|e| Status::new(Code::Internal, e.to_string()))?;
             }
+
             self.meta_store_handle
                 .store(DatabaseConfig::from(config))
                 .await
-                .map_err(|e| Error::Internal(e.into()))?;
+                .map_err(|e| dbg!(Error::Internal(e.into())))?;
 
             tracing::debug!("replica config has been updated");
         } else {

--- a/libsql-server/src/rpc/streaming_exec.rs
+++ b/libsql-server/src/rpc/streaming_exec.rs
@@ -396,9 +396,15 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::Anonymous,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
-                .await
-                .unwrap(),
+            MetaStore::new(
+                Default::default(),
+                tmp.path(),
+                maker().unwrap(),
+                manager,
+                crate::database::DatabaseKind::Primary,
+            )
+            .await
+            .unwrap(),
         );
         let stream = make_proxy_stream(conn, ctx, ReceiverStream::new(rcv));
         pin!(stream);
@@ -422,9 +428,15 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
-                .await
-                .unwrap(),
+            MetaStore::new(
+                Default::default(),
+                tmp.path(),
+                maker().unwrap(),
+                manager,
+                crate::database::DatabaseKind::Primary,
+            )
+            .await
+            .unwrap(),
         );
         let stream = make_proxy_stream(conn, ctx, ReceiverStream::new(rcv));
 
@@ -444,9 +456,15 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
-                .await
-                .unwrap(),
+            MetaStore::new(
+                Default::default(),
+                tmp.path(),
+                maker().unwrap(),
+                manager,
+                crate::database::DatabaseKind::Primary,
+            )
+            .await
+            .unwrap(),
         );
         let stream = make_proxy_stream(conn, ctx, ReceiverStream::new(rcv));
 
@@ -468,9 +486,15 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
-                .await
-                .unwrap(),
+            MetaStore::new(
+                Default::default(),
+                tmp.path(),
+                maker().unwrap(),
+                manager,
+                crate::database::DatabaseKind::Primary,
+            )
+            .await
+            .unwrap(),
         );
         // limit the size of the response to force a split
         let stream = make_proxy_stream_inner(conn, ctx, ReceiverStream::new(rcv), 500);
@@ -525,9 +549,15 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
-                .await
-                .unwrap(),
+            MetaStore::new(
+                Default::default(),
+                tmp.path(),
+                maker().unwrap(),
+                manager,
+                crate::database::DatabaseKind::Primary,
+            )
+            .await
+            .unwrap(),
         );
         let stream = make_proxy_stream(conn, ctx, ReceiverStream::new(rcv));
 
@@ -552,9 +582,15 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
-                .await
-                .unwrap(),
+            MetaStore::new(
+                Default::default(),
+                tmp.path(),
+                maker().unwrap(),
+                manager,
+                crate::database::DatabaseKind::Primary,
+            )
+            .await
+            .unwrap(),
         );
         let stream = make_proxy_stream(conn, ctx, ReceiverStream::new(rcv));
 
@@ -579,9 +615,15 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
-                .await
-                .unwrap(),
+            MetaStore::new(
+                Default::default(),
+                tmp.path(),
+                maker().unwrap(),
+                manager,
+                crate::database::DatabaseKind::Primary,
+            )
+            .await
+            .unwrap(),
         );
         let stream = make_proxy_stream(conn, ctx, ReceiverStream::new(rcv));
 
@@ -608,9 +650,15 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
-                .await
-                .unwrap(),
+            MetaStore::new(
+                Default::default(),
+                tmp.path(),
+                maker().unwrap(),
+                manager,
+                crate::database::DatabaseKind::Primary,
+            )
+            .await
+            .unwrap(),
         );
         let stream = make_proxy_stream(conn, ctx, ReceiverStream::new(rcv));
 

--- a/libsql-server/src/rpc/streaming_exec.rs
+++ b/libsql-server/src/rpc/streaming_exec.rs
@@ -396,7 +396,7 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::Anonymous,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager)
+            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
                 .await
                 .unwrap(),
         );
@@ -422,7 +422,7 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager)
+            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
                 .await
                 .unwrap(),
         );
@@ -444,7 +444,7 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager)
+            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
                 .await
                 .unwrap(),
         );
@@ -468,7 +468,7 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager)
+            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
                 .await
                 .unwrap(),
         );
@@ -525,7 +525,7 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager)
+            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
                 .await
                 .unwrap(),
         );
@@ -552,7 +552,7 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager)
+            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
                 .await
                 .unwrap(),
         );
@@ -579,7 +579,7 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager)
+            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
                 .await
                 .unwrap(),
         );
@@ -608,7 +608,7 @@ pub mod test {
         let ctx = RequestContext::new(
             Authenticated::FullAccess,
             NamespaceName::default(),
-            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager)
+            MetaStore::new(Default::default(), tmp.path(), maker().unwrap(), manager, crate::database::DatabaseKind::Primary)
                 .await
                 .unwrap(),
         );

--- a/libsql-server/src/schema/db.rs
+++ b/libsql-server/src/schema/db.rs
@@ -511,9 +511,15 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
-            .await
-            .unwrap();
+        let meta_store = MetaStore::new(
+            Default::default(),
+            tmp.path(),
+            conn,
+            manager,
+            crate::database::DatabaseKind::Primary,
+        )
+        .await
+        .unwrap();
         let mut conn = maker().unwrap();
         setup_schema(&mut conn).unwrap();
 
@@ -555,9 +561,15 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
-            .await
-            .unwrap();
+        let meta_store = MetaStore::new(
+            Default::default(),
+            tmp.path(),
+            conn,
+            manager,
+            crate::database::DatabaseKind::Primary,
+        )
+        .await
+        .unwrap();
 
         // FIXME: the actual error reported here is a shitty constraint error, we should make the
         // necessary checks beforehand, and return a nice error message.
@@ -577,9 +589,15 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
-            .await
-            .unwrap();
+        let meta_store = MetaStore::new(
+            Default::default(),
+            tmp.path(),
+            conn,
+            manager,
+            crate::database::DatabaseKind::Primary,
+        )
+        .await
+        .unwrap();
         let mut conn = maker().unwrap();
         setup_schema(&mut conn).unwrap();
 
@@ -624,9 +642,15 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
-            .await
-            .unwrap();
+        let meta_store = MetaStore::new(
+            Default::default(),
+            tmp.path(),
+            conn,
+            manager,
+            crate::database::DatabaseKind::Primary,
+        )
+        .await
+        .unwrap();
         let mut conn = maker().unwrap();
         setup_schema(&mut conn).unwrap();
 
@@ -674,9 +698,15 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
-            .await
-            .unwrap();
+        let meta_store = MetaStore::new(
+            Default::default(),
+            tmp.path(),
+            conn,
+            manager,
+            crate::database::DatabaseKind::Primary,
+        )
+        .await
+        .unwrap();
         let mut conn = maker().unwrap();
         setup_schema(&mut conn).unwrap();
 
@@ -725,9 +755,15 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
-            .await
-            .unwrap();
+        let meta_store = MetaStore::new(
+            Default::default(),
+            tmp.path(),
+            conn,
+            manager,
+            crate::database::DatabaseKind::Primary,
+        )
+        .await
+        .unwrap();
         let mut conn = maker().unwrap();
         setup_schema(&mut conn).unwrap();
 
@@ -751,9 +787,15 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
-            .await
-            .unwrap();
+        let meta_store = MetaStore::new(
+            Default::default(),
+            tmp.path(),
+            conn,
+            manager,
+            crate::database::DatabaseKind::Primary,
+        )
+        .await
+        .unwrap();
         let mut conn = maker().unwrap();
         setup_schema(&mut conn).unwrap();
 

--- a/libsql-server/src/schema/db.rs
+++ b/libsql-server/src/schema/db.rs
@@ -511,7 +511,7 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
             .await
             .unwrap();
         let mut conn = maker().unwrap();
@@ -555,7 +555,7 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
             .await
             .unwrap();
 
@@ -577,7 +577,7 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
             .await
             .unwrap();
         let mut conn = maker().unwrap();
@@ -624,7 +624,7 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
             .await
             .unwrap();
         let mut conn = maker().unwrap();
@@ -674,7 +674,7 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
             .await
             .unwrap();
         let mut conn = maker().unwrap();
@@ -725,7 +725,7 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
             .await
             .unwrap();
         let mut conn = maker().unwrap();
@@ -751,7 +751,7 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, crate::database::DatabaseKind::Primary)
             .await
             .unwrap();
         let mut conn = maker().unwrap();

--- a/libsql-server/src/schema/scheduler.rs
+++ b/libsql-server/src/schema/scheduler.rs
@@ -826,9 +826,15 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, DatabaseKind::Primary)
-            .await
-            .unwrap();
+        let meta_store = MetaStore::new(
+            Default::default(),
+            tmp.path(),
+            conn,
+            manager,
+            DatabaseKind::Primary,
+        )
+        .await
+        .unwrap();
         let (sender, mut receiver) = mpsc::channel(100);
         let config = make_config(sender.clone().into(), tmp.path());
         let store =
@@ -950,9 +956,15 @@ mod test {
         {
             let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
             let conn = maker().unwrap();
-            let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, DatabaseKind::Primary)
-                .await
-                .unwrap();
+            let meta_store = MetaStore::new(
+                Default::default(),
+                tmp.path(),
+                conn,
+                manager,
+                DatabaseKind::Primary,
+            )
+            .await
+            .unwrap();
             let (sender, mut receiver) = mpsc::channel(100);
             let config = make_config(sender.clone().into(), tmp.path());
             let store =
@@ -1025,9 +1037,15 @@ mod test {
 
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, DatabaseKind::Primary)
-            .await
-            .unwrap();
+        let meta_store = MetaStore::new(
+            Default::default(),
+            tmp.path(),
+            conn,
+            manager,
+            DatabaseKind::Primary,
+        )
+        .await
+        .unwrap();
         let (sender, _receiver) = mpsc::channel(100);
         let config = make_config(sender.clone().into(), tmp.path());
         let store =
@@ -1053,9 +1071,15 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, DatabaseKind::Primary)
-            .await
-            .unwrap();
+        let meta_store = MetaStore::new(
+            Default::default(),
+            tmp.path(),
+            conn,
+            manager,
+            DatabaseKind::Primary,
+        )
+        .await
+        .unwrap();
         let (sender, mut receiver) = mpsc::channel(100);
         let config = make_config(sender.clone().into(), tmp.path());
         let store =
@@ -1127,9 +1151,15 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, DatabaseKind::Primary)
-            .await
-            .unwrap();
+        let meta_store = MetaStore::new(
+            Default::default(),
+            tmp.path(),
+            conn,
+            manager,
+            DatabaseKind::Primary,
+        )
+        .await
+        .unwrap();
         let (sender, _receiver) = mpsc::channel(100);
         let config = make_config(sender.clone().into(), tmp.path());
         let store =

--- a/libsql-server/src/schema/scheduler.rs
+++ b/libsql-server/src/schema/scheduler.rs
@@ -826,7 +826,7 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, DatabaseKind::Primary)
             .await
             .unwrap();
         let (sender, mut receiver) = mpsc::channel(100);
@@ -950,7 +950,7 @@ mod test {
         {
             let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
             let conn = maker().unwrap();
-            let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+            let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, DatabaseKind::Primary)
                 .await
                 .unwrap();
             let (sender, mut receiver) = mpsc::channel(100);
@@ -1025,7 +1025,7 @@ mod test {
 
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, DatabaseKind::Primary)
             .await
             .unwrap();
         let (sender, _receiver) = mpsc::channel(100);
@@ -1053,7 +1053,7 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, DatabaseKind::Primary)
             .await
             .unwrap();
         let (sender, mut receiver) = mpsc::channel(100);
@@ -1127,7 +1127,7 @@ mod test {
         let tmp = tempdir().unwrap();
         let (maker, manager) = metastore_connection_maker(None, tmp.path()).await.unwrap();
         let conn = maker().unwrap();
-        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager)
+        let meta_store = MetaStore::new(Default::default(), tmp.path(), conn, manager, DatabaseKind::Primary)
             .await
             .unwrap();
         let (sender, _receiver) = mpsc::channel(100);

--- a/libsql-server/tests/cluster/mod.rs
+++ b/libsql-server/tests/cluster/mod.rs
@@ -17,6 +17,7 @@ use crate::common::{http::Client, net::SimServer, snapshot_metrics};
 
 mod replica_restart;
 mod replication;
+mod schema_dbs;
 
 pub fn make_cluster(sim: &mut Sim, num_replica: usize, disable_namespaces: bool) {
     init_tracing();

--- a/libsql-server/tests/cluster/schema_dbs.rs
+++ b/libsql-server/tests/cluster/schema_dbs.rs
@@ -1,0 +1,131 @@
+use std::time::Duration;
+
+use libsql::Database;
+use serde_json::json;
+use turmoil::Builder;
+
+use crate::common::http::Client;
+use crate::common::net::TurmoilConnector;
+
+use super::make_cluster;
+
+#[test]
+fn schema_migration_basics() {
+    let mut sim = Builder::new()
+        .simulation_duration(Duration::from_secs(1000))
+        .build();
+    make_cluster(&mut sim, 1, true);
+
+    sim.client("client", async {
+        let http = Client::new();
+
+        assert!(http
+            .post(
+                "http://primary:9090/v1/namespaces/schema/create",
+                json!({ "shared_schema": true })
+            )
+            .await
+            .unwrap()
+            .status()
+            .is_success());
+        assert!(http
+            .post(
+                "http://primary:9090/v1/namespaces/foo/create",
+                json!({ "shared_schema_name": "schema" })
+            )
+            .await
+            .unwrap()
+            .status()
+            .is_success());
+
+        {
+            let db = Database::open_remote_with_connector(
+                "http://schema.primary:8080",
+                "",
+                TurmoilConnector,
+            )
+            .unwrap();
+            let conn = db.connect().unwrap();
+            conn.execute("create table test (x)", ()).await.unwrap();
+        }
+
+        {
+            let db = Database::open_remote_with_connector(
+                "http://foo.primary:8080",
+                "",
+                TurmoilConnector,
+            )
+            .unwrap();
+            let conn = db.connect().unwrap();
+            conn.execute("insert into test values (42)", ())
+                .await
+                .unwrap();
+
+            assert_eq!(
+                conn.query("select count(*) from test", ())
+                    .await
+                    .unwrap()
+                    .next()
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .get::<u64>(0)
+                    .unwrap(),
+                1
+            );
+        }
+
+        {
+            let db = Database::open_remote_with_connector(
+                "http://schema.replica0:8080",
+                "",
+                TurmoilConnector,
+            )
+            .unwrap();
+            let conn = db.connect().unwrap();
+            conn.execute("create table test2 (x)", ()).await.unwrap();
+        }
+
+        {
+            let db = Database::open_remote_with_connector(
+                "http://foo.replica0:8080",
+                "",
+                TurmoilConnector,
+            )
+            .unwrap();
+            let conn = db.connect().unwrap();
+            conn.execute("insert into test values (42)", ())
+                .await
+                .unwrap();
+
+            assert_eq!(
+                conn.query("select count(*) from test", ())
+                    .await
+                    .unwrap()
+                    .next()
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .get::<u64>(0)
+                    .unwrap(),
+                2
+            );
+            assert_eq!(
+                conn.query("select count(*) from test2", ())
+                    .await
+                    .unwrap()
+                    .next()
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .get::<u64>(0)
+                    .unwrap(),
+                0
+            );
+        }
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}


### PR DESCRIPTION
The was a regression where the replica would check for migrations completion on load. This is fixed by skipping the check for replicas.

also add regression tests
