### PR TITLE
add support for basic auth for admin api

### DIFF
--- a/libsql-server/src/config.rs
+++ b/libsql-server/src/config.rs
@@ -83,6 +83,7 @@ pub struct AdminApiConfig<A = AddrIncoming, C = HttpsConnector<HttpConnector>> {
     pub acceptor: A,
     pub connector: C,
     pub disable_metrics: bool,
+    pub auth_key: Option<String>,
 }
 
 #[derive(Clone)]

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -320,6 +320,7 @@ where
             acceptor,
             connector,
             disable_metrics,
+            auth_key,
         }) = self.admin_api_config
         {
             task_manager.spawn_with_shutdown_notify(|shutdown| {
@@ -330,6 +331,7 @@ where
                     connector,
                     disable_metrics,
                     shutdown,
+                    auth_key.map(Into::into),
                 )
             });
         }

--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -276,6 +276,10 @@ struct Cli {
     /// Enables the main runtime deadlock monitor: if the main runtime deadlocks, logs an error
     #[clap(long)]
     enable_deadlock_monitor: bool,
+
+    /// Auth key for the admin API
+    #[clap(long, env = "LIBSQL_ADMIN_AUTH_KEY", requires = "admin_listen_addr")]
+    admin_auth_key: Option<String>,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -468,6 +472,7 @@ async fn make_admin_api_config(config: &Cli) -> anyhow::Result<Option<AdminApiCo
                 acceptor,
                 connector,
                 disable_metrics: false,
+                auth_key: config.admin_auth_key.clone(),
             }))
         }
         None => Ok(None),

--- a/libsql-server/tests/cluster/mod.rs
+++ b/libsql-server/tests/cluster/mod.rs
@@ -34,6 +34,7 @@ pub fn make_cluster(sim: &mut Sim, num_replica: usize, disable_namespaces: bool)
                     acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await?,
                     connector: TurmoilConnector,
                     disable_metrics: true,
+                    auth_key: None,
                 }),
                 rpc_server_config: Some(RpcServerConfig {
                     acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 4567)).await?,
@@ -64,6 +65,7 @@ pub fn make_cluster(sim: &mut Sim, num_replica: usize, disable_namespaces: bool)
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await?,
                         connector: TurmoilConnector,
                         disable_metrics: true,
+                        auth_key: None,
                     }),
                     rpc_client_config: Some(RpcClientConfig {
                         remote_url: "http://primary:4567".into(),

--- a/libsql-server/tests/cluster/replica_restart.rs
+++ b/libsql-server/tests/cluster/replica_restart.rs
@@ -34,6 +34,7 @@ fn replica_restart() {
                     acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await?,
                     connector: TurmoilConnector,
                     disable_metrics: true,
+                    auth_key: None,
                 }),
                 rpc_server_config: Some(RpcServerConfig {
                     acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 4567)).await?,
@@ -67,6 +68,7 @@ fn replica_restart() {
                             acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                             connector: TurmoilConnector,
                             disable_metrics: true,
+                            auth_key: None,
                         }),
                         rpc_client_config: Some(RpcClientConfig {
                             remote_url: "http://primary:4567".into(),
@@ -187,6 +189,7 @@ fn primary_regenerate_log_no_replica_restart() {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                         connector: TurmoilConnector,
                         disable_metrics: true,
+                        auth_key: None,
                     }),
                     rpc_server_config: Some(RpcServerConfig {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 4567)).await.unwrap(),
@@ -241,6 +244,7 @@ fn primary_regenerate_log_no_replica_restart() {
                             acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                             connector: TurmoilConnector,
                             disable_metrics: true,
+                            auth_key: None,
                         }),
                         rpc_client_config: Some(RpcClientConfig {
                             remote_url: "http://primary:4567".into(),
@@ -365,6 +369,7 @@ fn primary_regenerate_log_with_replica_restart() {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                         connector: TurmoilConnector,
                         disable_metrics: true,
+                        auth_key: None,
                     }),
                     rpc_server_config: Some(RpcServerConfig {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 4567)).await.unwrap(),
@@ -421,6 +426,7 @@ fn primary_regenerate_log_with_replica_restart() {
                             acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                             connector: TurmoilConnector,
                             disable_metrics: true,
+                            auth_key: None,
                         }),
                         rpc_client_config: Some(RpcClientConfig {
                             remote_url: "http://primary:4567".into(),

--- a/libsql-server/tests/cluster/replication.rs
+++ b/libsql-server/tests/cluster/replication.rs
@@ -40,6 +40,7 @@ fn apply_partial_snapshot() {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                         connector: TurmoilConnector,
                         disable_metrics: true,
+                        auth_key: None,
                     }),
                     rpc_server_config: Some(RpcServerConfig {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 5050)).await.unwrap(),
@@ -71,6 +72,7 @@ fn apply_partial_snapshot() {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                         connector: TurmoilConnector,
                         disable_metrics: true,
+                        auth_key: None,
                     }),
                     rpc_client_config: Some(RpcClientConfig {
                         remote_url: "http://primary:5050".into(),
@@ -167,6 +169,7 @@ fn replica_lazy_creation() {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                         connector: TurmoilConnector,
                         disable_metrics: true,
+                        auth_key: None,
                     }),
                     rpc_server_config: Some(RpcServerConfig {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 5050)).await.unwrap(),
@@ -197,6 +200,7 @@ fn replica_lazy_creation() {
                     acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                     connector: TurmoilConnector,
                     disable_metrics: true,
+                    auth_key: None,
                 }),
                 rpc_client_config: Some(RpcClientConfig {
                     remote_url: "http://primary:5050".into(),

--- a/libsql-server/tests/embedded_replica/mod.rs
+++ b/libsql-server/tests/embedded_replica/mod.rs
@@ -55,6 +55,7 @@ fn make_primary(sim: &mut Sim, path: PathBuf) {
                     acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await?,
                     connector: TurmoilConnector,
                     disable_metrics: false,
+                    auth_key: None,
                 }),
                 rpc_server_config: Some(RpcServerConfig {
                     acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 4567)).await?,
@@ -408,6 +409,7 @@ fn replica_primary_reset() {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                         connector: TurmoilConnector,
                         disable_metrics: true,
+                        auth_key: None,
                     }),
                     rpc_server_config: Some(RpcServerConfig {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 4567)).await.unwrap(),
@@ -692,6 +694,7 @@ fn replicate_with_snapshots() {
                     acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                     connector: TurmoilConnector,
                     disable_metrics: true,
+                    auth_key: None,
                 }),
                 rpc_server_config: Some(RpcServerConfig {
                     acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 4567)).await.unwrap(),
@@ -1266,6 +1269,7 @@ fn replicated_return() {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                         connector: TurmoilConnector,
                         disable_metrics: true,
+                        auth_key: None,
                     }),
                     rpc_server_config: Some(RpcServerConfig {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 4567)).await.unwrap(),
@@ -1395,6 +1399,7 @@ fn replicate_auth() {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await?,
                         connector: TurmoilConnector,
                         disable_metrics: true,
+                        auth_key: None,
                     }),
                     rpc_server_config: Some(RpcServerConfig {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 4567)).await?,
@@ -1430,6 +1435,7 @@ fn replicate_auth() {
                         acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await?,
                         connector: TurmoilConnector,
                         disable_metrics: true,
+                        auth_key: None,
                     }),
                     rpc_client_config: Some(RpcClientConfig {
                         remote_url: "http://primary:4567".into(),

--- a/libsql-server/tests/namespaces/mod.rs
+++ b/libsql-server/tests/namespaces/mod.rs
@@ -29,6 +29,7 @@ fn make_primary(sim: &mut Sim, path: PathBuf) {
                     acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await?,
                     connector: TurmoilConnector,
                     disable_metrics: true,
+                    auth_key: None,
                 }),
                 rpc_server_config: Some(RpcServerConfig {
                     acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 4567)).await?,

--- a/libsql-server/tests/standalone/admin.rs
+++ b/libsql-server/tests/standalone/admin.rs
@@ -1,0 +1,67 @@
+use std::time::Duration;
+
+use hyper::StatusCode;
+use libsql_server::config::{AdminApiConfig, UserApiConfig};
+use s3s::header::AUTHORIZATION;
+use serde_json::json;
+use tempfile::tempdir;
+
+use crate::common::{
+    http::Client,
+    net::{SimServer as _, TestServer, TurmoilAcceptor, TurmoilConnector},
+};
+
+#[test]
+fn admin_auth() {
+    let mut sim = turmoil::Builder::new()
+        .simulation_duration(Duration::from_secs(1000))
+        .build();
+
+    sim.host("primary", || async move {
+        let tmp = tempdir().unwrap();
+        let server = TestServer {
+            path: tmp.path().to_owned().into(),
+            user_api_config: UserApiConfig {
+                hrana_ws_acceptor: None,
+                ..Default::default()
+            },
+            admin_api_config: Some(AdminApiConfig {
+                acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
+                connector: TurmoilConnector,
+                disable_metrics: true,
+                auth_key: Some("secretkey".into()),
+            }),
+            disable_namespaces: false,
+            ..Default::default()
+        };
+        server.start_sim(8080).await?;
+        Ok(())
+    });
+
+    sim.client("test", async {
+        let client = Client::new();
+
+        assert_eq!(
+            client
+                .post("http://primary:9090/v1/namespaces/foo/create", json!({}))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert!(client
+            .post_with_headers(
+                "http://primary:9090/v1/namespaces/foo/create",
+                &[(AUTHORIZATION, "basic  secretkey")],
+                json!({})
+            )
+            .await
+            .unwrap()
+            .status()
+            .is_success());
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}

--- a/libsql-server/tests/standalone/mod.rs
+++ b/libsql-server/tests/standalone/mod.rs
@@ -17,6 +17,7 @@ use libsql_server::config::{AdminApiConfig, UserApiConfig};
 
 use common::net::{init_tracing, TestServer, TurmoilConnector};
 
+mod admin;
 mod attach;
 mod auth;
 
@@ -33,6 +34,7 @@ async fn make_standalone_server() -> Result<(), Box<dyn std::error::Error>> {
             acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
             connector: TurmoilConnector,
             disable_metrics: true,
+            auth_key: None,
         }),
         disable_namespaces: false,
         ..Default::default()
@@ -355,6 +357,7 @@ fn dirty_startup_dont_prevent_namespace_creation() {
                 acceptor: TurmoilAcceptor::bind(([0, 0, 0, 0], 9090)).await.unwrap(),
                 connector: TurmoilConnector,
                 disable_metrics: true,
+                auth_key: None,
             }),
             disable_default_namespace: true,
             disable_namespaces: false,


### PR DESCRIPTION
Add support for basic auth for the admin API.

when the flag `LIBSQL_ADMIN_AUTH_KEY` is set, that value is used to authenticate requests to the admin API with the header `authorization: basic <key>`
