### PR TITLE
libsql: fix musl builds failing due to fcntl64

### DIFF
--- a/Dockerfile.musl
+++ b/Dockerfile.musl
@@ -1,0 +1,17 @@
+# A dockerfile that can be used to build musl targets
+# currently this is setup to run the most basic libsql example
+# to force the linker to resolve. This was able to reproduce the
+# fcntl64 issues + other issues that require custom flags for musl.
+
+FROM messense/rust-musl-cross:x86_64-musl
+RUN rustup target add x86_64-unknown-linux-musl
+
+COPY . .
+
+RUN rm rust-toolchain.toml
+
+ENV LIBSQL_DEV=1
+
+RUN apt-get install -y cmake
+
+RUN cargo run -p libsql --example example --features encryption

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -349,8 +349,8 @@ fn build_multiple_ciphers(target: &str, out_path: &Path) {
     cmake_opts.push("-DCMAKE_POSITION_INDEPENDENT_CODE=ON");
 
     if target.contains("musl") {
-        cmake_opts.push("-DCMAKE_C_FLAGS=\"-U_FORTIFY_SOURCE\"");
-        cmake_opts.push("-DCMAKE_CXX_FLAGS=\"-U_FORTIFY_SOURCE\"");
+        cmake_opts.push("-DCMAKE_C_FLAGS=\"-U_FORTIFY_SOURCE\" -D_FILE_OFFSET_BITS=32");
+        cmake_opts.push("-DCMAKE_CXX_FLAGS=\"-U_FORTIFY_SOURCE\" -D_FILE_OFFSET_BITS=32");
     }
 
     let mut cmake = Command::new("cmake");


### PR DESCRIPTION
This fixes a build issue with musl based systems that do not have fcntl64 in their libc. This is done by setting `FILE_OFFSET_BITS=32` only for musl targets. This forces the compiler to not convert `fcntl` to `fcntl64`.