### PR TITLE
libsql-wal: fix SegmentKey

### DIFF
--- a/libsql-wal/src/replication/storage.rs
+++ b/libsql-wal/src/replication/storage.rs
@@ -9,6 +9,7 @@ use zerocopy::FromZeroes;
 
 use crate::io::buf::ZeroCopyBoxIoBuf;
 use crate::segment::Frame;
+use crate::storage::backend::FindSegmentReq;
 use crate::storage::Storage;
 
 use super::Result;
@@ -43,9 +44,10 @@ where
         mut current: u64,
         until: u64,
     ) -> Pin<Box<dyn Stream<Item = Result<Box<Frame>>> + Send + 'a>> {
+        
         Box::pin(async_stream::try_stream! {
             loop {
-                let key = self.storage.find_segment(&self.namespace, current, None).await?;
+                let key = self.storage.find_segment(&self.namespace, FindSegmentReq::EndFrameNoLessThan(current), None).await?;
                 let index = self.storage.fetch_segment_index(&self.namespace, &key, None).await?;
                 let mut pages = index.into_stream();
                 let mut maybe_seg = None;

--- a/libsql-wal/src/replication/storage.rs
+++ b/libsql-wal/src/replication/storage.rs
@@ -44,7 +44,6 @@ where
         mut current: u64,
         until: u64,
     ) -> Pin<Box<dyn Stream<Item = Result<Box<Frame>>> + Send + 'a>> {
-        
         Box::pin(async_stream::try_stream! {
             loop {
                 let key = self.storage.find_segment(&self.namespace, FindSegmentReq::EndFrameNoLessThan(current), None).await?;

--- a/libsql-wal/src/storage/async_storage.rs
+++ b/libsql-wal/src/storage/async_storage.rs
@@ -232,14 +232,7 @@ where
         config_override: Option<Self::Config>,
     ) -> super::Result<super::SegmentKey> {
         let config = config_override.unwrap_or_else(|| self.backend.default_config());
-        let key = self
-            .backend
-            .find_segment(
-                &config,
-                namespace,
-                req,
-            )
-            .await?;
+        let key = self.backend.find_segment(&config, namespace, req).await?;
         Ok(key)
     }
 

--- a/libsql-wal/src/storage/async_storage.rs
+++ b/libsql-wal/src/storage/async_storage.rs
@@ -13,7 +13,7 @@ use crate::io::{FileExt, Io, StdIO};
 use crate::segment::compacted::CompactedSegment;
 use crate::segment::Segment;
 
-use super::backend::Backend;
+use super::backend::{Backend, FindSegmentReq};
 use super::scheduler::Scheduler;
 use super::{OnStoreCallback, RestoreOptions, Storage, StoreSegmentRequest};
 
@@ -228,7 +228,7 @@ where
     async fn find_segment(
         &self,
         namespace: &NamespaceName,
-        frame_no: u64,
+        req: FindSegmentReq,
         config_override: Option<Self::Config>,
     ) -> super::Result<super::SegmentKey> {
         let config = config_override.unwrap_or_else(|| self.backend.default_config());
@@ -237,7 +237,7 @@ where
             .find_segment(
                 &config,
                 namespace,
-                super::backend::FindSegmentReq::Frame(frame_no),
+                req,
             )
             .await?;
         Ok(key)

--- a/libsql-wal/src/storage/backend/mod.rs
+++ b/libsql-wal/src/storage/backend/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use std::sync::Arc;
-use std::{future::Future, path::Path};
+use std::future::Future;
 
 use chrono::{DateTime, Utc};
 use fst::Map;
@@ -31,9 +31,10 @@ pub struct DbMeta {
     pub max_frame_no: u64,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum FindSegmentReq {
     /// returns a segment containing this frame
-    Frame(u64),
+    EndFrameNoLessThan(u64),
     /// Returns the segment with closest timestamp less than or equal to the requested timestamp
     Timestamp(DateTime<Utc>),
 }

--- a/libsql-wal/src/storage/backend/mod.rs
+++ b/libsql-wal/src/storage/backend/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
-use std::sync::Arc;
 use std::future::Future;
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use fst::Map;

--- a/libsql-wal/src/storage/backend/mod.rs
+++ b/libsql-wal/src/storage/backend/mod.rs
@@ -84,15 +84,6 @@ pub trait Backend: Send + Sync + 'static {
         key: SegmentKey,
     ) -> impl Future<Output = Result<impl FileExt>> + Send;
 
-    // /// Fetch a segment for `namespace` containing `frame_no`, and writes it to `dest`.
-    async fn fetch_segment(
-        &self,
-        config: &Self::Config,
-        namespace: &NamespaceName,
-        frame_no: u64,
-        dest_path: &Path,
-    ) -> Result<Map<Arc<[u8]>>>;
-
     /// Fetch meta for `namespace`
     fn meta(
         &self,
@@ -131,18 +122,6 @@ impl<T: Backend> Backend for Arc<T> {
     ) -> impl Future<Output = Result<()>> + Send {
         self.as_ref()
             .store(config, meta, segment_data, segment_index)
-    }
-
-    async fn fetch_segment(
-        &self,
-        config: &Self::Config,
-        namespace: &NamespaceName,
-        frame_no: u64,
-        dest_path: &Path,
-    ) -> Result<fst::Map<Arc<[u8]>>> {
-        self.as_ref()
-            .fetch_segment(config, namespace, frame_no, dest_path)
-            .await
     }
 
     async fn meta(&self, config: &Self::Config, namespace: &NamespaceName) -> Result<DbMeta> {

--- a/libsql-wal/src/storage/backend/s3.rs
+++ b/libsql-wal/src/storage/backend/s3.rs
@@ -38,9 +38,7 @@ pub struct S3Backend<IO> {
     client: Client,
     default_config: Arc<S3Config>,
     io: IO,
-}
-
-impl S3Backend<StdIO> {
+} impl S3Backend<StdIO> {
     pub async fn from_sdk_config(
         aws_config: SdkConfig,
         bucket: String,
@@ -581,35 +579,6 @@ where
         Ok(())
     }
 
-    async fn fetch_segment(
-        &self,
-        config: &Self::Config,
-        namespace: &NamespaceName,
-        frame_no: u64,
-        dest_path: &Path,
-    ) -> Result<fst::Map<Arc<[u8]>>> {
-        let folder_key = FolderKey {
-            cluster_id: &config.cluster_id,
-            namespace: &namespace,
-        };
-
-        let Some(segment_key) = self
-            .find_segment_by_frame_no(config, &folder_key, frame_no)
-            .await?
-        else {
-            return Err(Error::FrameNotFound(frame_no));
-        };
-
-        if segment_key.includes(frame_no) {
-            // TODO: make open async
-            let file = self.io.open(false, false, true, dest_path)?;
-            self.fetch_segment_from_key(config, &folder_key, &segment_key, &file)
-                .await
-        } else {
-            return Err(Error::FrameNotFound(frame_no));
-        }
-    }
-
     async fn meta(
         &self,
         config: &Self::Config,
@@ -832,7 +801,6 @@ mod tests {
     use fst::MapBuilder;
     use s3s::auth::SimpleAuth;
     use s3s::service::{S3ServiceBuilder, SharedS3Service};
-    use tempfile::NamedTempFile;
     use uuid::Uuid;
 
     use crate::io::StdIO;
@@ -902,7 +870,7 @@ mod tests {
                 SegmentMeta {
                     namespace: ns.clone(),
                     segment_id: Uuid::new_v4(),
-                    start_frame_no: 0u64.into(),
+                    start_frame_no: 1u64.into(),
                     end_frame_no: 64u64.into(),
                     segment_timestamp: Utc::now(),
                 },
@@ -937,30 +905,14 @@ mod tests {
         let db_meta = storage.meta(&s3_config, &ns).await.unwrap();
         assert_eq!(db_meta.max_frame_no, 128);
 
-        let tmp = NamedTempFile::new().unwrap();
-
-        let index = storage
-            .fetch_segment(&s3_config, &ns, 1, tmp.path())
+        let key = storage
+            .find_segment(&s3_config, &ns, FindSegmentReq::EndFrameNoLessThan(65))
             .await
             .unwrap();
+        assert_eq!(key.start_frame_no, 1);
+        assert_eq!(key.end_frame_no, 64);
+        
+        let index = storage.fetch_segment_index(&s3_config, &ns, &key).await.unwrap();
         assert_eq!(index.get(42u32.to_be_bytes()).unwrap(), 42);
-
-        let index = storage
-            .fetch_segment(&s3_config, &ns, 63, tmp.path())
-            .await
-            .unwrap();
-        assert_eq!(index.get(42u32.to_be_bytes()).unwrap(), 42);
-
-        let index = storage
-            .fetch_segment(&s3_config, &ns, 64, tmp.path())
-            .await
-            .unwrap();
-        assert_eq!(index.get(44u32.to_be_bytes()).unwrap(), 44);
-
-        let index = storage
-            .fetch_segment(&s3_config, &ns, 65, tmp.path())
-            .await
-            .unwrap();
-        assert_eq!(index.get(44u32.to_be_bytes()).unwrap(), 44);
     }
 }

--- a/libsql-wal/src/storage/backend/s3.rs
+++ b/libsql-wal/src/storage/backend/s3.rs
@@ -38,7 +38,8 @@ pub struct S3Backend<IO> {
     client: Client,
     default_config: Arc<S3Config>,
     io: IO,
-} impl S3Backend<StdIO> {
+}
+impl S3Backend<StdIO> {
     pub async fn from_sdk_config(
         aws_config: SdkConfig,
         bucket: String,
@@ -911,8 +912,11 @@ mod tests {
             .unwrap();
         assert_eq!(key.start_frame_no, 1);
         assert_eq!(key.end_frame_no, 64);
-        
-        let index = storage.fetch_segment_index(&s3_config, &ns, &key).await.unwrap();
+
+        let index = storage
+            .fetch_segment_index(&s3_config, &ns, &key)
+            .await
+            .unwrap();
         assert_eq!(index.get(42u32.to_be_bytes()).unwrap(), 42);
     }
 }

--- a/libsql-wal/src/storage/compaction/mod.rs
+++ b/libsql-wal/src/storage/compaction/mod.rs
@@ -392,7 +392,6 @@ impl AnalyzedSegments {
                         end_frame_no,
                         timestamp,
                     };
-                    dbg!(&key);
                     segments.push(key);
                 }
             }

--- a/libsql-wal/src/storage/error.rs
+++ b/libsql-wal/src/storage/error.rs
@@ -1,6 +1,6 @@
 use std::panic::Location;
 
-use chrono::{DateTime, Utc};
+use super::backend::FindSegmentReq;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -10,10 +10,8 @@ pub enum Error {
     Store(String),
     #[error("error compacting segment: {0}")]
     Compact(#[from] crate::error::Error),
-    #[error("frame not {0} found")]
-    FrameNotFound(u64),
-    #[error("No satisfying segment found for timestamp {0}")]
-    SegmentNotFoundTimestamp(DateTime<Utc>),
+    #[error("segment not found for request {0:?}")]
+    SegmentNotFound(FindSegmentReq),
     #[error("unhandled storage error: {error}, in {context}")]
     UnhandledStorageError {
         error: Box<dyn std::error::Error + Send + Sync + 'static>,

--- a/libsql-wal/src/storage/job.rs
+++ b/libsql-wal/src/storage/job.rs
@@ -266,16 +266,6 @@ mod test {
                 Ok(std::fs::File::open("").unwrap())
             }
 
-            async fn fetch_segment(
-                &self,
-                _config: &Self::Config,
-                _namespace: &NamespaceName,
-                _frame_no: u64,
-                _dest_path: &std::path::Path,
-            ) -> Result<fst::Map<Arc<[u8]>>> {
-                todo!()
-            }
-
             fn list_segments<'a>(
                 &'a self,
                 _config: Self::Config,

--- a/libsql-wal/src/storage/mod.rs
+++ b/libsql-wal/src/storage/mod.rs
@@ -207,7 +207,7 @@ pub trait Storage: Send + Sync + 'static {
     fn find_segment(
         &self,
         namespace: &NamespaceName,
-        frame_no: u64,
+        frame_no: FindSegmentReq,
         config_override: Option<Self::Config>,
     ) -> impl Future<Output = Result<SegmentKey>> + Send;
 
@@ -306,7 +306,7 @@ where
     fn find_segment(
         &self,
         namespace: &NamespaceName,
-        frame_no: u64,
+        frame_no: FindSegmentReq,
         config_override: Option<Self::Config>,
     ) -> impl Future<Output = Result<SegmentKey>> + Send {
         async move {
@@ -415,7 +415,7 @@ impl Storage for NoStorage {
     async fn find_segment(
         &self,
         _namespace: &NamespaceName,
-        _frame_no: u64,
+        _frame_no: FindSegmentReq,
         _config_override: Option<Self::Config>,
     ) -> Result<SegmentKey> {
         unimplemented!()
@@ -564,7 +564,7 @@ impl<IO: Io> Storage for TestStorage<IO> {
     async fn find_segment(
         &self,
         namespace: &NamespaceName,
-        frame_no: u64,
+        req: FindSegmentReq,
         _config_override: Option<Self::Config>,
     ) -> Result<SegmentKey> {
         let inner = self.inner.lock().await;

--- a/libsql-wal/src/storage/mod.rs
+++ b/libsql-wal/src/storage/mod.rs
@@ -569,9 +569,10 @@ impl<IO: Io> Storage for TestStorage<IO> {
     ) -> Result<SegmentKey> {
         let inner = self.inner.lock().await;
         if inner.store {
+            let FindSegmentReq::EndFrameNoLessThan(fno) = req else { panic!("unsupported lookup by ts") };
             if let Some(segs) = inner.stored.get(namespace) {
-                let Some((key, _path)) = segs.iter().find(|(k, _)| k.includes(frame_no)) else {
-                    return Err(Error::FrameNotFound(frame_no));
+                let Some((key, _path)) = segs.iter().find(|(k, _)| k.includes(fno)) else {
+                    return Err(Error::SegmentNotFound(req));
                 };
                 return Ok(*key);
             } else {

--- a/libsql-wal/src/storage/mod.rs
+++ b/libsql-wal/src/storage/mod.rs
@@ -569,7 +569,9 @@ impl<IO: Io> Storage for TestStorage<IO> {
     ) -> Result<SegmentKey> {
         let inner = self.inner.lock().await;
         if inner.store {
-            let FindSegmentReq::EndFrameNoLessThan(fno) = req else { panic!("unsupported lookup by ts") };
+            let FindSegmentReq::EndFrameNoLessThan(fno) = req else {
+                panic!("unsupported lookup by ts")
+            };
             if let Some(segs) = inner.stored.get(namespace) {
                 let Some((key, _path)) = segs.iter().find(|(k, _)| k.includes(fno)) else {
                     return Err(Error::SegmentNotFound(req));


### PR DESCRIPTION
Fix the SegmentKey formatting such that the biggest most recent segment is always returned first

The `SegmentKey` starts with the inverted end-frame-no such that all segments are ordered by reverse biggest frame_no, then comes the start_frame no, in natural order, so that, for the same end_frame_no, the one with the smallest frame_no is ordered first. Lastly is the segment timestamp, which is roughly the commit time of the last txn in the segment. On merge, this is inheritted from the most recent segment, and the timestamp is therefore never a tie-breaker.

This change of key scheme means that we can't easily find segment by frame_no like we did before, but that's actually ok: we never need to fetch a random frame_no, rather, we iterate backward from segment boundary to segment boundary. This new key scheme let's us do that by letting us find the next segment whose end frame_no is less than or equal to the some value, which is what we actually need. Fetching a segment with a end_frame_no less than u64::MAX will always return the biggest segment with the most recent end_frame_no.

All these changes force means that we need to refactor for semantics, but the usage remains unchanged.