### PR TITLE
Libsql-wal: implement forking

### DIFF
--- a/libsql-server/src/bottomless_migrate.rs
+++ b/libsql-server/src/bottomless_migrate.rs
@@ -50,7 +50,6 @@ pub async fn bottomless_migrate(
     let tmp = TempDir::new()?;
 
     tokio::fs::create_dir_all(tmp.path().join("dbs")).await?;
-    tokio::fs::create_dir_all(tmp.path().join("wals")).await?;
 
     let configs_stream = meta_store.namespaces();
     tokio::pin!(configs_stream);
@@ -68,7 +67,6 @@ pub async fn bottomless_migrate(
     });
 
     let tmp_registry = Arc::new(WalRegistry::new(
-        tmp.path().join("wals"),
         NoStorage.into(),
         sender,
     )?);
@@ -110,7 +108,6 @@ pub async fn bottomless_migrate(
     // doesn't exist, then we restore it, otherwise, we delete it.
     tokio::fs::rename(&base_dbs_dir, &base_dbs_dir_tmp).await?;
     tokio::fs::rename(tmp.path().join("dbs"), base_dbs_dir).await?;
-    tokio::fs::rename(tmp.path().join("wals"), base_config.base_path.join("wals")).await?;
     tokio::fs::remove_dir_all(base_config.base_path.join("_dbs")).await?;
 
     Ok(())

--- a/libsql-server/src/bottomless_migrate.rs
+++ b/libsql-server/src/bottomless_migrate.rs
@@ -66,10 +66,7 @@ pub async fn bottomless_migrate(
         }
     });
 
-    let tmp_registry = Arc::new(WalRegistry::new(
-        NoStorage.into(),
-        sender,
-    )?);
+    let tmp_registry = Arc::new(WalRegistry::new(NoStorage.into(), sender)?);
 
     let mut configurators = NamespaceConfigurators::default();
 

--- a/libsql-server/src/error.rs
+++ b/libsql-server/src/error.rs
@@ -325,6 +325,7 @@ impl IntoResponse for &ForkError {
             | ForkError::BackupServiceNotConfigured
             | ForkError::CreateNamespace(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             ForkError::ForkReplica => self.format_err(StatusCode::BAD_REQUEST),
+            ForkError::ForkNoStorage => self.format_err(StatusCode::BAD_REQUEST),
         }
     }
 }

--- a/libsql-server/src/namespace/configurator/fork.rs
+++ b/libsql-server/src/namespace/configurator/fork.rs
@@ -91,6 +91,8 @@ pub enum ForkError {
     ForkReplica,
     #[error("backup service not configured")]
     BackupServiceNotConfigured,
+    #[error("cannot fork a namespace without storage")]
+    ForkNoStorage,
 }
 
 impl From<tokio::task::JoinError> for ForkError {

--- a/libsql-server/src/namespace/configurator/libsql_fork.rs
+++ b/libsql-server/src/namespace/configurator/libsql_fork.rs
@@ -1,0 +1,127 @@
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use futures::Stream;
+use libsql_sys::wal::either::Either;
+use libsql_wal::io::StdIO;
+use libsql_wal::registry::WalRegistry;
+use libsql_wal::replication::injector::Injector;
+use libsql_wal::replication::storage::StorageReplicator;
+use libsql_wal::replication::{replicator::Replicator, storage::ReplicateFromStorage as _};
+use libsql_wal::segment::Frame;
+use libsql_wal::shared_wal::SharedWal;
+use libsql_wal::storage::backend::Backend as _;
+use tempfile::tempdir;
+use tokio_stream::StreamExt as _;
+
+use crate::namespace::configurator::fork::ForkError;
+use crate::namespace::RestoreOption;
+use crate::{
+    namespace::{meta_store::MetaStoreHandle, Namespace, NamespaceName, NamespaceStore},
+    SqldStorage,
+};
+
+pub(crate) async fn libsql_wal_fork(
+    registry: Arc<WalRegistry<StdIO, SqldStorage>>,
+    base_path: &Path,
+    from_ns: &Namespace,
+    to_ns: NamespaceName,
+    to_config: MetaStoreHandle,
+    timestamp: Option<DateTime<Utc>>,
+    store: NamespaceStore,
+) -> crate::Result<Namespace> {
+    let mut seen = Default::default();
+    let storage = registry.storage();
+    match &*storage {
+        Either::A(s) => {
+            let from_ns_name: libsql_sys::name::NamespaceName = from_ns.name().clone().into();
+            let to_ns_name: libsql_sys::name::NamespaceName = to_ns.clone().into();
+
+            let mut stream = match timestamp {
+                Some(ts) => {
+                    let key = s
+                        .backend()
+                        .find_segment(
+                            &s.backend().default_config(),
+                            &from_ns_name,
+                            libsql_wal::storage::backend::FindSegmentReq::Timestamp(ts),
+                        )
+                        .await
+                        .unwrap();
+                    let restore_until = key.end_frame_no;
+                    let replicator = StorageReplicator::new(storage.clone(), from_ns_name.clone());
+                    replicator.stream(&mut seen, restore_until, 1)
+                }
+                // find the most recent frame_no
+                None => {
+                    let from_shared = tokio::task::spawn_blocking({
+                        let registry = registry.clone();
+                        let from_ns_name = from_ns_name.clone();
+                        let path = from_ns.path.join("data");
+                        move || registry.open(&path, &from_ns_name)
+                    })
+                    .await
+                    .unwrap()?;
+
+                    let replicator = Replicator::new(from_shared, 1, false);
+                    Box::pin(replicator.into_frame_stream())
+                }
+            };
+
+            let tmp = tempdir()?;
+            let to_shared = tokio::task::spawn_blocking({
+                let registry = registry.clone();
+                let path = tmp.path().join("data");
+                let to_ns_name = to_ns_name.clone();
+                move || registry.open(&path, &to_ns_name)
+            })
+            .await
+            .unwrap()?;
+
+            // make sure that nobody can use that namespace
+            registry.tombstone(&to_ns_name).await;
+            let ret = try_inject(to_shared, &mut stream).await;
+            registry.remove(&to_ns_name).await;
+            ret?;
+
+            tokio::fs::rename(tmp.path(), base_path.join("dbs").join(to_ns.as_str())).await?;
+
+            Ok(store
+                .make_namespace(&to_ns, to_config, RestoreOption::Latest)
+                .await?)
+        }
+        Either::B(_) => Err(crate::Error::Fork(super::fork::ForkError::ForkNoStorage)),
+    }
+}
+
+async fn try_inject(
+    to_shared: Arc<SharedWal<StdIO>>,
+    stream: &mut Pin<
+        Box<dyn Stream<Item = Result<Box<Frame>, libsql_wal::replication::Error>> + Send + '_>,
+    >,
+) -> crate::Result<()> {
+    let stream = stream.peekable();
+    tokio::pin!(stream);
+    let mut injector = Injector::new(to_shared.clone(), 16)?;
+    let mut count = 0;
+    while let Some(f) = stream.next().await {
+        let mut frame = f.map_err(|e| ForkError::Internal(anyhow::anyhow!(e)))?;
+        count += 1;
+        if stream.peek().await.is_none() {
+            frame.header_mut().set_size_after(count);
+        }
+
+        injector.insert_frame(frame).await?;
+    }
+
+    tokio::task::spawn_blocking({
+        let shared = to_shared.clone();
+        move || shared.seal_current()
+    })
+    .await
+    .unwrap()?;
+
+    Ok(())
+}

--- a/libsql-server/src/namespace/configurator/libsql_primary.rs
+++ b/libsql-server/src/namespace/configurator/libsql_primary.rs
@@ -5,10 +5,8 @@ use std::sync::Arc;
 
 use futures::prelude::Future;
 use libsql_sys::name::NamespaceResolver;
-use libsql_sys::wal::either::Either;
 use libsql_wal::io::StdIO;
 use libsql_wal::registry::WalRegistry;
-use libsql_wal::storage::backend::Backend;
 use libsql_wal::wal::LibsqlWalManager;
 use tokio::task::JoinSet;
 
@@ -267,38 +265,15 @@ impl ConfigureNamespace for LibsqlPrimaryConfigurator {
         &'a self,
         from_ns: &'a Namespace,
         _from_config: MetaStoreHandle,
-        _to_ns: NamespaceName,
-        _to_config: MetaStoreHandle,
-        timestamp: Option<chrono::prelude::NaiveDateTime>,
-        _store: NamespaceStore,
+        to_ns: NamespaceName,
+        to_config: MetaStoreHandle,
+        timestamp: Option<DateTime<Utc>>,
+        store: NamespaceStore,
     ) -> Pin<Box<dyn Future<Output = crate::Result<Namespace>> + Send + 'a>> {
-        Box::pin(async move {
-            match self.registry.storage() {
-                Either::A(s) => {
-                    match timestamp {
-                        Some(ts) => {
-                            let ns: libsql_sys::name::NamespaceName = from_ns.name().clone().into();
-                            let _key = s
-                                .backend()
-                                .find_segment(
-                                    &s.backend().default_config(),
-                                    &ns,
-                                    libsql_wal::storage::backend::FindSegmentReq::Timestamp(
-                                        ts.and_utc(),
-                                    ),
-                                )
-                                .await
-                                .unwrap();
-                            todo!()
-                        }
-                        // find the most recent frame_no
-                        None => todo!("fork from most recent"),
-                    };
-                }
-                Either::B(_) => {
-                    todo!("cannot fork without storage");
-                }
-            }
-        })
+        let registry = self.registry.clone();
+        let base_path = &self.base.base_path;
+        Box::pin(super::libsql_fork::libsql_wal_fork(
+            registry, base_path, from_ns, to_ns, to_config, timestamp, store,
+        ))
     }
 }

--- a/libsql-server/src/namespace/configurator/libsql_primary.rs
+++ b/libsql-server/src/namespace/configurator/libsql_primary.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use chrono::NaiveDateTime;
 use futures::prelude::Future;
 use libsql_sys::name::NamespaceResolver;
 use libsql_wal::io::StdIO;
@@ -267,13 +268,19 @@ impl ConfigureNamespace for LibsqlPrimaryConfigurator {
         _from_config: MetaStoreHandle,
         to_ns: NamespaceName,
         to_config: MetaStoreHandle,
-        timestamp: Option<DateTime<Utc>>,
+        timestamp: Option<NaiveDateTime>,
         store: NamespaceStore,
     ) -> Pin<Box<dyn Future<Output = crate::Result<Namespace>> + Send + 'a>> {
         let registry = self.registry.clone();
         let base_path = &self.base.base_path;
         Box::pin(super::libsql_fork::libsql_wal_fork(
-            registry, base_path, from_ns, to_ns, to_config, timestamp, store,
+            registry,
+            base_path,
+            from_ns,
+            to_ns,
+            to_config,
+            timestamp.map(|ts| ts.and_utc()),
+            store,
         ))
     }
 }

--- a/libsql-server/src/namespace/configurator/libsql_schema.rs
+++ b/libsql-server/src/namespace/configurator/libsql_schema.rs
@@ -160,21 +160,16 @@ impl ConfigureNamespace for LibsqlSchemaConfigurator {
     fn fork<'a>(
         &'a self,
         from_ns: &'a Namespace,
-        from_config: MetaStoreHandle,
+        _from_config: MetaStoreHandle,
         to_ns: NamespaceName,
         to_config: MetaStoreHandle,
-        timestamp: Option<chrono::prelude::NaiveDateTime>,
+        timestamp: Option<DateTime<Utc>>,
         store: NamespaceStore,
     ) -> std::pin::Pin<Box<dyn Future<Output = crate::Result<Namespace>> + Send + 'a>> {
-        Box::pin(super::fork::fork(
-            from_ns,
-            from_config,
-            to_ns,
-            to_config,
-            timestamp,
-            store,
-            &self.primary_config,
-            self.base.base_path.clone(),
+        let registry = self.registry.clone();
+        let base_path = &self.base.base_path;
+        Box::pin(super::libsql_fork::libsql_wal_fork(
+            registry, base_path, from_ns, to_ns, to_config, timestamp, store,
         ))
     }
 }

--- a/libsql-server/src/namespace/configurator/libsql_schema.rs
+++ b/libsql-server/src/namespace/configurator/libsql_schema.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use chrono::NaiveDateTime;
 use futures::prelude::Future;
 use libsql_sys::name::NamespaceResolver;
 use libsql_wal::io::StdIO;
@@ -163,13 +164,19 @@ impl ConfigureNamespace for LibsqlSchemaConfigurator {
         _from_config: MetaStoreHandle,
         to_ns: NamespaceName,
         to_config: MetaStoreHandle,
-        timestamp: Option<DateTime<Utc>>,
+        timestamp: Option<NaiveDateTime>,
         store: NamespaceStore,
     ) -> std::pin::Pin<Box<dyn Future<Output = crate::Result<Namespace>> + Send + 'a>> {
         let registry = self.registry.clone();
         let base_path = &self.base.base_path;
         Box::pin(super::libsql_fork::libsql_wal_fork(
-            registry, base_path, from_ns, to_ns, to_config, timestamp, store,
+            registry,
+            base_path,
+            from_ns,
+            to_ns,
+            to_config,
+            timestamp.map(|ts| ts.and_utc()),
+            store,
         ))
     }
 }

--- a/libsql-server/src/namespace/configurator/mod.rs
+++ b/libsql-server/src/namespace/configurator/mod.rs
@@ -20,8 +20,8 @@ use super::{
 };
 
 pub mod fork;
-mod libsql_fork;
 mod helpers;
+mod libsql_fork;
 mod libsql_primary;
 mod libsql_replica;
 mod libsql_schema;

--- a/libsql-server/src/namespace/configurator/mod.rs
+++ b/libsql-server/src/namespace/configurator/mod.rs
@@ -20,6 +20,7 @@ use super::{
 };
 
 pub mod fork;
+mod libsql_fork;
 mod helpers;
 mod libsql_primary;
 mod libsql_replica;

--- a/libsql-server/src/rpc/replication/libsql_replicator.rs
+++ b/libsql-server/src/rpc/replication/libsql_replicator.rs
@@ -157,6 +157,7 @@ impl ReplicationLog for LibsqlReplicationService {
         let replicator = libsql_wal::replication::replicator::Replicator::new(
             shared.clone(),
             req.next_offset.max(1),
+            true,
         );
 
         let flavor = req.wal_flavor();

--- a/libsql-wal/benches/benchmarks.rs
+++ b/libsql-wal/benches/benchmarks.rs
@@ -61,7 +61,7 @@ fn with_libsql_conn(f: impl FnOnce(&mut Connection<LibsqlWal<StdIO>>)) {
 
     let (sender, _) = tokio::sync::mpsc::channel(12);
     let registry =
-        Arc::new(WalRegistry::new(tmp.path().join("wals"), NoStorage.into(), sender).unwrap());
+        Arc::new(WalRegistry::new(NoStorage.into(), sender).unwrap());
     let wal_manager = LibsqlWalManager::new(registry.clone(), Arc::new(resolver));
 
     let mut conn = libsql_sys::Connection::open(

--- a/libsql-wal/benches/benchmarks.rs
+++ b/libsql-wal/benches/benchmarks.rs
@@ -60,8 +60,7 @@ fn with_libsql_conn(f: impl FnOnce(&mut Connection<LibsqlWal<StdIO>>)) {
     let resolver = |_: &Path| NamespaceName::from_string("test".into());
 
     let (sender, _) = tokio::sync::mpsc::channel(12);
-    let registry =
-        Arc::new(WalRegistry::new(NoStorage.into(), sender).unwrap());
+    let registry = Arc::new(WalRegistry::new(NoStorage.into(), sender).unwrap());
     let wal_manager = LibsqlWalManager::new(registry.clone(), Arc::new(resolver));
 
     let mut conn = libsql_sys::Connection::open(

--- a/libsql-wal/src/lib.rs
+++ b/libsql-wal/src/lib.rs
@@ -110,12 +110,8 @@ pub mod test {
 
             let (sender, receiver) = mpsc::channel(128);
             let registry = Arc::new(
-                WalRegistry::new_with_io(
-                    io.clone(),
-                    TestStorage::new_io(store, io).into(),
-                    sender,
-                )
-                .unwrap(),
+                WalRegistry::new_with_io(io.clone(), TestStorage::new_io(store, io).into(), sender)
+                    .unwrap(),
             );
 
             if store {

--- a/libsql-wal/src/lib.rs
+++ b/libsql-wal/src/lib.rs
@@ -112,7 +112,6 @@ pub mod test {
             let registry = Arc::new(
                 WalRegistry::new_with_io(
                     io.clone(),
-                    tmp.path().join("test/wals"),
                     TestStorage::new_io(store, io).into(),
                     sender,
                 )

--- a/libsql-wal/src/replication/injector.rs
+++ b/libsql-wal/src/replication/injector.rs
@@ -137,7 +137,7 @@ mod test {
         let primary_conn = primary_env.open_conn("test");
         let primary_shared = primary_env.shared("test");
 
-        let replicator = Replicator::new(primary_shared.clone(), 1);
+        let replicator = Replicator::new(primary_shared.clone(), 1, true);
         let stream = replicator.into_frame_stream();
 
         tokio::pin!(stream);

--- a/libsql-wal/src/replication/storage.rs
+++ b/libsql-wal/src/replication/storage.rs
@@ -10,7 +10,7 @@ use zerocopy::FromZeroes;
 use crate::io::buf::ZeroCopyBoxIoBuf;
 use crate::segment::Frame;
 use crate::storage::backend::FindSegmentReq;
-use crate::storage::{Storage};
+use crate::storage::Storage;
 
 use super::Result;
 

--- a/libsql-wal/src/replication/storage.rs
+++ b/libsql-wal/src/replication/storage.rs
@@ -10,13 +10,13 @@ use zerocopy::FromZeroes;
 use crate::io::buf::ZeroCopyBoxIoBuf;
 use crate::segment::Frame;
 use crate::storage::backend::FindSegmentReq;
-use crate::storage::Storage;
+use crate::storage::{Storage};
 
 use super::Result;
 
 pub trait ReplicateFromStorage: Sync + Send + 'static {
-    fn stream<'a>(
-        &'a self,
+    fn stream<'a, 'b>(
+        &'b self,
         seen: &'a mut RoaringBitmap,
         current: u64,
         until: u64,
@@ -38,16 +38,18 @@ impl<S> ReplicateFromStorage for StorageReplicator<S>
 where
     S: Storage,
 {
-    fn stream<'a>(
-        &'a self,
+    fn stream<'a, 'b>(
+        &'b self,
         seen: &'a mut roaring::RoaringBitmap,
         mut current: u64,
         until: u64,
     ) -> Pin<Box<dyn Stream<Item = Result<Box<Frame>>> + Send + 'a>> {
+        let storage = self.storage.clone();
+        let namespace = self.namespace.clone();
         Box::pin(async_stream::try_stream! {
             loop {
-                let key = self.storage.find_segment(&self.namespace, FindSegmentReq::EndFrameNoLessThan(current), None).await?;
-                let index = self.storage.fetch_segment_index(&self.namespace, &key, None).await?;
+                let key = storage.find_segment(&namespace, FindSegmentReq::EndFrameNoLessThan(current), None).await?;
+                let index = storage.fetch_segment_index(&namespace, &key, None).await?;
                 let mut pages = index.into_stream();
                 let mut maybe_seg = None;
                 while let Some((page, offset)) = pages.next() {
@@ -58,7 +60,7 @@ where
                         let segment = match maybe_seg {
                             Some(ref seg) => seg,
                             None => {
-                                maybe_seg = Some(self.storage.fetch_segment_data(&self.namespace, &key, None).await?);
+                                maybe_seg = Some(storage.fetch_segment_data(&namespace, &key, None).await?);
                                 maybe_seg.as_ref().unwrap()
                             },
                         };

--- a/libsql-wal/src/segment/current.rs
+++ b/libsql-wal/src/segment/current.rs
@@ -455,6 +455,7 @@ impl<F> CurrentSegment<F> {
             self.file.clone(),
             self.path.clone(),
             self.read_locks.clone(),
+            now,
         )?;
 
         // we only flip the sealed mark when no more error can occur, or we risk to deadlock a read

--- a/libsql-wal/src/segment/mod.rs
+++ b/libsql-wal/src/segment/mod.rs
@@ -163,7 +163,6 @@ pub trait Segment: Send + Sync + 'static {
     fn start_frame_no(&self) -> u64;
     fn last_committed(&self) -> u64;
     fn index(&self) -> &fst::Map<Arc<[u8]>>;
-    fn is_storable(&self) -> bool;
     fn read_page(&self, page_no: u32, max_frame_no: u64, buf: &mut [u8]) -> io::Result<bool>;
     /// returns the number of readers currently holding a reference to this log.
     /// The read count must monotonically decrease.
@@ -197,10 +196,6 @@ impl<T: Segment> Segment for Arc<T> {
 
     fn index(&self) -> &fst::Map<Arc<[u8]>> {
         self.as_ref().index()
-    }
-
-    fn is_storable(&self) -> bool {
-        self.as_ref().is_storable()
     }
 
     fn read_page(&self, page_no: u32, max_frame_no: u64, buf: &mut [u8]) -> io::Result<bool> {

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -4,8 +4,8 @@ use std::io::{BufWriter, ErrorKind, Write};
 use std::mem::size_of;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use chrono::prelude::{DateTime, Utc};
 use fst::{Map, MapBuilder, Streamer};
@@ -210,7 +210,12 @@ where
 }
 
 impl<F: FileExt> SealedSegment<F> {
-    pub fn open(file: Arc<F>, path: PathBuf, read_locks: Arc<AtomicU64>, now: DateTime<Utc>) -> Result<Option<Self>> {
+    pub fn open(
+        file: Arc<F>,
+        path: PathBuf,
+        read_locks: Arc<AtomicU64>,
+        now: DateTime<Utc>,
+    ) -> Result<Option<Self>> {
         let mut header: SegmentHeader = SegmentHeader::new_zeroed();
         file.read_exact_at(header.as_bytes_mut(), 0)?;
 
@@ -246,7 +251,12 @@ impl<F: FileExt> SealedSegment<F> {
         }))
     }
 
-    fn recover(file: Arc<F>, path: PathBuf, mut header: SegmentHeader, now: DateTime<Utc>) -> Result<Self> {
+    fn recover(
+        file: Arc<F>,
+        path: PathBuf,
+        mut header: SegmentHeader,
+        now: DateTime<Utc>,
+    ) -> Result<Self> {
         assert!(!header.is_empty());
         assert_eq!(header.index_size.get(), 0);
         assert_eq!(header.index_offset.get(), 0);

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -157,17 +157,6 @@ where
         &self.index
     }
 
-    fn is_storable(&self) -> bool {
-        // we don't store unordered segments, since they only happen in two cases:
-        // - in a replica: no need for storage
-        // - in a primary, on recovery from storage: we don't want to override remote
-        // segment.
-        !self
-            .header()
-            .flags()
-            .contains(SegmentFlags::FRAME_UNORDERED)
-    }
-
     fn read_page(&self, page_no: u32, max_frame_no: u64, buf: &mut [u8]) -> std::io::Result<bool> {
         if self.header().start_frame_no.get() > max_frame_no {
             return Ok(false);

--- a/libsql-wal/src/segment/sealed.rs
+++ b/libsql-wal/src/segment/sealed.rs
@@ -4,10 +4,8 @@ use std::io::{BufWriter, ErrorKind, Write};
 use std::mem::size_of;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Arc,
-};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use chrono::prelude::{DateTime, Utc};
 use fst::{Map, MapBuilder, Streamer};
@@ -212,7 +210,7 @@ where
 }
 
 impl<F: FileExt> SealedSegment<F> {
-    pub fn open(file: Arc<F>, path: PathBuf, read_locks: Arc<AtomicU64>) -> Result<Option<Self>> {
+    pub fn open(file: Arc<F>, path: PathBuf, read_locks: Arc<AtomicU64>, now: DateTime<Utc>) -> Result<Option<Self>> {
         let mut header: SegmentHeader = SegmentHeader::new_zeroed();
         file.read_exact_at(header.as_bytes_mut(), 0)?;
 
@@ -230,7 +228,7 @@ impl<F: FileExt> SealedSegment<F> {
         // recover the index, and seal the segment.
         if !header.flags().contains(SegmentFlags::SEALED) {
             assert_eq!(header.index_offset.get(), 0, "{header:?}");
-            return Self::recover(file, path, header).map(Some);
+            return Self::recover(file, path, header, now).map(Some);
         }
 
         let mut slice = vec![0; index_len as usize];
@@ -248,7 +246,7 @@ impl<F: FileExt> SealedSegment<F> {
         }))
     }
 
-    fn recover(file: Arc<F>, path: PathBuf, mut header: SegmentHeader) -> Result<Self> {
+    fn recover(file: Arc<F>, path: PathBuf, mut header: SegmentHeader, now: DateTime<Utc>) -> Result<Self> {
         assert!(!header.is_empty());
         assert_eq!(header.index_size.get(), 0);
         assert_eq!(header.index_offset.get(), 0);
@@ -335,6 +333,7 @@ impl<F: FileExt> SealedSegment<F> {
         header.index_size = index_size.into();
         header.last_commited_frame_no = last_committed.into();
         header.size_after = size_after.into();
+        header.sealed_at_timestamp = (now.timestamp_millis() as u64).into();
         let flags = header.flags();
         header.set_flags(flags | SegmentFlags::SEALED);
         header.recompute_checksum();

--- a/libsql-wal/src/shared_wal.rs
+++ b/libsql-wal/src/shared_wal.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -55,6 +56,7 @@ pub struct SharedWal<IO: Io> {
     pub(crate) checkpoint_notifier: mpsc::Sender<CheckpointMessage>,
     pub(crate) io: Arc<IO>,
     pub(crate) swap_strategy: Box<dyn SegmentSwapStrategy>,
+    pub(crate) wals_path: PathBuf,
 }
 
 impl<IO: Io> SharedWal<IO> {

--- a/libsql-wal/src/storage/job.rs
+++ b/libsql-wal/src/storage/job.rs
@@ -176,10 +176,6 @@ mod test {
                 async move { todo!() }
             }
 
-            fn is_storable(&self) -> bool {
-                true
-            }
-
             fn timestamp(&self) -> DateTime<Utc> {
                 Utc::now()
             }

--- a/libsql-wal/tests/flaky_fs.rs
+++ b/libsql-wal/tests/flaky_fs.rs
@@ -213,14 +213,13 @@ async fn flaky_fs() {
     let registry = Arc::new(
         WalRegistry::new_with_io(
             io.clone(),
-            tmp.path().join("test/wals"),
             TestStorage::new_io(false, io).into(),
             sender,
         )
         .unwrap(),
     );
     let wal_manager = LibsqlWalManager::new(registry.clone(), Arc::new(resolver));
-
+    tokio::fs::create_dir_all(tmp.path().join("test")).await.unwrap();
     let conn = libsql_sys::Connection::open(
         tmp.path().join("test/data").clone(),
         OpenFlags::SQLITE_OPEN_CREATE | OpenFlags::SQLITE_OPEN_READ_WRITE,

--- a/libsql-wal/tests/flaky_fs.rs
+++ b/libsql-wal/tests/flaky_fs.rs
@@ -211,15 +211,13 @@ async fn flaky_fs() {
     };
     let (sender, _receiver) = tokio::sync::mpsc::channel(64);
     let registry = Arc::new(
-        WalRegistry::new_with_io(
-            io.clone(),
-            TestStorage::new_io(false, io).into(),
-            sender,
-        )
-        .unwrap(),
+        WalRegistry::new_with_io(io.clone(), TestStorage::new_io(false, io).into(), sender)
+            .unwrap(),
     );
     let wal_manager = LibsqlWalManager::new(registry.clone(), Arc::new(resolver));
-    tokio::fs::create_dir_all(tmp.path().join("test")).await.unwrap();
+    tokio::fs::create_dir_all(tmp.path().join("test"))
+        .await
+        .unwrap();
     let conn = libsql_sys::Connection::open(
         tmp.path().join("test/data").clone(),
         OpenFlags::SQLITE_OPEN_CREATE | OpenFlags::SQLITE_OPEN_READ_WRITE,

--- a/libsql-wal/tests/oracle.rs
+++ b/libsql-wal/tests/oracle.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use libsql_sys::ffi::{sqlite3_finalize, sqlite3_prepare, Sqlite3DbHeader};
 use libsql_sys::name::NamespaceName;
 use libsql_sys::rusqlite::OpenFlags;
-use libsql_sys::wal::{Sqlite3WalManager, Wal};
+use libsql_sys::wal::{Sqlite3WalManager, Wal, WalManager};
 use libsql_sys::Connection;
 use libsql_wal::registry::WalRegistry;
 use libsql_wal::storage::TestStorage;
@@ -67,7 +67,7 @@ async fn run_test_sample(path: &Path) -> Result {
 
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
     let before = std::time::Instant::now();
-    let sqlite_results = run_script(&sqlite_conn, &script, &mut rng).collect::<Vec<_>>();
+    let sqlite_results = run_script(&sqlite_conn, &script, &mut rng, Sqlite3WalManager::default()).collect::<Vec<_>>();
     println!("ran sqlite in {:?}", before.elapsed());
     drop(sqlite_conn);
 
@@ -95,13 +95,13 @@ async fn run_test_sample(path: &Path) -> Result {
     let (sender, _receiver) = tokio::sync::mpsc::channel(64);
     let registry = Arc::new(
         WalRegistry::new(
-            tmp.path().join("test/wals"),
             TestStorage::new().into(),
             sender,
         )
         .unwrap(),
     );
     let wal_manager = LibsqlWalManager::new(registry.clone(), Arc::new(resolver));
+    tokio::fs::create_dir_all(tmp.path().join("test")).await.unwrap();
     let db_path = tmp.path().join("test/data").clone();
     let libsql_conn = libsql_sys::Connection::open(
         &db_path,
@@ -114,7 +114,7 @@ async fn run_test_sample(path: &Path) -> Result {
 
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
     let before = std::time::Instant::now();
-    let libsql_results = run_script(&libsql_conn, &script, &mut rng).collect::<Vec<_>>();
+    let libsql_results = run_script(&libsql_conn, &script, &mut rng, wal_manager.clone()).collect::<Vec<_>>();
     println!("ran libsql in {:?}", before.elapsed());
 
     for ((a, _), (b, _)) in sqlite_results.iter().zip(libsql_results.iter()) {
@@ -204,12 +204,13 @@ fn run_script<'a, T: Wal>(
     conn: &'a Connection<T>,
     script: &'a str,
     rng: &'a mut ChaCha8Rng,
+    wal_manager: impl WalManager + Clone + 'static,
 ) -> impl Iterator<Item = (String, String)> + 'a {
     let mut stmts = split_statements(conn, script);
     std::iter::from_fn(move || {
         let stmt_str = patch_randomness(stmts.next()?, rng);
         if stmt_str.trim_start().starts_with("ATTACH") {
-            patch_attach(&stmt_str);
+            patch_attach(&stmt_str, wal_manager.clone());
         }
         let mut stmt = conn.prepare(&stmt_str).unwrap();
 
@@ -227,14 +228,14 @@ fn run_script<'a, T: Wal>(
     })
 }
 
-fn patch_attach(s: &str) {
+fn patch_attach(s: &str, wal: impl WalManager) {
     let mut split = s.split_whitespace();
     let name = split.nth(1).unwrap();
     let name = name.trim_matches('\'');
     let _ = libsql_sys::Connection::open(
         name,
         OpenFlags::SQLITE_OPEN_CREATE | OpenFlags::SQLITE_OPEN_READ_WRITE,
-        Sqlite3WalManager::default(),
+        wal,
         100000,
         None,
     )


### PR DESCRIPTION
Implement forking for libsql-wal in a similar fashion to what was done before: create a new namespace, and replicate to is from the source namespace.

This PR also remove the use of the `wals` directory, and instead, it stores the wals alonside the dbs themselves.