### PR TITLE
sqld: schema db and replica fixes

### DIFF
--- a/libsql-server/src/rpc/proxy.rs
+++ b/libsql-server/src/rpc/proxy.rs
@@ -635,7 +635,7 @@ impl Proxy for ProxyService {
                         Ok(conn) => {
                             if !conn.is_primary() {
                                 return Err(tonic::Status::failed_precondition(
-                                    "cannot run schema migration against a replica",
+                                    "cannot run schema migration against a replica from a replica",
                                 ));
                             }
 
@@ -710,7 +710,7 @@ impl Proxy for ProxyService {
                     Ok(conn) => {
                         if !conn.is_primary() {
                             return Err(tonic::Status::failed_precondition(
-                                "cannot run schema migration against a replica",
+                                "cannot run schema migration against a replica from a replica",
                             ));
                         }
 

--- a/libsql-server/tests/cluster/schema_dbs.rs
+++ b/libsql-server/tests/cluster/schema_dbs.rs
@@ -131,7 +131,7 @@ fn schema_migration_basics() {
 }
 
 #[test]
-fn error_on_replicate() {
+fn schema_migration_via_replica() {
     let mut sim = Builder::new()
         .simulation_duration(Duration::from_secs(1000))
         .build();

--- a/libsql-server/tests/cluster/schema_dbs.rs
+++ b/libsql-server/tests/cluster/schema_dbs.rs
@@ -129,3 +129,64 @@ fn schema_migration_basics() {
 
     sim.run().unwrap();
 }
+
+#[test]
+fn error_on_replicate() {
+    let mut sim = Builder::new()
+        .simulation_duration(Duration::from_secs(1000))
+        .build();
+    make_cluster(&mut sim, 1, true);
+
+    sim.client("client", async {
+        let http = Client::new();
+
+        assert!(http
+            .post(
+                "http://primary:9090/v1/namespaces/schema/create",
+                json!({ "shared_schema": true })
+            )
+            .await
+            .unwrap()
+            .status()
+            .is_success());
+        assert!(http
+            .post(
+                "http://primary:9090/v1/namespaces/foo/create",
+                json!({ "shared_schema_name": "schema" })
+            )
+            .await
+            .unwrap()
+            .status()
+            .is_success());
+
+        {
+            let db = Database::open_remote_with_connector(
+                "http://schema.primary:8080",
+                "",
+                TurmoilConnector,
+            )
+            .unwrap();
+            let conn = db.connect().unwrap();
+            conn.execute("create table test (x)", ()).await.unwrap();
+        }
+
+        {
+            let db = Database::open_remote_with_connector(
+                "http://schema.replica0:8080",
+                "",
+                TurmoilConnector,
+            )
+            .unwrap();
+            let conn = db.connect().unwrap();
+            conn.execute("select * from sqlite_master;", ())
+                .await
+                .unwrap();
+
+            conn.execute("create table foo (x)", ()).await.unwrap();
+        }
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}


### PR DESCRIPTION
This PR contains two fixes one for preventing embedded replica's from being able to sync a schema db and another that cleans up the conn.is_primary panics/errors that we had before.