### PR TITLE
libsql wal multipart upload

### DIFF
--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -734,33 +734,6 @@ async fn build_server(
 async fn main() -> Result<()> {
     let args = Cli::parse();
 
-    if let Some(ref subcommand) = args.subcommand {
-        match subcommand {
-            UtilsSubcommands::AdminShell {
-                admin_api_url,
-                namespace,
-                auth,
-            } => {
-                let client = libsql_server::admin_shell::AdminShellClient::new(
-                    admin_api_url.clone(),
-                    auth.clone(),
-                );
-                if let Some(ns) = namespace {
-                    client.run_namespace(ns).await?;
-                }
-            }
-            UtilsSubcommands::WalToolkit {
-                command,
-                path,
-                s3_args,
-            } => {
-                command.exec(path, s3_args).await?;
-            }
-        }
-
-        return Ok(());
-    }
-
     if std::env::var("RUST_LOG").is_err() {
         std::env::set_var("RUST_LOG", "info");
     }
@@ -788,6 +761,33 @@ async fn main() -> Result<()> {
                 .with_filter(filter),
         )
         .init();
+
+    if let Some(ref subcommand) = args.subcommand {
+        match subcommand {
+            UtilsSubcommands::AdminShell {
+                admin_api_url,
+                namespace,
+                auth,
+            } => {
+                let client = libsql_server::admin_shell::AdminShellClient::new(
+                    admin_api_url.clone(),
+                    auth.clone(),
+                );
+                if let Some(ns) = namespace {
+                    client.run_namespace(ns).await?;
+                }
+            }
+            UtilsSubcommands::WalToolkit {
+                command,
+                path,
+                s3_args,
+            } => {
+                command.exec(path, s3_args).await?;
+            }
+        }
+
+        return Ok(());
+    }
 
     args.print_welcome_message();
     let server = build_server(&args, set_log_level).await?;

--- a/libsql-wal/src/storage/backend/mod.rs
+++ b/libsql-wal/src/storage/backend/mod.rs
@@ -57,7 +57,7 @@ pub trait Backend: Send + Sync + 'static {
         config: &Self::Config,
         namespace: &NamespaceName,
         key: &SegmentKey,
-        segment_data: impl Stream<Item = Result<Bytes>> + Send + Sync + 'static,
+        segment_data: impl Stream<Item = Result<Bytes>> + Send + 'static,
     ) -> impl Future<Output = Result<()>> + Send;
 
     /// Store `segment_data` with its associated `meta`
@@ -224,7 +224,7 @@ impl<T: Backend> Backend for Arc<T> {
         config: &Self::Config,
         namespace: &NamespaceName,
         key: &SegmentKey,
-        segment_data: impl Stream<Item = Result<Bytes>> + Send + Sync + 'static,
+        segment_data: impl Stream<Item = Result<Bytes>> + Send + 'static,
     ) -> Result<()> {
         self.as_ref()
             .store_segment_data(config, namespace, key, segment_data)


### PR DESCRIPTION
This PR implements multipart uploads instead of regular uploads for the libsql-wal segment. That is because AWS S3 refuses payloads that are not known in size.

We instead use a multipart upload, where we stream in chunks of 50MB to temporary files that we then upload as parts of the multipart upload.
