### PR TITLE
libsql-wal replication fixed

### DIFF
--- a/libsql-server/src/connection/write_proxy.rs
+++ b/libsql-server/src/connection/write_proxy.rs
@@ -1,5 +1,7 @@
+use std::pin::Pin;
 use std::sync::Arc;
 
+use futures::Future;
 use futures_core::future::BoxFuture;
 use futures_core::Stream;
 use libsql_replication::rpc::proxy::proxy_client::ProxyClient;
@@ -8,7 +10,7 @@ use libsql_replication::rpc::proxy::{
 };
 use libsql_sys::EncryptionConfig;
 use parking_lot::Mutex as PMutex;
-use tokio::sync::{mpsc, watch, Mutex};
+use tokio::sync::{mpsc, Mutex};
 use tokio_stream::StreamExt;
 use tonic::transport::Channel;
 use tonic::{Request, Streaming};
@@ -22,16 +24,21 @@ use crate::replication::FrameNo;
 use crate::stats::Stats;
 use crate::{Result, DEFAULT_AUTO_CHECKPOINT};
 
+use super::connection_core::GetCurrentFrameNo;
 use super::program::DescribeResponse;
 use super::{Connection, RequestContext};
 use super::{MakeConnection, Program};
 
 pub type RpcStream = Streaming<ExecResp>;
+pub type WaitForFrameNo = Arc<
+    dyn Fn(FrameNo) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> + Send + 'static + Sync,
+>;
 
 pub struct MakeWriteProxyConn<M> {
     client: ProxyClient<Channel>,
     stats: Arc<Stats>,
-    applied_frame_no_receiver: watch::Receiver<Option<FrameNo>>,
+    wait_for_frame_no: WaitForFrameNo,
+    get_current_frame_no: GetCurrentFrameNo,
     max_response_size: u64,
     max_total_response_size: u64,
     primary_replication_index: Option<FrameNo>,
@@ -46,23 +53,25 @@ impl<M> MakeWriteProxyConn<M> {
         channel: Channel,
         uri: tonic::transport::Uri,
         stats: Arc<Stats>,
-        applied_frame_no_receiver: watch::Receiver<Option<FrameNo>>,
+        wait_for_frame_no: WaitForFrameNo,
         max_response_size: u64,
         max_total_response_size: u64,
         primary_replication_index: Option<FrameNo>,
         encryption_config: Option<EncryptionConfig>,
         make_read_only_conn: M,
+        get_current_frame_no: GetCurrentFrameNo,
     ) -> Self {
         let client = ProxyClient::with_origin(channel, uri);
         Self {
             client,
             stats,
-            applied_frame_no_receiver,
+            wait_for_frame_no,
             max_response_size,
             max_total_response_size,
             make_read_only_conn,
             primary_replication_index,
             encryption_config,
+            get_current_frame_no,
         }
     }
 }
@@ -77,7 +86,7 @@ where
         Ok(WriteProxyConnection::new(
             self.client.clone(),
             self.stats.clone(),
-            self.applied_frame_no_receiver.clone(),
+            self.wait_for_frame_no.clone(),
             QueryBuilderConfig {
                 max_size: Some(self.max_response_size),
                 max_total_size: Some(self.max_total_response_size),
@@ -85,6 +94,7 @@ where
                 encryption_config: self.encryption_config.clone(),
             },
             self.primary_replication_index,
+            self.get_current_frame_no.clone(),
             self.make_read_only_conn.create().await?,
         )?)
     }
@@ -99,8 +109,9 @@ pub struct WriteProxyConnection<R, C> {
     /// any subsequent read on this connection must wait for the replicator to catch up with this
     /// frame_no
     last_write_frame_no: PMutex<Option<FrameNo>>,
-    /// Notifier from the repliator of the currently applied frameno
-    applied_frame_no_receiver: watch::Receiver<Option<FrameNo>>,
+    /// Notifier from the replicator of the currently applied frame_no
+    wait_for_frame_no: WaitForFrameNo,
+    get_current_frame_no: GetCurrentFrameNo,
     builder_config: QueryBuilderConfig,
     stats: Arc<Stats>,
 
@@ -114,9 +125,10 @@ impl<C: Connection> WriteProxyConnection<RpcStream, C> {
     fn new(
         write_proxy: ProxyClient<Channel>,
         stats: Arc<Stats>,
-        applied_frame_no_receiver: watch::Receiver<Option<FrameNo>>,
+        wait_for_frame_no: WaitForFrameNo,
         builder_config: QueryBuilderConfig,
         primary_replication_index: Option<u64>,
+        get_current_frame_no: GetCurrentFrameNo,
         read_conn: C,
     ) -> Result<Self> {
         Ok(Self {
@@ -124,11 +136,12 @@ impl<C: Connection> WriteProxyConnection<RpcStream, C> {
             write_proxy,
             state: Mutex::new(TxnStatus::Init),
             last_write_frame_no: Default::default(),
-            applied_frame_no_receiver,
+            wait_for_frame_no,
             builder_config,
             stats,
             remote_conn: Default::default(),
             primary_replication_index,
+            get_current_frame_no,
         })
     }
 
@@ -199,15 +212,7 @@ impl<C: Connection> WriteProxyConnection<RpcStream, C> {
         let current_fno = replication_index.or_else(|| *self.last_write_frame_no.lock());
         match current_fno {
             Some(current_frame_no) => {
-                let mut receiver = self.applied_frame_no_receiver.clone();
-                receiver
-                    .wait_for(|last_applied| match last_applied {
-                        Some(x) => *x >= current_frame_no,
-                        None => true,
-                    })
-                    .await
-                    .map_err(|_| Error::ReplicatorExited)?;
-
+                (self.wait_for_frame_no)(current_frame_no).await;
                 Ok(())
             }
             None => Ok(()),
@@ -219,7 +224,7 @@ impl<C: Connection> WriteProxyConnection<RpcStream, C> {
     fn should_proxy(&self) -> bool {
         // There primary has data
         if let Some(primary_index) = self.primary_replication_index {
-            let last_applied = *self.applied_frame_no_receiver.borrow();
+            let last_applied = (self.get_current_frame_no)();
             // if we either don't have data while the primary has, or the data we have is
             // anterior to that of the primary when we loaded the namespace, then proxy the
             // request to the primary

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -1008,12 +1008,13 @@ where
         let make_replication_svc = Box::new({
             let registry = registry.clone();
             let disable_namespaces = self.disable_namespaces;
-            move |store, user_auth, _, _, _| -> BoxReplicationService {
+            move |store, user_auth, _, _, service_internal| -> BoxReplicationService {
                 Box::new(LibsqlReplicationService::new(
                     registry.clone(),
                     store,
                     user_auth,
                     disable_namespaces,
+                    service_internal,
                 ))
             }
         });


### PR DESCRIPTION
This PR fixes issues related to the integration of libsql-wal replication:
- auth issue: we changed auth to disambiguate between internal and external services, that didn't reflect on libsql-wal replication
- replication wasn't setup to retrieve the replica current frame_no and was replicating for scratch on restart
- when replica restarts, start replicating from the last durable frame_no to account for primary potential data loss