### PR TITLE
bottomless: add upload on shutdown skip option

### DIFF
--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -131,6 +131,7 @@ pub async fn metastore_connection_maker(
                 s3_max_parallelism: 32,
                 s3_max_retries: 10,
                 skip_snapshot: false,
+                skip_shutdown_upload: false,
             };
             let mut replicator = bottomless::replicator::Replicator::with_options(
                 db_path.join("data").to_str().unwrap(),


### PR DESCRIPTION
This commit adds a env var that can be set via
`LIBSQL_BOTTOMLESS_SKIP_SHUTDOWN_UPLOAD` that will force bottomless to ignore uploading a snapshot during a graceful shutdown.