### PR TITLE
libSQL WAL API

### DIFF
--- a/libsql-ffi/bundled/bindings/bindgen.rs
+++ b/libsql-ffi/bundled/bindings/bindgen.rs
@@ -3289,6 +3289,14 @@ pub struct libsql_wal_methods {
             arg3: *mut ::std::os::raw::c_uchar,
         ) -> ::std::os::raw::c_int,
     >,
+    pub xReadFrameRaw: ::std::option::Option<
+        unsafe extern "C" fn(
+            pWal: *mut wal_impl,
+            arg1: ::std::os::raw::c_uint,
+            arg2: ::std::os::raw::c_int,
+            arg3: *mut ::std::os::raw::c_uchar,
+        ) -> ::std::os::raw::c_int,
+    >,
     pub xDbsize:
         ::std::option::Option<unsafe extern "C" fn(pWal: *mut wal_impl) -> ::std::os::raw::c_uint>,
     pub xBeginWriteTransaction:

--- a/libsql-ffi/bundled/bindings/bindgen.rs
+++ b/libsql-ffi/bundled/bindings/bindgen.rs
@@ -3316,6 +3316,13 @@ pub struct libsql_wal_methods {
             aWalData: *mut ::std::os::raw::c_uint,
         ) -> ::std::os::raw::c_int,
     >,
+    pub xFrameCount: ::std::option::Option<
+        unsafe extern "C" fn(
+            pWal: *mut wal_impl,
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut ::std::os::raw::c_uint,
+        ) -> ::std::os::raw::c_int,
+    >,
     pub xFrames: ::std::option::Option<
         unsafe extern "C" fn(
             pWal: *mut wal_impl,

--- a/libsql-ffi/bundled/bindings/bindgen.rs
+++ b/libsql-ffi/bundled/bindings/bindgen.rs
@@ -940,7 +940,7 @@ extern "C" {
 extern "C" {
     pub fn sqlite3_vmprintf(
         arg1: *const ::std::os::raw::c_char,
-        arg2: *mut __va_list_tag,
+        arg2: va_list,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -956,7 +956,7 @@ extern "C" {
         arg1: ::std::os::raw::c_int,
         arg2: *mut ::std::os::raw::c_char,
         arg3: *const ::std::os::raw::c_char,
-        arg4: *mut __va_list_tag,
+        arg4: va_list,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2503,7 +2503,7 @@ extern "C" {
     pub fn sqlite3_str_vappendf(
         arg1: *mut sqlite3_str,
         zFormat: *const ::std::os::raw::c_char,
-        arg2: *mut __va_list_tag,
+        arg2: va_list,
     );
 }
 extern "C" {
@@ -2862,6 +2862,37 @@ extern "C" {
         >,
         arg: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
+}
+extern "C" {
+    pub fn libsql_wal_disable_checkpoint(db: *mut sqlite3) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn libsql_wal_frame_count(
+        arg1: *mut sqlite3,
+        arg2: *mut ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn libsql_wal_get_frame(
+        arg1: *mut sqlite3,
+        arg2: ::std::os::raw::c_uint,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn libsql_wal_insert_begin(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn libsql_wal_insert_end(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn libsql_wal_insert_frame(
+        arg1: *mut sqlite3,
+        arg2: ::std::os::raw::c_uint,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn sqlite3_system_errno(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
@@ -3539,12 +3570,4 @@ extern "C" {
 extern "C" {
     pub static sqlite3_wal_manager: libsql_wal_manager;
 }
-pub type __builtin_va_list = [__va_list_tag; 1usize];
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __va_list_tag {
-    pub gp_offset: ::std::os::raw::c_uint,
-    pub fp_offset: ::std::os::raw::c_uint,
-    pub overflow_arg_area: *mut ::std::os::raw::c_void,
-    pub reg_save_area: *mut ::std::os::raw::c_void,
-}
+pub type __builtin_va_list = *mut ::std::os::raw::c_char;

--- a/libsql-ffi/bundled/bindings/session_bindgen.rs
+++ b/libsql-ffi/bundled/bindings/session_bindgen.rs
@@ -23,10 +23,11 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 
-pub const SQLITE_VERSION: &[u8; 7] = b"3.44.0\0";
-pub const SQLITE_VERSION_NUMBER: i32 = 3044000;
+pub const __GNUC_VA_LIST: i32 = 1;
+pub const SQLITE_VERSION: &[u8; 7] = b"3.45.1\0";
+pub const SQLITE_VERSION_NUMBER: i32 = 3045001;
 pub const SQLITE_SOURCE_ID: &[u8; 85] =
-    b"2023-11-01 11:23:50 17129ba1ff7f0daf37100ee82d507aef7827cf38de1866e2633096ae6ad8alt1\0";
+    b"2024-01-30 16:01:20 e876e51a0ed5c5b3126f52e532044363a014bc594cfefa87ffb5b82257ccalt1\0";
 pub const LIBSQL_VERSION: &[u8; 6] = b"0.2.3\0";
 pub const SQLITE_OK: i32 = 0;
 pub const SQLITE_ERROR: i32 = 1;
@@ -355,6 +356,7 @@ pub const SQLITE_DETERMINISTIC: i32 = 2048;
 pub const SQLITE_DIRECTONLY: i32 = 524288;
 pub const SQLITE_SUBTYPE: i32 = 1048576;
 pub const SQLITE_INNOCUOUS: i32 = 2097152;
+pub const SQLITE_RESULT_SUBTYPE: i32 = 16777216;
 pub const SQLITE_WIN32_DATA_DIRECTORY_TYPE: i32 = 1;
 pub const SQLITE_WIN32_TEMP_DIRECTORY_TYPE: i32 = 2;
 pub const SQLITE_TXN_NONE: i32 = 0;
@@ -407,6 +409,7 @@ pub const SQLITE_TESTCTRL_PENDING_BYTE: i32 = 11;
 pub const SQLITE_TESTCTRL_ASSERT: i32 = 12;
 pub const SQLITE_TESTCTRL_ALWAYS: i32 = 13;
 pub const SQLITE_TESTCTRL_RESERVE: i32 = 14;
+pub const SQLITE_TESTCTRL_JSON_SELFCHECK: i32 = 14;
 pub const SQLITE_TESTCTRL_OPTIMIZATIONS: i32 = 15;
 pub const SQLITE_TESTCTRL_ISKEYWORD: i32 = 16;
 pub const SQLITE_TESTCTRL_SCRATCHMALLOC: i32 = 17;
@@ -516,8 +519,8 @@ pub const FTS5_TOKENIZE_DOCUMENT: i32 = 4;
 pub const FTS5_TOKENIZE_AUX: i32 = 8;
 pub const FTS5_TOKEN_COLOCATED: i32 = 1;
 pub const WAL_SAVEPOINT_NDATA: i32 = 4;
-pub type __gnuc_va_list = __builtin_va_list;
 pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
 extern "C" {
     pub static sqlite3_version: [::std::os::raw::c_char; 0usize];
 }
@@ -2278,11 +2281,7 @@ pub struct sqlite3_module {
             pzErr: *mut *mut ::std::os::raw::c_char,
         ) -> ::std::os::raw::c_int,
     >,
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct libsql_module {
-    pub iVersion: ::std::os::raw::c_int,
+    pub reserved: [::std::option::Option<unsafe extern "C" fn()>; 5usize],
     pub xPreparedSql: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: *mut sqlite3_vtab_cursor,
@@ -2345,16 +2344,6 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn libsql_create_module(
-        db: *mut sqlite3,
-        zName: *const ::std::os::raw::c_char,
-        p: *const sqlite3_module,
-        pLibsql: *const libsql_module,
-        pClientData: *mut ::std::os::raw::c_void,
-        xDestroy: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
     pub fn sqlite3_drop_modules(
         db: *mut sqlite3,
         azKeep: *mut *const ::std::os::raw::c_char,
@@ -2364,7 +2353,6 @@ extern "C" {
 #[derive(Debug, Copy, Clone)]
 pub struct sqlite3_vtab {
     pub pModule: *const sqlite3_module,
-    pub pLibsqlModule: *const libsql_module,
     pub nRef: ::std::os::raw::c_int,
     pub zErrMsg: *mut ::std::os::raw::c_char,
 }
@@ -2891,6 +2879,37 @@ extern "C" {
         >,
         arg: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
+}
+extern "C" {
+    pub fn libsql_wal_disable_checkpoint(db: *mut sqlite3) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn libsql_wal_frame_count(
+        arg1: *mut sqlite3,
+        arg2: *mut ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn libsql_wal_get_frame(
+        arg1: *mut sqlite3,
+        arg2: ::std::os::raw::c_uint,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn libsql_wal_insert_begin(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn libsql_wal_insert_end(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn libsql_wal_insert_frame(
+        arg1: *mut sqlite3,
+        arg2: ::std::os::raw::c_uint,
+        arg3: *mut ::std::os::raw::c_void,
+        arg4: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn sqlite3_system_errno(arg1: *mut sqlite3) -> ::std::os::raw::c_int;
@@ -3658,6 +3677,24 @@ pub struct Fts5ExtensionApi {
             arg2: *mut Fts5PhraseIter,
             piCol: *mut ::std::os::raw::c_int,
         ),
+    >,
+    pub xQueryToken: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut Fts5Context,
+            iPhrase: ::std::os::raw::c_int,
+            iToken: ::std::os::raw::c_int,
+            ppToken: *mut *const ::std::os::raw::c_char,
+            pnToken: *mut ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
+    >,
+    pub xInstToken: ::std::option::Option<
+        unsafe extern "C" fn(
+            arg1: *mut Fts5Context,
+            iIdx: ::std::os::raw::c_int,
+            iToken: ::std::os::raw::c_int,
+            arg2: *mut *const ::std::os::raw::c_char,
+            arg3: *mut ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
     >,
 }
 #[repr(C)]

--- a/libsql-ffi/bundled/bindings/session_bindgen.rs
+++ b/libsql-ffi/bundled/bindings/session_bindgen.rs
@@ -3822,6 +3822,13 @@ pub struct libsql_wal_methods {
             aWalData: *mut ::std::os::raw::c_uint,
         ) -> ::std::os::raw::c_int,
     >,
+    pub xFrameCount: ::std::option::Option<
+        unsafe extern "C" fn(
+            pWal: *mut wal_impl,
+            arg1: ::std::os::raw::c_int,
+            arg2: *mut ::std::os::raw::c_uint,
+        ) -> ::std::os::raw::c_int,
+    >,
     pub xFrames: ::std::option::Option<
         unsafe extern "C" fn(
             pWal: *mut wal_impl,

--- a/libsql-ffi/bundled/bindings/session_bindgen.rs
+++ b/libsql-ffi/bundled/bindings/session_bindgen.rs
@@ -3795,6 +3795,14 @@ pub struct libsql_wal_methods {
             arg3: *mut ::std::os::raw::c_uchar,
         ) -> ::std::os::raw::c_int,
     >,
+    pub xReadFrameRaw: ::std::option::Option<
+        unsafe extern "C" fn(
+            pWal: *mut wal_impl,
+            arg1: ::std::os::raw::c_uint,
+            arg2: ::std::os::raw::c_int,
+            arg3: *mut ::std::os::raw::c_uchar,
+        ) -> ::std::os::raw::c_int,
+    >,
     pub xDbsize:
         ::std::option::Option<unsafe extern "C" fn(pWal: *mut wal_impl) -> ::std::os::raw::c_uint>,
     pub xBeginWriteTransaction:

--- a/libsql-replication/src/injector/sqlite_injector/injector_wal.rs
+++ b/libsql-replication/src/injector/sqlite_injector/injector_wal.rs
@@ -110,6 +110,10 @@ impl Wal for InjectorWal {
         self.inner.read_frame(frame_no, buffer)
     }
 
+    fn read_frame_raw(&mut self, frame_no: NonZeroU32, buffer: &mut [u8]) -> Result<()> {
+        self.inner.read_frame_raw(frame_no, buffer)
+    }
+
     fn db_size(&self) -> u32 {
         self.inner.db_size()
     }

--- a/libsql-replication/src/injector/sqlite_injector/injector_wal.rs
+++ b/libsql-replication/src/injector/sqlite_injector/injector_wal.rs
@@ -134,6 +134,10 @@ impl Wal for InjectorWal {
         self.inner.savepoint_undo(rollback_data)
     }
 
+    fn frame_count(&self, locked: i32) -> Result<u32> {
+        self.inner.frame_count(locked)
+    }
+
     fn insert_frames(
         &mut self,
         page_size: c_int,

--- a/libsql-sqlite3/src/main.c
+++ b/libsql-sqlite3/src/main.c
@@ -2475,6 +2475,35 @@ int libsql_wal_frame_count(
 #endif
 }
 
+int libsql_wal_get_frame(
+  sqlite3* db,
+  unsigned int iFrame,
+  void *pBuf,
+  unsigned int nBuf
+){
+  int rc = SQLITE_OK;
+  Pager *pPager;
+
+#ifdef SQLITE_OMIT_WAL
+  UNUSED_PARAMETER(iFrame);
+  UNUSED_PARAMETER(nBuf);
+  UNUSED_PARAMETER(pBuf);
+  return SQLITE_OK;
+#else
+
+#ifdef SQLITE_ENABLE_API_ARMOR
+  if( !sqlite3SafetyCheckOk(db) ) return SQLITE_MISUSE_BKPT;
+#endif
+  
+    sqlite3_mutex_enter(db->mutex);
+    pPager = sqlite3BtreePager(db->aDb[0].pBt);
+    rc = sqlite3PagerWalReadFrameRaw(pPager, iFrame, pBuf, nBuf);
+    sqlite3_mutex_leave(db->mutex);
+  
+    return rc;
+#endif
+}
+
 /*
 ** Register a function to be invoked prior to each autovacuum that
 ** determines the number of pages to vacuum.

--- a/libsql-sqlite3/src/main.c
+++ b/libsql-sqlite3/src/main.c
@@ -2450,6 +2450,32 @@ int libsql_wal_disable_checkpoint(sqlite3 *db) {
 }
 
 /*
+** Return the number of frames in the WAL of the given database.
+*/
+int libsql_wal_frame_count(
+  sqlite3* db,
+  unsigned int *pnFrame
+){
+  int rc = SQLITE_OK;
+  Pager *pPager;
+
+#ifdef SQLITE_OMIT_WAL
+  *pnFrame = 0;
+  return SQLITE_OK;
+#else
+#ifdef SQLITE_ENABLE_API_ARMOR
+  if( !sqlite3SafetyCheckOk(db) ) return SQLITE_MISUSE_BKPT;
+#endif
+
+  sqlite3_mutex_enter(db->mutex);
+  pPager = sqlite3BtreePager(db->aDb[0].pBt);
+  rc = sqlite3PagerWalFrameCount(pPager, pnFrame);
+  sqlite3_mutex_leave(db->mutex);
+  return rc;
+#endif
+}
+
+/*
 ** Register a function to be invoked prior to each autovacuum that
 ** determines the number of pages to vacuum.
 */

--- a/libsql-sqlite3/src/pager.c
+++ b/libsql-sqlite3/src/pager.c
@@ -7771,6 +7771,19 @@ int sqlite3PagerCloseWal(Pager *pPager, sqlite3 *db){
   return rc;
 }
 
+/**
+** Return the number of frames in the WAL file.
+**
+** If the pager is not in WAL mode or we failed to obtain an exclusive write lock, returns -1.
+**/
+int sqlite3PagerWalFrameCount(Pager *pPager, unsigned int *pnFrames){
+  if( pagerUseWal(pPager) ){
+    return pPager->wal->methods.xFrameCount(pPager->wal->pData, 0, pnFrames);
+  }else{
+    return SQLITE_ERROR;
+  }
+}
+
 #ifdef SQLITE_ENABLE_SETLK_TIMEOUT
 /*
 ** If pager pPager is a wal-mode database not in exclusive locking mode,

--- a/libsql-sqlite3/src/pager.c
+++ b/libsql-sqlite3/src/pager.c
@@ -7784,6 +7784,21 @@ int sqlite3PagerWalFrameCount(Pager *pPager, unsigned int *pnFrames){
   }
 }
 
+int sqlite3PagerWalReadFrameRaw(
+  Pager *pPager,
+  unsigned int iFrame,
+  void *pFrameOut,
+  unsigned int nFrameOutLen
+){
+  if( pagerUseWal(pPager) ){
+    unsigned int nFrameLen = 24+pPager->pageSize;
+    if( nFrameOutLen!=nFrameLen ) return SQLITE_MISUSE;
+    return pPager->wal->methods.xReadFrameRaw(pPager->wal->pData, iFrame, nFrameOutLen, pFrameOut);
+  }else{
+    return SQLITE_ERROR;
+  }
+}
+
 #ifdef SQLITE_ENABLE_SETLK_TIMEOUT
 /*
 ** If pager pPager is a wal-mode database not in exclusive locking mode,

--- a/libsql-sqlite3/src/pager.c
+++ b/libsql-sqlite3/src/pager.c
@@ -7799,6 +7799,66 @@ int sqlite3PagerWalReadFrameRaw(
   }
 }
 
+int sqlite3PagerWalBeginCommit(Pager *pPager) {
+  int rc;
+  if (!pagerUseWal(pPager)) {
+    return SQLITE_ERROR;
+  }
+  rc = pagerBeginReadTransaction(pPager);
+  if (rc != SQLITE_OK) {
+    return rc;
+  }
+  return pPager->wal->methods.xBeginWriteTransaction(pPager->wal->pData);
+}
+
+int sqlite3PagerWalEndCommit(Pager *pPager) {
+  if (!pagerUseWal(pPager)) {
+    return SQLITE_ERROR;
+  }
+  return pPager->wal->methods.xEndWriteTransaction(pPager->wal->pData);
+}
+
+int sqlite3PagerWalInsert(Pager *pPager, unsigned int iFrame, void *pBuf, unsigned int nBuf) {
+  int rc = SQLITE_OK;
+
+  if (!pagerUseWal(pPager)) {
+    return SQLITE_ERROR;
+  }
+  unsigned int mxFrame;
+  rc = pPager->wal->methods.xFrameCount(pPager->wal->pData, 1, &mxFrame);
+  if (rc != SQLITE_OK) {
+    return rc;
+  }
+  if (iFrame <= mxFrame) {
+    return SQLITE_OK;
+  }
+  u8 *aFrame = (u8*)pBuf;
+  u32 pgno = sqlite3Get4byte(&aFrame[0]);
+  u32 nTruncate = sqlite3Get4byte(&aFrame[4]);
+  u8 *pData = aFrame + 24;
+
+  PgHdr pghdr;
+  memset(&pghdr, 0, sizeof(PgHdr));
+  pghdr.pPage = NULL;
+  pghdr.pData = pData;
+  pghdr.pExtra = NULL;
+  pghdr.pgno = pgno;
+  pghdr.flags = 0;
+
+  int isCommit = (nTruncate != 0);
+
+  int nFrames = 0;
+  rc = pPager->wal->methods.xFrames(pPager->wal->pData, 
+                                    pPager->pageSize, 
+                                    &pghdr, 
+                                    nTruncate, 
+                                    isCommit, 
+                                    pPager->walSyncFlags, 
+                                    &nFrames);
+  assert( nFrames == 1 );
+  return rc;
+}
+
 #ifdef SQLITE_ENABLE_SETLK_TIMEOUT
 /*
 ** If pager pPager is a wal-mode database not in exclusive locking mode,

--- a/libsql-sqlite3/src/pager.h
+++ b/libsql-sqlite3/src/pager.h
@@ -133,6 +133,8 @@ int sqlite3PagerReadFileheader(Pager*, int, unsigned char*);
 void sqlite3PagerSetBusyHandler(Pager*, int(*)(void *), void *);
 int sqlite3PagerSetPagesize(Pager*, u32*, int);
 Pgno sqlite3PagerMaxPageCount(Pager*, Pgno);
+int sqlite3PagerWalFrameCount(Pager *, unsigned int *);
+
 void sqlite3PagerSetCachesize(Pager*, int);
 int sqlite3PagerSetSpillsize(Pager*, int);
 void sqlite3PagerSetMmapLimit(Pager *, sqlite3_int64);

--- a/libsql-sqlite3/src/pager.h
+++ b/libsql-sqlite3/src/pager.h
@@ -134,6 +134,7 @@ void sqlite3PagerSetBusyHandler(Pager*, int(*)(void *), void *);
 int sqlite3PagerSetPagesize(Pager*, u32*, int);
 Pgno sqlite3PagerMaxPageCount(Pager*, Pgno);
 int sqlite3PagerWalFrameCount(Pager *, unsigned int *);
+int sqlite3PagerWalReadFrame(Pager *, unsigned int, void *, unsigned int);
 
 void sqlite3PagerSetCachesize(Pager*, int);
 int sqlite3PagerSetSpillsize(Pager*, int);

--- a/libsql-sqlite3/src/pager.h
+++ b/libsql-sqlite3/src/pager.h
@@ -135,6 +135,9 @@ int sqlite3PagerSetPagesize(Pager*, u32*, int);
 Pgno sqlite3PagerMaxPageCount(Pager*, Pgno);
 int sqlite3PagerWalFrameCount(Pager *, unsigned int *);
 int sqlite3PagerWalReadFrame(Pager *, unsigned int, void *, unsigned int);
+int sqlite3PagerWalBeginCommit(Pager*);
+int sqlite3PagerWalEndCommit(Pager*);
+int sqlite3PagerWalInsert(Pager*, unsigned int, void *, unsigned int);
 
 void sqlite3PagerSetCachesize(Pager*, int);
 int sqlite3PagerSetSpillsize(Pager*, int);

--- a/libsql-sqlite3/src/sqlite.h.in
+++ b/libsql-sqlite3/src/sqlite.h.in
@@ -10550,6 +10550,21 @@ int sqlite3_preupdate_blobwrite(sqlite3 *);
 void *libsql_close_hook(sqlite3 *db, void (*xClose)(void *pCtx, sqlite3 *db), void *arg);
 
 /*
+** CAPI3REF: Disable WAL checkpointing
+** METHOD: sqlite3
+**
+** ^The [libsql_wal_disable_checkpoint(D)] interface disables automatic
+** checkpointing of the WAL file for [database connection] D.
+**
+** Note: This function disables WAL checkpointing entirely, including when
+** the last database connection is closed. This is different from
+** sqlite3_wal_autocheckpoint() which only disables automatic checkpoints
+** for the current connection, but still allows checkpointing when the
+** connection is closed.
+*/
+int libsql_wal_disable_checkpoint(sqlite3 *db);
+
+/*
 ** CAPI3REF: Low-level system error code
 ** METHOD: sqlite3
 **

--- a/libsql-sqlite3/src/sqlite.h.in
+++ b/libsql-sqlite3/src/sqlite.h.in
@@ -10585,6 +10585,24 @@ int libsql_wal_frame_count(sqlite3*, unsigned int*);
 int libsql_wal_get_frame(sqlite3*, unsigned int, void*, unsigned int);
 
 /*
+** CAPI3REF: Begin frame insertion into the WAL
+** METHOD: sqlite3
+*/
+int libsql_wal_insert_begin(sqlite3*);
+
+/*
+** CAPI3REF: End frame insertion into the WAL
+** METHOD: sqlite3
+*/
+int libsql_wal_insert_end(sqlite3*);
+
+/*
+** CAPI3REF: Insert a frame into the WAL
+** METHOD: sqlite3
+*/
+int libsql_wal_insert_frame(sqlite3*, unsigned int, void *, unsigned int);
+
+/*
 ** CAPI3REF: Low-level system error code
 ** METHOD: sqlite3
 **

--- a/libsql-sqlite3/src/sqlite.h.in
+++ b/libsql-sqlite3/src/sqlite.h.in
@@ -10565,6 +10565,15 @@ void *libsql_close_hook(sqlite3 *db, void (*xClose)(void *pCtx, sqlite3 *db), vo
 int libsql_wal_disable_checkpoint(sqlite3 *db);
 
 /*
+** CAPI3REF: Get the number of frames in the WAL file
+** METHOD: sqlite3
+**
+** ^The [libsql_wal_frame_count(D,P)] interface returns the number of frames
+** in the WAL file for [database connection] D into *P.
+*/
+int libsql_wal_frame_count(sqlite3*, unsigned int*);
+
+/*
 ** CAPI3REF: Low-level system error code
 ** METHOD: sqlite3
 **

--- a/libsql-sqlite3/src/sqlite.h.in
+++ b/libsql-sqlite3/src/sqlite.h.in
@@ -10574,6 +10574,17 @@ int libsql_wal_disable_checkpoint(sqlite3 *db);
 int libsql_wal_frame_count(sqlite3*, unsigned int*);
 
 /*
+** CAPI3REF: Get a frame from the WAL file
+** METHOD: sqlite3
+**
+** ^The [libsql_wal_get_frame(D,I,P,S)] interface extracts frame I from
+** the WAL file for [database connection] D into memory obtained from
+** [sqlite3_malloc64()] and returns a pointer to that memory. The size of
+** the memory allocated is given by S.
+*/
+int libsql_wal_get_frame(sqlite3*, unsigned int, void*, unsigned int);
+
+/*
 ** CAPI3REF: Low-level system error code
 ** METHOD: sqlite3
 **

--- a/libsql-sqlite3/src/sqliteInt.h
+++ b/libsql-sqlite3/src/sqliteInt.h
@@ -1755,6 +1755,7 @@ struct sqlite3 {
   PreUpdate *pPreUpdate;        /* Context for active pre-update callback */
 #endif /* SQLITE_ENABLE_PREUPDATE_HOOK */
 #ifndef SQLITE_OMIT_WAL
+  int walCheckPointDisabled;
   int (*xWalCallback)(void *, sqlite3 *, const char *, int);
   void *pWalArg;
 #endif

--- a/libsql-sqlite3/src/test_walapi.c
+++ b/libsql-sqlite3/src/test_walapi.c
@@ -1,0 +1,154 @@
+#include <sqlite3.h>
+#include <stdio.h>
+#include <string.h>
+
+#if 0
+static void dump_frame(unsigned char *frame, size_t size){
+  for(int addr=0; addr<size; addr+=16){
+    int sum = 0;
+    for(int i=0; i<16 && addr+1<size; i++){
+      sum += frame[addr+i] != 0;
+    }
+    if( sum ){
+      printf("%08x: ", addr);
+      for(int i=0; i<16 && addr+i<size; i++){
+        printf("%02x ", frame[addr+i]);
+      }
+      printf("  |");
+      for(int i=0; i<16 && addr+i<size; i++){
+        printf("%c", frame[addr+i] ? frame[addr+i] : '.');
+      }
+      printf("|");
+      printf("\n");
+    }
+  }
+}
+#endif
+
+static int cmp_data(sqlite3 *db1, sqlite3 *db2){
+  sqlite3_stmt *stmt1, *stmt2;
+  int rc;
+
+  rc = sqlite3_prepare_v2(db1, "SELECT * FROM users", -1, &stmt1, 0);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "Can't prepare statement: %s\n", sqlite3_errmsg(db1));
+    return 1;
+  }
+
+  rc = sqlite3_prepare_v2(db2, "SELECT * FROM users", -1, &stmt2, 0);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "Can't prepare statement: %s\n", sqlite3_errmsg(db2));
+    return 1;
+  }
+
+  for(;;){
+    int step1 = sqlite3_step(stmt1);
+    int step2 = sqlite3_step(stmt2);
+    if( step1!=step2 ){
+      fprintf(stderr, "Step mismatch: %d != %d\n", step1, step2);
+      return 1;
+    }
+    if( step1!=SQLITE_ROW ){
+      break;
+    }
+    const unsigned char *name1 = sqlite3_column_text(stmt1, 1);
+    const unsigned char *name2 = sqlite3_column_text(stmt2, 1);
+    if( strcmp((const char *)name1, (const char *)name2)!=0 ){
+      fprintf(stderr, "Data mismatch: %s != %s\n", name1, name2);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int sync_db(sqlite3 *db_primary, sqlite3 *db_backup){
+  unsigned int max_frame;
+  int rc;
+
+  rc = libsql_wal_frame_count(db_primary, &max_frame);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "Can't get frame count: %s\n", sqlite3_errmsg(db_primary));
+    return 1;
+  }
+  rc = libsql_wal_insert_begin(db_backup);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "Can't begin commit: %s\n", sqlite3_errmsg(db_backup));
+    return 1;
+  }
+  for(int i=1; i<=max_frame; i++){
+    char frame[4096+24];
+    rc = libsql_wal_get_frame(db_primary, i, frame, sizeof(frame));
+    if( rc!=SQLITE_OK ){
+      fprintf(stderr, "Can't get frame: %s\n", sqlite3_errmsg(db_primary));
+      return 1;
+    }
+    rc = libsql_wal_insert_frame(db_backup, i, frame, sizeof(frame));
+    if( rc!=SQLITE_OK ){
+      fprintf(stderr, "Can't inject frame %d: %s\n", rc, sqlite3_errmsg(db_backup));
+      return 1;
+    }
+  }
+  rc = libsql_wal_insert_end(db_backup);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "Can't end commit: %s\n", sqlite3_errmsg(db_backup));
+    return 1;
+  }
+  return 0;
+}
+
+static void gen_data(sqlite3 *db){
+  sqlite3_exec(db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)", 0, 0, 0);
+  sqlite3_exec(db, "INSERT INTO users (id, name) VALUES (1, 'John Doe')", 0, 0, 0);
+  sqlite3_exec(db, "INSERT INTO users (id, name) VALUES (2, 'Jane Doe')", 0, 0, 0);
+  sqlite3_exec(db, "INSERT INTO users (id, name) VALUES (3, 'Jim Beam')", 0, 0, 0);
+}
+
+int main(int argc, char *argv[])
+{
+    sqlite3 *db_primary, *db_backup;
+    int rc;
+
+    rc = sqlite3_open("primary.db", &db_primary);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db_primary));
+        return 1;
+    }
+    rc = sqlite3_wal_autocheckpoint(db_primary, 0);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Can't disable checkpointing: %s\n", sqlite3_errmsg(db_primary));
+        return 1;
+    }
+    sqlite3_exec(db_primary, "PRAGMA journal_mode=WAL", NULL, NULL, NULL);
+
+    gen_data(db_primary);
+
+    rc = sqlite3_open("backup.db", &db_backup); 
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db_backup));
+        return 1;
+    }
+    rc = sqlite3_wal_autocheckpoint(db_backup, 0);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Can't disable checkpointing: %s\n", sqlite3_errmsg(db_backup));
+        return 1;
+    }
+    rc = sqlite3_exec(db_backup, "PRAGMA journal_mode=WAL", NULL, NULL, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Can't set journal mode: %s\n", sqlite3_errmsg(db_backup));
+        return 1;
+    }
+
+    sync_db(db_primary, db_backup);
+    if (cmp_data(db_primary, db_backup)) {
+        return 1;
+    }
+
+    sync_db(db_primary, db_backup);
+    if (cmp_data(db_primary, db_backup)) {
+        return 1;
+    }
+
+    printf("OK\n");
+
+    return 0;
+}

--- a/libsql-sqlite3/src/wal.c
+++ b/libsql-sqlite3/src/wal.c
@@ -2256,9 +2256,14 @@ static int sqlite3WalClose(
       if( pWal->exclusiveMode==WAL_NORMAL_MODE ){
         pWal->exclusiveMode = WAL_EXCLUSIVE_MODE;
       }
-      rc = sqlite3WalCheckpoint(pWal, db,
-          SQLITE_CHECKPOINT_PASSIVE, 0, 0, sync_flags, nBuf, zBuf, 0, 0, NULL, NULL
-      );
+      /* Don't checkpoint on close if automatic WAL checkpointing is disabled. */
+      if( !db->walCheckPointDisabled ){
+        rc = sqlite3WalCheckpoint(pWal, db,
+            SQLITE_CHECKPOINT_PASSIVE, 0, 0, sync_flags, nBuf, zBuf, 0, 0, NULL, NULL
+        );
+      } else {
+        rc = SQLITE_ERROR;
+      }
       if( rc==SQLITE_OK ){
         int bPersist = -1;
         sqlite3OsFileControlHint(

--- a/libsql-sqlite3/src/wal.h
+++ b/libsql-sqlite3/src/wal.h
@@ -56,6 +56,7 @@ typedef struct libsql_wal_methods {
   /* Read a page from the write-ahead log, if it is present. */
   int (*xFindFrame)(wal_impl* pWal, unsigned int, unsigned int *);
   int (*xReadFrame)(wal_impl* pWal, unsigned int, int, unsigned char *);
+  int (*xReadFrameRaw)(wal_impl* pWal, unsigned int, int, unsigned char *);
 
   /* If the WAL is not empty, return the size of the database. */
   unsigned int (*xDbsize)(wal_impl* pWal);

--- a/libsql-sqlite3/src/wal.h
+++ b/libsql-sqlite3/src/wal.h
@@ -75,6 +75,9 @@ typedef struct libsql_wal_methods {
   ** response to a ROLLBACK TO command. */
   int (*xSavepointUndo)(wal_impl* pWal, unsigned int *aWalData);
 
+  /* Return the number of frames in the WAL */
+  int (*xFrameCount)(wal_impl* pWal, int, unsigned int *);
+
   /* Write a frame or frames to the log. */
   int (*xFrames)(wal_impl* pWal, int, libsql_pghdr *, unsigned int, int, int, int*);
 

--- a/libsql-sqlite3/test/rust_suite/src/virtual_wal.rs
+++ b/libsql-sqlite3/test/rust_suite/src/virtual_wal.rs
@@ -98,6 +98,10 @@ mod tests {
             self.0.read_frame(frame_no, buffer)
         }
 
+        fn frame_count(&self, locked: i32) -> libsql_sys::wal::Result<u32> {
+            self.0.frame_count(locked)
+        }
+
         fn db_size(&self) -> u32 {
             self.0.db_size()
         }

--- a/libsql-sqlite3/test/rust_suite/src/virtual_wal.rs
+++ b/libsql-sqlite3/test/rust_suite/src/virtual_wal.rs
@@ -98,6 +98,14 @@ mod tests {
             self.0.read_frame(frame_no, buffer)
         }
 
+        fn read_frame_raw(
+            &mut self,
+            page_no: NonZeroU32,
+            buffer: &mut [u8],
+        ) -> libsql_sys::wal::Result<()> {
+            self.0.read_frame_raw(page_no, buffer)
+        }
+
         fn frame_count(&self, locked: i32) -> libsql_sys::wal::Result<u32> {
             self.0.frame_count(locked)
         }

--- a/libsql-storage/src/lib.rs
+++ b/libsql-storage/src/lib.rs
@@ -266,6 +266,10 @@ impl Wal for DurableWal {
         Ok(())
     }
 
+    fn read_frame_raw(&mut self, _page_no: std::num::NonZeroU32, _buffer: &mut [u8]) -> Result<()> {
+        todo!()
+    }
+
     fn frame_count(&self, _locked: i32) -> Result<u32> {
         todo!()
     }

--- a/libsql-storage/src/lib.rs
+++ b/libsql-storage/src/lib.rs
@@ -266,6 +266,10 @@ impl Wal for DurableWal {
         Ok(())
     }
 
+    fn frame_count(&self, _locked: i32) -> Result<u32> {
+        todo!()
+    }
+
     fn db_size(&self) -> u32 {
         let size = self.local_cache.get_max_frame_num().unwrap();
         trace!("DurableWal::db_size() => {}", size);

--- a/libsql-sys/src/wal/either.rs
+++ b/libsql-sys/src/wal/either.rs
@@ -75,6 +75,12 @@ macro_rules! create_either {
                 }
             }
 
+            fn frame_count(&self, locked: i32) -> super::Result<u32> {
+                match self {
+                    $( $name::$t(inner) => inner.frame_count(locked) ),*
+                }
+            }
+
             fn insert_frames(
                 &mut self,
                 page_size: std::ffi::c_int,

--- a/libsql-sys/src/wal/either.rs
+++ b/libsql-sys/src/wal/either.rs
@@ -39,6 +39,12 @@ macro_rules! create_either {
                 }
             }
 
+            fn read_frame_raw(&mut self, frame_no: std::num::NonZeroU32, buffer: &mut [u8]) -> super::Result<()> {
+                match self {
+                    $( $name::$t(inner) => inner.read_frame_raw(frame_no, buffer) ),*
+                }
+            }
+
             fn db_size(&self) -> u32 {
                 match self {
                     $( $name::$t(inner) => inner.db_size() ),*

--- a/libsql-sys/src/wal/ffi.rs
+++ b/libsql-sys/src/wal/ffi.rs
@@ -23,6 +23,7 @@ pub(crate) fn construct_libsql_wal<W: Wal>(wal: *mut W) -> libsql_wal {
             xEndReadTransaction: Some(end_read_transaction::<W>),
             xFindFrame: Some(find_frame::<W>),
             xReadFrame: Some(read_frame::<W>),
+            xReadFrameRaw: Some(read_frame_raw::<W>),
             xDbsize: Some(db_size::<W>),
             xBeginWriteTransaction: Some(begin_write_transaction::<W>),
             xEndWriteTransaction: Some(end_write_transaction::<W>),
@@ -203,6 +204,23 @@ pub unsafe extern "C" fn read_frame<T: Wal>(
     let this = &mut (*(wal as *mut T));
     let buffer = std::slice::from_raw_parts_mut(p_out, n_out as usize);
     match this.read_frame(
+        NonZeroU32::new(frame).expect("invalid frame number"),
+        buffer,
+    ) {
+        Ok(_) => SQLITE_OK,
+        Err(code) => code.extended_code,
+    }
+}
+
+pub unsafe extern "C" fn read_frame_raw<T: Wal>(
+    wal: *mut wal_impl,
+    frame: u32,
+    n_out: c_int,
+    p_out: *mut u8,
+) -> i32 {
+    let this = &mut (*(wal as *mut T));
+    let buffer = std::slice::from_raw_parts_mut(p_out, n_out as usize);
+    match this.read_frame_raw(
         NonZeroU32::new(frame).expect("invalid frame number"),
         buffer,
     ) {

--- a/libsql-sys/src/wal/ffi.rs
+++ b/libsql-sys/src/wal/ffi.rs
@@ -1,4 +1,4 @@
-use std::ffi::{c_char, c_int, c_longlong, c_void, CStr};
+use std::ffi::{c_char, c_int, c_longlong, c_uint, c_void, CStr};
 use std::num::NonZeroU32;
 use std::ptr::null;
 
@@ -29,6 +29,7 @@ pub(crate) fn construct_libsql_wal<W: Wal>(wal: *mut W) -> libsql_wal {
             xUndo: Some(undo::<W>),
             xSavepoint: Some(savepoint::<W>),
             xSavepointUndo: Some(savepoint_undo::<W>),
+            xFrameCount: Some(frame_count::<W>),
             xFrames: Some(frames::<W>),
             xCheckpoint: Some(checkpoint::<W>),
             xCallback: Some(callback::<W>),
@@ -272,6 +273,25 @@ pub unsafe extern "C" fn savepoint_undo<T: Wal>(wal: *mut wal_impl, wal_data: *m
     let data = std::slice::from_raw_parts_mut(wal_data, WAL_SAVEPOINT_NDATA as usize);
     match this.savepoint_undo(data) {
         Ok(_) => SQLITE_OK,
+        Err(code) => code.extended_code,
+    }
+}
+
+pub unsafe extern "C" fn frame_count<T: Wal>(
+    wal: *mut wal_impl,
+    locked: i32,
+    out: *mut c_uint,
+) -> c_int {
+    let this = &mut (*(wal as *mut T));
+    match this.frame_count(locked) {
+        Ok(n) => {
+            if !out.is_null() {
+                unsafe {
+                    *out = n as _;
+                }
+            }
+            SQLITE_OK
+        }
         Err(code) => code.extended_code,
     }
 }

--- a/libsql-sys/src/wal/mod.rs
+++ b/libsql-sys/src/wal/mod.rs
@@ -197,6 +197,8 @@ pub trait Wal {
     fn savepoint(&mut self, rollback_data: &mut [u32]);
     fn savepoint_undo(&mut self, rollback_data: &mut [u32]) -> Result<()>;
 
+    fn frame_count(&self, locked: i32) -> Result<u32>;
+
     /// Insert frames in the wal. On commit, returns the number of inserted frames for that
     /// transaction, or 0 for non-commit calls.
     fn insert_frames(

--- a/libsql-sys/src/wal/mod.rs
+++ b/libsql-sys/src/wal/mod.rs
@@ -186,6 +186,8 @@ pub trait Wal {
     fn find_frame(&mut self, page_no: NonZeroU32) -> Result<Option<NonZeroU32>>;
     /// reads frame `frame_no` into buffer.
     fn read_frame(&mut self, frame_no: NonZeroU32, buffer: &mut [u8]) -> Result<()>;
+    /// reads frame `frame_no` including its frame header into buffer.
+    fn read_frame_raw(&mut self, frame_no: NonZeroU32, buffer: &mut [u8]) -> Result<()>;
 
     fn db_size(&self) -> u32;
 

--- a/libsql-sys/src/wal/sqlite3_wal.rs
+++ b/libsql-sys/src/wal/sqlite3_wal.rs
@@ -203,6 +203,22 @@ impl Wal for Sqlite3Wal {
         }
     }
 
+    fn read_frame_raw(&mut self, frame_no: NonZeroU32, buffer: &mut [u8]) -> Result<()> {
+        let rc = unsafe {
+            (self.inner.methods.xReadFrameRaw.unwrap())(
+                self.inner.pData,
+                frame_no.into(),
+                buffer.len() as _,
+                buffer.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            Err(Error::new(rc))
+        } else {
+            Ok(())
+        }
+    }
+
     fn db_size(&self) -> u32 {
         unsafe { (self.inner.methods.xDbsize.unwrap())(self.inner.pData) }
     }

--- a/libsql-sys/src/wal/sqlite3_wal.rs
+++ b/libsql-sys/src/wal/sqlite3_wal.rs
@@ -272,6 +272,18 @@ impl Wal for Sqlite3Wal {
         }
     }
 
+    fn frame_count(&self, locked: i32) -> Result<u32> {
+        let mut out: u32 = 0;
+        let rc = unsafe {
+            (self.inner.methods.xFrameCount.unwrap())(self.inner.pData, locked, &mut out)
+        };
+        if rc != 0 {
+            Err(Error::new(rc))
+        } else {
+            Ok(out)
+        }
+    }
+
     fn insert_frames(
         &mut self,
         page_size: c_int,

--- a/libsql-sys/src/wal/wrapper.rs
+++ b/libsql-sys/src/wal/wrapper.rs
@@ -85,6 +85,10 @@ impl<T: WrapWal<W>, W: Wal> Wal for WalRef<T, W> {
         unsafe { (*self.wrapper).savepoint_undo(&mut *self.wrapped, rollback_data) }
     }
 
+    fn frame_count(&self, locked: i32) -> super::Result<u32> {
+        unsafe { (*self.wrapper).frame_count(&*self.wrapped, locked) }
+    }
+
     fn insert_frames(
         &mut self,
         page_size: c_int,
@@ -259,6 +263,10 @@ where
             .savepoint_undo(&mut self.wrapped, rollback_data)
     }
 
+    fn frame_count(&self, locked: i32) -> super::Result<u32> {
+        self.wrapper.frame_count(&self.wrapped, locked)
+    }
+
     fn insert_frames(
         &mut self,
         page_size: std::ffi::c_int,
@@ -381,6 +389,10 @@ pub trait WrapWal<W: Wal> {
 
     fn savepoint_undo(&mut self, wrapped: &mut W, rollback_data: &mut [u32]) -> super::Result<()> {
         wrapped.savepoint_undo(rollback_data)
+    }
+
+    fn frame_count(&self, wrapped: &W, locked: i32) -> super::Result<u32> {
+        wrapped.frame_count(locked)
     }
 
     fn insert_frames(

--- a/libsql-wal/src/wal.rs
+++ b/libsql-wal/src/wal.rs
@@ -171,6 +171,15 @@ where
     }
 
     #[tracing::instrument(skip_all, fields(id = self.conn_id))]
+    fn read_frame_raw(
+        &mut self,
+        _page_no: std::num::NonZeroU32,
+        _buffer: &mut [u8],
+    ) -> libsql_sys::wal::Result<()> {
+        Err(libsql_sys::wal::Error::new(10)) // SQLITE_IOERR
+    }
+
+    #[tracing::instrument(skip_all, fields(id = self.conn_id))]
     fn db_size(&self) -> u32 {
         let db_size = match self.tx.as_ref() {
             Some(tx) => tx.db_size,

--- a/libsql-wal/src/wal.rs
+++ b/libsql-wal/src/wal.rs
@@ -267,6 +267,11 @@ where
     }
 
     #[tracing::instrument(skip_all, fields(id = self.conn_id))]
+    fn frame_count(&self, _locked: i32) -> libsql_sys::wal::Result<u32> {
+        Err(libsql_sys::wal::Error::new(10)) // SQLITE_IOERR
+    }
+
+    #[tracing::instrument(skip_all, fields(id = self.conn_id))]
     fn insert_frames(
         &mut self,
         page_size: std::ffi::c_int,


### PR DESCRIPTION
The libSQL has the following WAL API functions, which are useful for
syncing the WAL between databases:

* `libsql_wal_disable_checkpoint` -- Disable checkpointing, including on database close.
* `libsql_wal_frame_count` -- Get the number of frames in the WAL.
* `libsql_wal_get_frame` -- Get a frame from the WAL.
* `libsql_wal_insert_begin` -- Begin WAL insertion.
* `libsql_wal_insert_frame` -- Insert a frame into the WAL.
* `libsql_wal_insert_end` -- End WAL insertion.

The purpose of this API is to allow syncing the frames of one database WAL onto another. Example usage looks as follows (omitting error handling):

```c
static void sync_db(sqlite3 *db_primary, sqlite3 *db_backup){
  unsigned int max_frame;

  libsql_wal_frame_count(db_primary, &max_frame);
  libsql_wal_begin_commit(db_backup);
  for(int i=1; i<=max_frame; i++){
    char frame[4096+24];
    libsql_wal_get_frame(db_primary, i, frame, sizeof(frame));
    libsql_wal_insert_frame(db_backup, i, frame, sizeof(frame));
  }
  libsql_wal_end_commit(db_backup);
}
```

Possible future work:

* Do we need to make the WAL salt the same across synced databases?
* How can we detect that frames belong to a database that it is synced to?

Fixes #200