### PR TITLE
libsql-sqlite3: Fix xPrepareSql init in test8.c

### DIFF
--- a/libsql-sqlite3/src/test8.c
+++ b/libsql-sqlite3/src/test8.c
@@ -1361,8 +1361,13 @@ static sqlite3_module echoModuleV2 = {
   echoRelease,
   echoRollbackTo,
   0,                         /* xShadowName */
+  0,                         /* xIntegrity  */
+  0,
+  0,
+  0,
+  0,
+  0,
   echoPreparedSql,
-  0                          /* xIntegrity  */
 };
 
 /*


### PR DESCRIPTION
The module struct initializer for xPrepareSql is wrong since commit d178de8f07 ("bugfix: reset modifications of `sqlite3_vtab` (#1027)") because it assings the xPrepareSql as the xIntegrity hook:

```
/home/runner/work/libsql/libsql/libsql-sqlite3/src/test8.c:1364:3: warning: initialization of 'int (*)(sqlite3_vtab *, const char *, const char *, int,  char **)' from incompatible pointer type 'int (*)(sqlite3_vtab_cursor *, const char *)' [-Wincompatible-pointer-types]
 1364 |   echoPreparedSql,
      |   ^~~~~~~~~~~~~~~
/home/runner/work/libsql/libsql/libsql-sqlite3/src/test8.c:1364:3: note: (near initialization for 'echoModuleV2.xIntegrity')
```