### PR TITLE
LibSql (rust lib) doesnt expose the BatchRows type

### DIFF
--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -171,7 +171,7 @@ cfg_hrana! {
 }
 
 pub use self::{
-    connection::Connection,
+    connection::{BatchRows, Connection},
     database::{Builder, Database},
     load_extension_guard::LoadExtensionGuard,
     rows::{Column, Row, Rows},


### PR DESCRIPTION
I had created some .net bindings to the lib and i need this type to be expose.