### PR TITLE
Add Database::get_sync_usage_stats

### DIFF
--- a/libsql/src/replication/remote_client.rs
+++ b/libsql/src/replication/remote_client.rs
@@ -89,7 +89,7 @@ impl RemoteClient {
     ) -> Result<bool, Error> {
         let hello = hello?.into_inner();
         verify_session_token(&hello.session_token).map_err(Error::Client)?;
-        let new_session = self.session_token != Some(hello.session_token.clone());
+        let new_session = self.session_token.as_ref() != Some(&hello.session_token);
         self.session_token = Some(hello.session_token.clone());
         let current_replication_index = hello.current_replication_index;
         if let Err(e) = self.meta.init_from_hello(hello) {

--- a/libsql/src/replication/remote_client.rs
+++ b/libsql/src/replication/remote_client.rs
@@ -107,7 +107,7 @@ impl RemoteClient {
         Ok(new_session)
     }
 
-    async fn do_handshake_with_prefetch(&mut self) -> (Result<bool, Error>, Duration) {
+    async fn do_handshake_with_prefetch(&mut self) -> (Result<(), Error>, Duration) {
         tracing::info!("Attempting to perform handshake with primary.");
         if self.dirty {
             self.prefetched_batch_log_entries = None;
@@ -144,7 +144,7 @@ impl RemoteClient {
             frames
         };
 
-        hello
+        (hello.0.map(|_| ()), hello.1)
     }
 
     async fn handle_next_frames_response(
@@ -255,7 +255,7 @@ impl ReplicatorClient for RemoteClient {
             &result,
             "handshake",
         );
-        result.map(|_| ())
+        result
     }
 
     /// Return a stream of frames to apply to the database

--- a/libsql/src/replication/remote_client.rs
+++ b/libsql/src/replication/remote_client.rs
@@ -24,7 +24,7 @@ async fn time<O>(fut: impl Future<Output = O>) -> (O, Duration) {
     (out, before.elapsed())
 }
 
-struct SyncStats {
+pub(crate) struct SyncStats {
     pub prefetched_bytes: AtomicU64,
     pub prefetched_bytes_discarded_due_to_new_session: AtomicU64,
     pub prefetched_bytes_discarded_due_to_consecutive_handshake: AtomicU64,
@@ -119,6 +119,10 @@ impl RemoteClient {
             snapshot_latency_count: 0,
             sync_stats: Arc::new(SyncStats::new()),
         })
+    }
+
+    pub(crate) fn sync_stats(&self) -> Arc<SyncStats> {
+        self.sync_stats.clone()
     }
 
     fn next_offset(&self) -> FrameNo {


### PR DESCRIPTION
Track detailed usage of synced bytes that will hopefully allow to identify why we're accounting so many bytes for sync.

Expose those detailed stats through Database::get_sync_usage_stats.