### PR TITLE
Initial offline write support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.70",
  "which",
@@ -885,7 +885,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.70",
  "which",
@@ -1022,9 +1022,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -2661,6 +2661,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -2713,6 +2714,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls 0.23.11",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+ "webpki-roots 0.26.3",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,6 +2754,25 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tungstenite",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3097,6 +3135,7 @@ dependencies = [
  "parking_lot",
  "pprof",
  "rand",
+ "reqwest 0.12.9",
  "serde",
  "serde_json",
  "tempfile",
@@ -3126,7 +3165,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "num-traits",
- "reqwest",
+ "reqwest 0.11.27",
  "serde_json",
  "url",
 ]
@@ -3246,7 +3285,7 @@ dependencies = [
  "prost-build",
  "rand",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "rheaper",
  "ring",
  "rustls 0.21.12",
@@ -4393,6 +4432,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.11",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.11",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4550,7 +4637,7 @@ checksum = "d4a52e724646c6c0800fc456ec43b4165d2f91fba88ceaca06d9e0b400023478"
 dependencies = [
  "hashbrown 0.13.2",
  "log",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "slice-group-by",
  "smallvec",
 ]
@@ -4647,6 +4734,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.11",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.26.3",
+ "windows-registry",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4721,6 +4850,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4777,6 +4912,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.5",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
+dependencies = [
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.5",
@@ -5531,6 +5680,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "system-configuration"
@@ -5775,6 +5927,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.11",
  "rustls-pki-types",
  "tokio",
 ]
@@ -6889,6 +7052,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -42,6 +42,7 @@ fallible-iterator = { version = "0.3", optional = true }
 
 libsql_replication = { version = "0.6", path = "../libsql-replication", optional = true }
 async-stream = { version = "0.3.5", optional = true }
+reqwest = { version = "0.12.9", default-features = false, features = [ "rustls-tls" ], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports", "async", "async_futures", "async_tokio"] }
@@ -53,7 +54,7 @@ tempfile = { version = "3.7.0" }
 rand = "0.8.5"
 
 [features]
-default = ["core", "replication", "remote", "tls"]
+default = ["core", "replication", "remote", "sync", "tls"]
 core = [
   "libsql-sys",
   "dep:bitflags",
@@ -90,6 +91,21 @@ replication = [
   "dep:tower-http",
   "dep:futures",
   "dep:libsql_replication",
+]
+sync = [
+  "core",
+  "parser",
+  "serde",
+  "stream",
+  "dep:tower",
+  "dep:hyper",
+  "dep:http",
+  "dep:tokio",
+  "dep:zerocopy",
+  "dep:bytes",
+  "dep:tokio",
+  "dep:futures",
+  "dep:reqwest",
 ]
 hrana = [
   "parser",

--- a/libsql/examples/offline_writes.rs
+++ b/libsql/examples/offline_writes.rs
@@ -1,0 +1,79 @@
+// Example of using a offline writes with libSQL.
+
+use libsql::{params, Builder};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    // The local database path where the data will be stored.
+    let db_path = std::env::var("LIBSQL_DB_PATH")
+        .map_err(|_| {
+            eprintln!(
+                "Please set the LIBSQL_DB_PATH environment variable to set to local database path."
+            )
+        })
+        .unwrap();
+
+    // The remote sync URL to use.
+    let sync_url = std::env::var("LIBSQL_SYNC_URL")
+        .map_err(|_| {
+            eprintln!(
+                "Please set the LIBSQL_SYNC_URL environment variable to set to remote sync URL."
+            )
+        })
+        .unwrap();
+
+    // The authentication token to use.
+    let auth_token = std::env::var("LIBSQL_AUTH_TOKEN").unwrap_or("".to_string());
+
+    let db_builder = Builder::new_synced_database(db_path, sync_url, auth_token);
+
+    let db = match db_builder.build().await {
+        Ok(db) => db,
+        Err(error) => {
+            eprintln!("Error connecting to remote sync server: {}", error);
+            return;
+        }
+    };
+
+    let conn = db.connect().unwrap();
+
+    conn.execute(
+        r#"
+        CREATE TABLE IF NOT EXISTS guest_book_entries (
+            text TEXT
+        )"#,
+        (),
+    )
+    .await
+    .unwrap();
+
+    let mut input = String::new();
+    println!("Please write your entry to the guestbook:");
+    match std::io::stdin().read_line(&mut input) {
+        Ok(_) => {
+            println!("You entered: {}", input);
+            let params = params![input.as_str()];
+            conn.execute("INSERT INTO guest_book_entries (text) VALUES (?)", params)
+                .await
+                .unwrap();
+        }
+        Err(error) => {
+            eprintln!("Error reading input: {}", error);
+        }
+    }
+    let mut results = conn
+        .query("SELECT * FROM guest_book_entries", ())
+        .await
+        .unwrap();
+    println!("Guest book entries:");
+    while let Some(row) = results.next().await.unwrap() {
+        let text: String = row.get(0).unwrap();
+        println!("  {}", text);
+    }
+
+    println!("Syncing database to remote...");
+    db.sync().await.unwrap();
+    println!("Done!");
+}

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -33,6 +33,32 @@ cfg_core! {
     }
 }
 
+cfg_replication_or_sync! {
+    pub type FrameNo = u64;
+
+    #[derive(Debug)]
+    pub struct Replicated {
+        pub(crate) frame_no: Option<FrameNo>,
+        pub(crate) frames_synced: usize,
+    }
+
+    impl Replicated {
+        /// The currently synced frame number. This can be used to track
+        /// where in the log you might be. Beware that this value can be reset to a lower value by the
+        /// server in certain situations. Please use `frames_synced` if you want to track the amount of
+        /// work a sync has done.
+        pub fn frame_no(&self) -> Option<FrameNo> {
+            self.frame_no
+        }
+
+        /// The count of frames synced during this call of `sync`. A frame is a 4kB frame from the
+        /// libsql write ahead log.
+        pub fn frames_synced(&self) -> usize {
+            self.frames_synced
+        }
+    }
+}
+
 enum DbType {
     #[cfg(feature = "core")]
     Memory { db: crate::local::Database },
@@ -47,6 +73,8 @@ enum DbType {
         db: crate::local::Database,
         encryption_config: Option<EncryptionConfig>,
     },
+    #[cfg(feature = "sync")]
+    Offline { db: crate::local::Database },
     #[cfg(feature = "remote")]
     Remote {
         url: String,
@@ -66,6 +94,8 @@ impl fmt::Debug for DbType {
             Self::File { .. } => write!(f, "File"),
             #[cfg(feature = "replication")]
             Self::Sync { .. } => write!(f, "Sync"),
+            #[cfg(feature = "sync")]
+            Self::Offline { .. } => write!(f, "Offline"),
             #[cfg(feature = "remote")]
             Self::Remote { .. } => write!(f, "Remote"),
             _ => write!(f, "no database type set"),
@@ -118,7 +148,6 @@ cfg_core! {
 
 cfg_replication! {
     use crate::Error;
-    use libsql_replication::frame::FrameNo;
 
 
     impl Database {
@@ -332,17 +361,19 @@ cfg_replication! {
 
         /// Sync database from remote, and returns the committed frame_no after syncing, if
         /// applicable.
-        pub async fn sync(&self) -> Result<crate::replication::Replicated> {
-            if let DbType::Sync { db, encryption_config: _ } = &self.db_type {
-                db.sync().await
-            } else {
-                Err(Error::SyncNotSupported(format!("{:?}", self.db_type)))
+        pub async fn sync(&self) -> Result<Replicated> {
+            match &self.db_type {
+                #[cfg(feature = "replication")]
+                DbType::Sync { db, encryption_config: _ } => db.sync().await,
+                #[cfg(feature = "sync")]
+                DbType::Offline { db } => db.push().await,
+                _ => Err(Error::SyncNotSupported(format!("{:?}", self.db_type))),
             }
         }
 
         /// Sync database from remote until it gets to a given replication_index or further,
         /// and returns the committed frame_no after syncing, if applicable.
-        pub async fn sync_until(&self, replication_index: FrameNo) -> Result<crate::replication::Replicated> {
+        pub async fn sync_until(&self, replication_index: FrameNo) -> Result<Replicated> {
             if let DbType::Sync { db, encryption_config: _ } = &self.db_type {
                 db.sync_until(replication_index).await
             } else {
@@ -591,6 +622,17 @@ impl Database {
                     self.max_write_replication_index.clone(),
                 );
                 let conn = std::sync::Arc::new(remote);
+
+                Ok(Connection { conn })
+            }
+
+            #[cfg(feature = "sync")]
+            DbType::Offline { db } => {
+                use crate::local::impls::LibsqlConnection;
+
+                let conn = db.connect()?;
+
+                let conn = std::sync::Arc::new(LibsqlConnection { conn });
 
                 Ok(Connection { conn })
             }

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -129,6 +129,10 @@ cfg_core! {
 
 pub mod params;
 
+cfg_sync! {
+    mod sync;
+}
+
 cfg_replication! {
     pub mod replication;
 }

--- a/libsql/src/macros.rs
+++ b/libsql/src/macros.rs
@@ -13,8 +13,8 @@ macro_rules! cfg_core {
 macro_rules! cfg_replication_or_remote {
     ($($item:item)*) => {
         $(
-            #[cfg(any(feature = "replication", feature = "remote"))]
-            #[cfg_attr(docsrs, doc(cfg(any(feature = "replication", feature = "remote"))))]
+            #[cfg(any(feature = "replication", feature = "sync", feature = "remote"))]
+            #[cfg_attr(docsrs, doc(cfg(any(feature = "replication", feature = "sync", feature = "remote"))))]
             $item
         )*
     }
@@ -35,6 +35,26 @@ macro_rules! cfg_replication {
         $(
             #[cfg(feature = "replication")]
             #[cfg_attr(docsrs, doc(cfg(feature = "replication")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_sync {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "sync")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_replication_or_sync {
+    ($($item:item)*) => {
+        $(
+            #[cfg(any(feature = "replication", feature = "sync"))]
+            #[cfg_attr(docsrs, doc(cfg(any(feature = "replication", feature = "sync"))))]
             $item
         )*
     }

--- a/libsql/src/replication/mod.rs
+++ b/libsql/src/replication/mod.rs
@@ -34,27 +34,7 @@ mod connection;
 pub(crate) mod local_client;
 pub(crate) mod remote_client;
 
-#[derive(Debug)]
-pub struct Replicated {
-    pub(crate) frame_no: Option<FrameNo>,
-    pub(crate) frames_synced: usize,
-}
-
-impl Replicated {
-    /// The currently synced frame number. This can be used to track
-    /// where in the log you might be. Beware that this value can be reset to a lower value by the
-    /// server in certain situations. Please use `frames_synced` if you want to track the amount of
-    /// work a sync has done.
-    pub fn frame_no(&self) -> Option<FrameNo> {
-        self.frame_no
-    }
-
-    /// The count of frames synced during this call of `sync`. A frame is a 4kB frame from the
-    /// libsql write ahead log.
-    pub fn frames_synced(&self) -> usize {
-        self.frames_synced
-    }
-}
+pub use crate::database::Replicated;
 
 /// A set of rames to be injected via `sync_frames`.
 pub enum Frames {

--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -1,0 +1,18 @@
+const DEFAULT_MAX_RETRIES: usize = 5;
+pub struct SyncContext {
+    pub sync_url: String,
+    pub auth_token: Option<String>,
+    pub max_retries: usize,
+    pub durable_frame_num: u32,
+}
+
+impl SyncContext {
+    pub fn new(sync_url: String, auth_token: Option<String>) -> Self {
+        Self {
+            sync_url,
+            auth_token,
+            durable_frame_num: 0,
+            max_retries: DEFAULT_MAX_RETRIES,
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a new type of database, synced database, which
allows local writes that can sync to a remote server.

The protocol on server side is simple:

  **POST** `/sync/<generation>/<start_frame>/<end_frame>`

where request body is the WAL frames.