### PR TITLE
bump sqld version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-server"
-version = "0.24.27"
+version = "0.24.28"
 dependencies = [
  "aes",
  "anyhow",

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-server"
-version = "0.24.27"
+version = "0.24.28"
 edition = "2021"
 default-run = "sqld"
 repository = "https://github.com/tursodatabase/libsql"


### PR DESCRIPTION
- new release will include fix for vector search in attached DBs (see https://github.com/tursodatabase/libsql/pull/1799)