### PR TITLE
libsql: Improve WAL frame push logic

### DIFF
--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -42,7 +42,7 @@ fallible-iterator = { version = "0.3", optional = true }
 
 libsql_replication = { version = "0.6", path = "../libsql-replication", optional = true }
 async-stream = { version = "0.3.5", optional = true }
-reqwest = { version = "0.12.9", default-features = false, features = [ "rustls-tls" ], optional = true }
+reqwest = { version = "0.12.9", default-features = false, features = [ "rustls-tls", "json" ], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports", "async", "async_futures", "async_tokio"] }
@@ -106,6 +106,7 @@ sync = [
   "dep:tokio",
   "dep:futures",
   "dep:reqwest",
+  "dep:serde_json",
 ]
 hrana = [
   "parser",


### PR DESCRIPTION
The server returns its maximum frame number so let's use that as a hint to avoid pushing frames it already knows about. IOW, let's start by sending the first frame in the WAL, but immediately skip to a the server's max frame number. Later we should also cache the server max frame number on client side to make the first push start from the right frame.