### PR TITLE
libsql: add wal frame_count and get_frame safe fn

### DIFF
--- a/libsql/src/local/connection.rs
+++ b/libsql/src/local/connection.rs
@@ -445,6 +445,43 @@ impl Connection {
             }
         }
     }
+
+    pub(crate) fn wal_frame_count(&self) -> u32 {
+        let mut max_frame_no: std::os::raw::c_uint = 0;
+        unsafe { libsql_sys::ffi::libsql_wal_frame_count(self.handle(), &mut max_frame_no) };
+
+        max_frame_no
+    }
+
+    pub(crate) fn wal_get_frame(&self, frame_no: u32, page_size: u32) -> Result<bytes::BytesMut> {
+        use bytes::BufMut;
+
+        let frame_size: usize = 24 + page_size as usize;
+
+        // Use a BytesMut to provide cheaper clones of frame data (think retries)
+        // and more efficient buffer usage for extracting wal frames and spliting them off.
+        let mut buf = bytes::BytesMut::with_capacity(frame_size);
+
+        let rc = unsafe {
+            libsql_sys::ffi::libsql_wal_get_frame(
+                self.handle(),
+                frame_no,
+                buf.chunk_mut().as_mut_ptr() as *mut _,
+                frame_size as u32,
+            )
+        };
+
+        if rc != 0 {
+            return Err(crate::errors::Error::SqliteFailure(
+                rc as std::ffi::c_int,
+                format!("Failed to get frame: {}", frame_no),
+            ));
+        }
+
+        unsafe { buf.advance_mut(frame_size) };
+
+        Ok(buf)
+    }
 }
 
 impl fmt::Debug for Connection {


### PR DESCRIPTION
This just moves unsafe wal code from safe database code to their own self contained safe fn. This clears up the safe and unsafe boundary instead of mixing and matching like before. This also creates a clear point of audit of our unsafe usage.