### PR TITLE
libsql: refactor push and sync code

### DIFF
--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -401,7 +401,7 @@ impl Database {
         let max_frame_no = conn.wal_frame_count();
 
         let generation = 1; // TODO: Probe from WAL.
-        let start_frame_no = sync_ctx.durable_frame_num + 1;
+        let start_frame_no = sync_ctx.durable_frame_num() + 1;
         let end_frame_no = max_frame_no;
 
         let mut frame_no = start_frame_no;

--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -2,10 +2,10 @@ use crate::Result;
 
 const DEFAULT_MAX_RETRIES: usize = 5;
 pub struct SyncContext {
-    pub sync_url: String,
-    pub auth_token: Option<String>,
-    pub max_retries: usize,
-    pub durable_frame_num: u32,
+    sync_url: String,
+    auth_token: Option<String>,
+    max_retries: usize,
+    durable_frame_num: u32,
 }
 
 impl SyncContext {
@@ -91,5 +91,9 @@ impl SyncContext {
             tokio::time::sleep(delay).await;
             nr_retries += 1;
         }
+    }
+
+    pub(crate) fn durable_frame_num(&self) -> u32 {
+        self.durable_frame_num
     }
 }

--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -1,3 +1,5 @@
+use crate::Result;
+
 const DEFAULT_MAX_RETRIES: usize = 5;
 pub struct SyncContext {
     pub sync_url: String,
@@ -13,6 +15,61 @@ impl SyncContext {
             auth_token,
             durable_frame_num: 0,
             max_retries: DEFAULT_MAX_RETRIES,
+        }
+    }
+
+    pub(crate) async fn push_with_retry(
+        &self,
+        uri: String,
+        auth_token: &Option<String>,
+        frame: Vec<u8>,
+        max_retries: usize,
+    ) -> Result<u32> {
+        let mut nr_retries = 0;
+        loop {
+            // TODO(lucio): add custom connector + tls support here
+            let client = hyper::client::Client::builder().build_http::<hyper::Body>();
+
+            let mut req = http::Request::post(uri.clone());
+
+            match auth_token {
+                Some(ref auth_token) => {
+                    let auth_header =
+                        http::HeaderValue::try_from(format!("Bearer {}", auth_token.to_owned()))
+                            .unwrap();
+
+                    req.headers_mut()
+                        .expect("valid http request")
+                        .insert("Authorization", auth_header);
+                }
+                None => {}
+            }
+
+            // TODO(lucio): convert this to use bytes to make this clone cheap, it should be
+            // to possible use BytesMut when reading frames from the WAL and efficiently use Bytes
+            // from that.
+            let req = req.body(frame.clone().into()).expect("valid body");
+
+            let res = client.request(req).await.unwrap();
+
+            // TODO(lucio): only retry on server side errors
+            if res.status().is_success() {
+                let res_body = hyper::body::to_bytes(res.into_body()).await.unwrap();
+                let resp = serde_json::from_slice::<serde_json::Value>(&res_body[..]).unwrap();
+
+                let max_frame_no = resp.get("max_frame_no").unwrap().as_u64().unwrap();
+                return Ok(max_frame_no as u32);
+            }
+
+            if nr_retries > max_retries {
+                return Err(crate::errors::Error::ConnectionFailed(format!(
+                    "Failed to push frame: {}",
+                    res.status()
+                )));
+            }
+            let delay = std::time::Duration::from_millis(100 * (1 << nr_retries));
+            tokio::time::sleep(delay).await;
+            nr_retries += 1;
         }
     }
 }

--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -18,7 +18,27 @@ impl SyncContext {
         }
     }
 
-    pub(crate) async fn push_with_retry(
+    pub(crate) async fn push_one_frame(
+        &self,
+        frame: Vec<u8>,
+        generation: u32,
+        frame_no: u32,
+    ) -> Result<u32> {
+        let uri = format!(
+            "{}/sync/{}/{}/{}",
+            self.sync_url,
+            generation,
+            frame_no,
+            frame_no + 1
+        );
+        let max_frame_no = self
+            .push_with_retry(uri, &self.auth_token, frame.to_vec(), self.max_retries)
+            .await?;
+
+        Ok(max_frame_no)
+    }
+
+    async fn push_with_retry(
         &self,
         uri: String,
         auth_token: &Option<String>,


### PR DESCRIPTION
This PR has multiple commits each broken up into their own refactor piece. Broken down is the list of refactors and why:

- Move sync ctx behind a mutex, this in general makes sense since we only want one push to be active at a time but also will enable the future durable_frame_no caching by allow us to mutate the struct on push. It is an async lock since we want to sync access to push over long async periods.
- move push_with_retry into sync.rs
- move push_one_frame into sync.rs these both make sense since the data they depend on is inside the sync_ctx struct so this allows us to make those fields private.
- Following up on those two, the next commit makes those fields private to improve code encapsulation.
- Small refactor now to use the auth_token field from the struct.

This PR just moves some code around but doesn't actually touch any of the logic in the code.