### PR TITLE
libsql: use hyper for offline writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.70",
  "which",
@@ -885,7 +885,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.70",
  "which",
@@ -2661,7 +2661,6 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "want",
 ]
 
 [[package]]
@@ -2714,24 +2713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
-dependencies = [
- "futures-util",
- "http 1.1.0",
- "hyper 1.4.1",
- "hyper-util",
- "rustls 0.23.11",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.26.0",
- "tower-service",
- "webpki-roots 0.26.3",
-]
-
-[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,25 +2735,6 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tungstenite",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
- "hyper 1.4.1",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3135,7 +3097,6 @@ dependencies = [
  "parking_lot",
  "pprof",
  "rand",
- "reqwest 0.12.9",
  "serde",
  "serde_json",
  "tempfile",
@@ -3165,7 +3126,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "num-traits",
- "reqwest 0.11.27",
+ "reqwest",
  "serde_json",
  "url",
 ]
@@ -3285,7 +3246,7 @@ dependencies = [
  "prost-build",
  "rand",
  "regex",
- "reqwest 0.11.27",
+ "reqwest",
  "rheaper",
  "ring",
  "rustls 0.21.12",
@@ -4432,54 +4393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash 2.0.0",
- "rustls 0.23.11",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
-dependencies = [
- "bytes",
- "rand",
- "ring",
- "rustc-hash 2.0.0",
- "rustls 0.23.11",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
-dependencies = [
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4637,7 +4550,7 @@ checksum = "d4a52e724646c6c0800fc456ec43b4165d2f91fba88ceaca06d9e0b400023478"
 dependencies = [
  "hashbrown 0.13.2",
  "log",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "slice-group-by",
  "smallvec",
 ]
@@ -4734,48 +4647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http 1.1.0",
- "http-body 1.0.0",
- "http-body-util",
- "hyper 1.4.1",
- "hyper-rustls 0.27.3",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls 0.23.11",
- "rustls-pemfile 2.1.2",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 1.0.1",
- "tokio",
- "tokio-rustls 0.26.0",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.26.3",
- "windows-registry",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4850,12 +4721,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-hash"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4912,20 +4777,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.5",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
-dependencies = [
- "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.5",
@@ -5680,9 +5531,6 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "system-configuration"
@@ -5927,17 +5775,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
-dependencies = [
- "rustls 0.23.11",
  "rustls-pki-types",
  "tokio",
 ]
@@ -7053,36 +6890,6 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result",
  "windows-targets 0.52.6",
 ]
 

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -42,7 +42,6 @@ fallible-iterator = { version = "0.3", optional = true }
 
 libsql_replication = { version = "0.6", path = "../libsql-replication", optional = true }
 async-stream = { version = "0.3.5", optional = true }
-reqwest = { version = "0.12.9", default-features = false, features = [ "rustls-tls", "json" ], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports", "async", "async_futures", "async_tokio"] }
@@ -105,7 +104,6 @@ sync = [
   "dep:bytes",
   "dep:tokio",
   "dep:futures",
-  "dep:reqwest",
   "dep:serde_json",
 ]
 hrana = [

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -663,7 +663,8 @@ impl Database {
 
 #[cfg(any(
     all(feature = "tls", feature = "replication"),
-    all(feature = "tls", feature = "remote")
+    all(feature = "tls", feature = "remote"),
+    all(feature = "tls", feature = "sync")
 ))]
 fn connector() -> Result<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>> {
     let mut http = hyper::client::HttpConnector::new();
@@ -680,7 +681,8 @@ fn connector() -> Result<hyper_rustls::HttpsConnector<hyper::client::HttpConnect
 
 #[cfg(any(
     all(not(feature = "tls"), feature = "replication"),
-    all(not(feature = "tls"), feature = "remote")
+    all(not(feature = "tls"), feature = "remote"),
+    all(not(feature = "tls"), feature = "sync")
 ))]
 fn connector() -> Result<hyper::client::HttpConnector> {
     panic!("The `tls` feature is disabled, you must provide your own http connector");

--- a/libsql/src/database/builder.rs
+++ b/libsql/src/database/builder.rs
@@ -424,7 +424,17 @@ cfg_sync! {
 
             let path = path.to_str().ok_or(crate::Error::InvalidUTF8Path)?.to_owned();
 
+            let https = super::connector()?;
+            use tower::ServiceExt;
+
+            let svc = https
+                .map_err(|e| e.into())
+                .map_response(|s| Box::new(s) as Box<dyn crate::util::Socket>);
+
+            let connector = crate::util::ConnectorService::new(svc);
+
             let db = crate::local::Database::open_local_with_offline_writes(
+                connector,
                 path,
                 flags,
                 url,

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -412,7 +412,7 @@ impl Database {
             // frames the server already knows about, we need to update the
             // frame number to the one returned by the server.
             let max_frame_no = sync_ctx
-                .push_one_frame(frame.to_vec(), generation, frame_no)
+                .push_one_frame(frame.freeze(), generation, frame_no)
                 .await?;
 
             if max_frame_no > frame_no {

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -131,6 +131,7 @@ impl Database {
     #[cfg(feature = "sync")]
     #[doc(hidden)]
     pub async fn open_local_with_offline_writes(
+        connector: crate::util::ConnectorService,
         db_path: impl Into<String>,
         flags: OpenFlags,
         endpoint: String,
@@ -144,6 +145,7 @@ impl Database {
         };
         let mut db = Database::open(&db_path, flags)?;
         db.sync_ctx = Some(tokio::sync::Mutex::new(SyncContext::new(
+            connector,
             endpoint,
             Some(auth_token),
         )));

--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -1,6 +1,6 @@
-use crate::Result;
+use crate::{util::ConnectorService, Result};
 use bytes::Bytes;
-use hyper::{client::HttpConnector, Body};
+use hyper::Body;
 
 const DEFAULT_MAX_RETRIES: usize = 5;
 
@@ -9,13 +9,13 @@ pub struct SyncContext {
     auth_token: Option<String>,
     max_retries: usize,
     durable_frame_num: u32,
-    client: hyper::Client<HttpConnector, Body>,
+    client: hyper::Client<ConnectorService, Body>,
 }
 
 impl SyncContext {
-    pub fn new(sync_url: String, auth_token: Option<String>) -> Self {
+    pub fn new(connector: ConnectorService, sync_url: String, auth_token: Option<String>) -> Self {
         // TODO(lucio): add custom connector + tls support here
-        let client = hyper::client::Client::builder().build_http::<hyper::Body>();
+        let client = hyper::client::Client::builder().build::<_, hyper::Body>(connector);
 
         Self {
             sync_url,


### PR DESCRIPTION
This PR adds 3 new commits related to integrating hyper into offline writes. This also includes tls support. 

Tested this against a platform server:

```
❯ cargo run --example offline_writes
   Compiling libsql v0.6.0 (/home/lucio/code/libsql/libsql)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12.21s
     Running `target/debug/examples/offline_writes`
Please write your entry to the guestbook:
hello
You entered: hello

Guest book entries:
  cargo run --example offline_writeshello

  hello

  hello

  hello

Syncing database to remote...
Done!
```