### PR TITLE
Make it possible to use offline writes in C bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5433,6 +5433,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "cbindgen",
+ "http 1.1.0",
  "hyper-rustls 0.25.0",
  "lazy_static",
  "libsql",

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { version = "1.29.1", features = [ "rt-multi-thread" ] }
 hyper-rustls = { version = "0.25", features = ["webpki-roots"]}
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
+http = "1.1.0"
 
 [target.'cfg(not(any(target_os = "ios", target_os = "android")))'.dependencies]
 libsql = { path = "../../libsql", features = ["encryption"] }


### PR DESCRIPTION
This is to make it possible to test offline writes in opsqlite.
To make the integration easy we don't create a new factory function but modify `libsql_open_sync_with_config` to create offline writes database if primary url contains `offline` query parameter.