### PR TITLE
sqld: reject `ATTACH` statements

### DIFF
--- a/libsql-server/src/error.rs
+++ b/libsql-server/src/error.rs
@@ -297,6 +297,8 @@ pub enum LoadDumpError {
     NoCommit,
     #[error("Path is not a file")]
     NotAFile,
+    #[error("The passed dump sql is invalid: {0}")]
+    InvalidSqlInput(String),
 }
 
 impl ResponseError for LoadDumpError {}
@@ -315,7 +317,8 @@ impl IntoResponse for &LoadDumpError {
             | NoTxn
             | NoCommit
             | NotAFile
-            | DumpFilePathNotAbsolute => self.format_err(StatusCode::BAD_REQUEST),
+            | DumpFilePathNotAbsolute
+            | InvalidSqlInput(_) => self.format_err(StatusCode::BAD_REQUEST),
         }
     }
 }

--- a/libsql-server/tests/namespaces/dumps.rs
+++ b/libsql-server/tests/namespaces/dumps.rs
@@ -352,3 +352,76 @@ fn load_dump_with_attach_rejected() {
 
     sim.run().unwrap();
 }
+
+#[test]
+fn load_dump_with_invalid_sql() {
+    const DUMP: &str = r#"
+        PRAGMA foreign_keys=OFF;
+    BEGIN TRANSACTION;
+    CREATE TABLE test (x);
+    INSERT INTO test VALUES(42);
+    SELECT abs(-9223372036854775808) 
+    COMMIT;"#;
+
+    let mut sim = Builder::new()
+        .simulation_duration(Duration::from_secs(1000))
+        .build();
+    let tmp = tempdir().unwrap();
+    let tmp_path = tmp.path().to_path_buf();
+
+    std::fs::write(tmp_path.join("dump.sql"), DUMP).unwrap();
+
+    make_primary(&mut sim, tmp.path().to_path_buf());
+
+    sim.client("client", async move {
+        let client = Client::new();
+
+        // path is not absolute is an error
+        let resp = client
+            .post(
+                "http://primary:9090/v1/namespaces/foo/create",
+                json!({ "dump_url": "file:dump.sql"}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // path doesn't exist is an error
+        let resp = client
+            .post(
+                "http://primary:9090/v1/namespaces/foo/create",
+                json!({ "dump_url": "file:/dump.sql"}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let resp = client
+            .post(
+                "http://primary:9090/v1/namespaces/foo/create",
+                json!({ "dump_url": format!("file:{}", tmp_path.join("dump.sql").display())}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "{}",
+            resp.json::<serde_json::Value>().await.unwrap_or_default()
+        );
+
+        assert_snapshot!(resp.body_string().await?);
+
+        let foo =
+            Database::open_remote_with_connector("http://foo.primary:8080", "", TurmoilConnector)?;
+        let foo_conn = foo.connect()?;
+
+        let res = foo_conn.query("select count(*) from test", ()).await;
+        // This should error since the dump should have failed!
+        assert!(res.is_err());
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}

--- a/libsql-server/tests/namespaces/dumps.rs
+++ b/libsql-server/tests/namespaces/dumps.rs
@@ -279,3 +279,76 @@ fn export_dump() {
 
     sim.run().unwrap();
 }
+
+#[test]
+fn load_dump_with_attach_rejected() {
+    const DUMP: &str = r#"
+        PRAGMA foreign_keys=OFF;
+    BEGIN TRANSACTION;
+    CREATE TABLE test (x);
+    INSERT INTO test VALUES(42);
+    ATTACH foo/bar.sql
+    COMMIT;"#;
+
+    let mut sim = Builder::new()
+        .simulation_duration(Duration::from_secs(1000))
+        .build();
+    let tmp = tempdir().unwrap();
+    let tmp_path = tmp.path().to_path_buf();
+
+    std::fs::write(tmp_path.join("dump.sql"), DUMP).unwrap();
+
+    make_primary(&mut sim, tmp.path().to_path_buf());
+
+    sim.client("client", async move {
+        let client = Client::new();
+
+        // path is not absolute is an error
+        let resp = client
+            .post(
+                "http://primary:9090/v1/namespaces/foo/create",
+                json!({ "dump_url": "file:dump.sql"}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // path doesn't exist is an error
+        let resp = client
+            .post(
+                "http://primary:9090/v1/namespaces/foo/create",
+                json!({ "dump_url": "file:/dump.sql"}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let resp = client
+            .post(
+                "http://primary:9090/v1/namespaces/foo/create",
+                json!({ "dump_url": format!("file:{}", tmp_path.join("dump.sql").display())}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "{}",
+            resp.json::<serde_json::Value>().await.unwrap_or_default()
+        );
+
+        assert_snapshot!(resp.body_string().await?);
+
+        let foo =
+            Database::open_remote_with_connector("http://foo.primary:8080", "", TurmoilConnector)?;
+        let foo_conn = foo.connect()?;
+
+        let res = foo_conn.query("select count(*) from test", ()).await;
+        // This should error since the dump should have failed!
+        assert!(res.is_err());
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__dumps__load_dump_with_attach_rejected.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__dumps__load_dump_with_attach_rejected.snap
@@ -1,0 +1,6 @@
+---
+source: libsql-server/tests/namespaces/dumps.rs
+expression: resp.body_string().await?
+snapshot_kind: text
+---
+{"error":"The passed dump sql is invalid: attach statements are not allowed in dumps, msg: near \"COMMIT\": syntax error, sql:     ATTACH foo/bar.sql\n     COMMIT;, offset: 28"}

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__dumps__load_dump_with_invalid_sql.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__dumps__load_dump_with_invalid_sql.snap
@@ -1,0 +1,6 @@
+---
+source: libsql-server/tests/namespaces/dumps.rs
+expression: resp.body_string().await?
+snapshot_kind: text
+---
+{"error":"The passed dump sql is invalid: msg: near \"COMMIT\": syntax error, sql:     SELECT abs(-9223372036854775808) \n     COMMIT;, offset: 43"}


### PR DESCRIPTION
This adds support for rejecting `ATTACH` statements from dumps. `ATTACH` statements should be considered dangerous in a multi-tenant setting. With this commit any `ATTACH` statement inside a dump will be rejected with a 400 status code and a message. In addition, any other sql errors returned by sqlite will be returned as a 400. All other dump errors through this code path (conn.with_raw) will return a 500 like before.