### PR TITLE
Fix: strcpy on possible NULL value

### DIFF
--- a/libsql-ffi/bundled/SQLite3MultipleCiphers/src/extensionfunctions.c
+++ b/libsql-ffi/bundled/SQLite3MultipleCiphers/src/extensionfunctions.c
@@ -219,7 +219,7 @@ int double_cmp(const void *a, const void *b);
 
 static char *sqlite3StrDup( const char *z ) {
     char *res = sqlite3_malloc( (int) (strlen(z)+1) );
-    return strcpy( res, z );
+    return res ? strcpy( res, z ) : NULL;
 }
 
 /*


### PR DESCRIPTION
I may be wrong but using `strcpy` on a `NULL` value might cause Undefined Behaviour and could potentially be an attack vector