### PR TITLE
sqliteInt.h: fix pointer size for ppc64

### DIFF
--- a/libsql-sqlite3/src/sqliteInt.h
+++ b/libsql-sqlite3/src/sqliteInt.h
@@ -894,7 +894,7 @@ typedef INT16_TYPE LogEst;
 #   define SQLITE_PTRSIZE __SIZEOF_POINTER__
 # elif defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
        defined(_M_ARM)   || defined(__arm__)    || defined(__x86)   ||    \
-      (defined(__APPLE__) && defined(__POWERPC__)) ||                     \
+      (defined(__APPLE__) && defined(__ppc__))  ||                        \
       (defined(__TOS_AIX__) && !defined(__64BIT__))
 #   define SQLITE_PTRSIZE 4
 # else


### PR DESCRIPTION
`__POWERPC__` is defined both for 32- and 64-bit PowerPC on Darwin. Pointer size should be 4-byte only on 32-bit `ppc`.