### PR TITLE
libsql: improve hrana api error message

### DIFF
--- a/libsql-server/tests/cluster/snapshots/tests__cluster__create_namespace.snap
+++ b/libsql-server/tests/cluster/snapshots/tests__cluster__create_namespace.snap
@@ -1,5 +1,6 @@
 ---
-source: sqld/tests/cluster/mod.rs
+source: libsql-server/tests/cluster/mod.rs
 expression: e.to_string()
+snapshot_kind: text
 ---
-Hrana: `api error: `{"error":"Namespace `foo` doesn't exist"}``
+Hrana: `api error: `status=404 Not Found, body={"error":"Namespace `foo` doesn't exist"}``

--- a/libsql-server/tests/cluster/snapshots/tests__cluster__replication__replica_lazy_creation.snap
+++ b/libsql-server/tests/cluster/snapshots/tests__cluster__replication__replica_lazy_creation.snap
@@ -1,9 +1,10 @@
 ---
 source: libsql-server/tests/cluster/replication.rs
 expression: "conn.execute(\"create table test (x)\", ()).await.unwrap_err()"
+snapshot_kind: text
 ---
 Hrana(
     Api(
-        "{\"error\":\"Replicator error: Requested namespace doesn't exist\"}",
+        "status=404 Not Found, body={\"error\":\"Replicator error: Requested namespace doesn't exist\"}",
     ),
 )

--- a/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_restart_query_execute_invalid_baton.snap
+++ b/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_restart_query_execute_invalid_baton.snap
@@ -1,0 +1,6 @@
+---
+source: libsql-server/tests/hrana/batch.rs
+expression: err
+snapshot_kind: text
+---
+Hrana: `api error: `status=400 Bad Request, body=Received an invalid baton``

--- a/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_restart_timeout.snap
+++ b/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_restart_timeout.snap
@@ -1,0 +1,6 @@
+---
+source: libsql-server/tests/hrana/batch.rs
+expression: err
+snapshot_kind: text
+---
+Hrana: `api error: `status=400 Bad Request, body={"message":"The stream has expired due to inactivity","code":"STREAM_EXPIRED"}``

--- a/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_restart_txn_execute_execute_invalid_baton.snap
+++ b/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_restart_txn_execute_execute_invalid_baton.snap
@@ -1,0 +1,6 @@
+---
+source: libsql-server/tests/hrana/batch.rs
+expression: err
+snapshot_kind: text
+---
+Hrana: `api error: `status=400 Bad Request, body=Received an invalid baton``

--- a/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_restart_txn_execute_query_invalid_baton.snap
+++ b/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_restart_txn_execute_query_invalid_baton.snap
@@ -1,0 +1,6 @@
+---
+source: libsql-server/tests/hrana/batch.rs
+expression: err
+snapshot_kind: text
+---
+Hrana: `api error: `status=400 Bad Request, body=Received an invalid baton``

--- a/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_restart_txn_query_execute_invalid_baton.snap
+++ b/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_restart_txn_query_execute_invalid_baton.snap
@@ -1,0 +1,6 @@
+---
+source: libsql-server/tests/hrana/batch.rs
+expression: err
+snapshot_kind: text
+---
+Hrana: `api error: `status=400 Bad Request, body=Received an invalid baton``

--- a/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_timeout.snap
+++ b/libsql-server/tests/hrana/snapshots/tests__hrana__batch__server_timeout.snap
@@ -1,0 +1,6 @@
+---
+source: libsql-server/tests/hrana/batch.rs
+expression: err
+snapshot_kind: text
+---
+Hrana: `api error: `status=400 Bad Request, body={"message":"The stream has expired due to inactivity","code":"STREAM_EXPIRED"}``

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__check_migration_perms.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__check_migration_perms.snap
@@ -1,9 +1,10 @@
 ---
 source: libsql-server/tests/namespaces/shared_schema.rs
 expression: "conn.execute(\"create table test (x)\", ()).await.unwrap_err()"
+snapshot_kind: text
 ---
 Hrana(
     Api(
-        "{\"error\":\"Authorization forbidden: Current session doesn't not have Write permission to namespace schema\"}",
+        "status=403 Forbidden, body={\"error\":\"Authorization forbidden: Current session doesn't not have Write permission to namespace schema\"}",
     ),
 )

--- a/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__disable_ddl.snap
+++ b/libsql-server/tests/namespaces/snapshots/tests__namespaces__shared_schema__disable_ddl.snap
@@ -1,9 +1,10 @@
 ---
 source: libsql-server/tests/namespaces/shared_schema.rs
 expression: "conn.execute(\"create table test (x)\", ()).await.unwrap_err()"
+snapshot_kind: text
 ---
 Hrana(
     Api(
-        "{\"error\":\"Authorization forbidden: DDL statements not permitted on namespace ns1\"}",
+        "status=403 Forbidden, body={\"error\":\"Authorization forbidden: DDL statements not permitted on namespace ns1\"}",
     ),
 )

--- a/libsql-server/tests/standalone/snapshots/tests__standalone__attach__attach_auth-2.snap
+++ b/libsql-server/tests/standalone/snapshots/tests__standalone__attach__attach_auth-2.snap
@@ -1,9 +1,10 @@
 ---
 source: libsql-server/tests/standalone/attach.rs
 expression: "txn.execute(\"ATTACH DATABASE bar as bar\", ()).await.unwrap_err()"
+snapshot_kind: text
 ---
 Hrana(
     Api(
-        "{\"error\":\"Authorization forbidden: Current session doesn't not have AttachRead permission to namespace bar\"}",
+        "status=403 Forbidden, body={\"error\":\"Authorization forbidden: Current session doesn't not have AttachRead permission to namespace bar\"}",
     ),
 )

--- a/libsql-server/tests/standalone/snapshots/tests__standalone__attach__attach_auth-3.snap
+++ b/libsql-server/tests/standalone/snapshots/tests__standalone__attach__attach_auth-3.snap
@@ -1,9 +1,10 @@
 ---
 source: libsql-server/tests/standalone/attach.rs
 expression: "bar_conn.execute(\"ATTACH foo as foo\", ()).await.unwrap_err()"
+snapshot_kind: text
 ---
 Hrana(
     Api(
-        "{\"error\":\"Authorization forbidden: Namespace `foo` doesn't allow attach\"}",
+        "status=403 Forbidden, body={\"error\":\"Authorization forbidden: Namespace `foo` doesn't allow attach\"}",
     ),
 )

--- a/libsql-server/tests/standalone/snapshots/tests__standalone__attach__attach_auth.snap
+++ b/libsql-server/tests/standalone/snapshots/tests__standalone__attach__attach_auth.snap
@@ -1,9 +1,10 @@
 ---
 source: libsql-server/tests/standalone/attach.rs
 expression: "bar_conn.execute(\"ATTACH foo as foo\", ()).await.unwrap_err()"
+snapshot_kind: text
 ---
 Hrana(
     Api(
-        "{\"error\":\"Authorization forbidden: Current session doesn't not have AttachRead permission to namespace foo\"}",
+        "status=403 Forbidden, body={\"error\":\"Authorization forbidden: Current session doesn't not have AttachRead permission to namespace foo\"}",
     ),
 )

--- a/libsql-server/tests/standalone/snapshots/tests__standalone__attach__attach_no_auth.snap
+++ b/libsql-server/tests/standalone/snapshots/tests__standalone__attach__attach_no_auth.snap
@@ -1,9 +1,10 @@
 ---
 source: libsql-server/tests/standalone/attach.rs
 expression: "bar_conn.execute(\"ATTACH foo as foo\", ()).await.unwrap_err()"
+snapshot_kind: text
 ---
 Hrana(
     Api(
-        "{\"error\":\"Authorization forbidden: Namespace `foo` doesn't allow attach\"}",
+        "status=403 Forbidden, body={\"error\":\"Authorization forbidden: Namespace `foo` doesn't allow attach\"}",
     ),
 )

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -52,12 +52,13 @@ impl HttpSender {
 
         let resp = self.inner.request(req).await.map_err(HranaError::from)?;
 
-        if resp.status() != StatusCode::OK {
+        let status = resp.status();
+        if status != StatusCode::OK {
             let body = hyper::body::to_bytes(resp.into_body())
                 .await
                 .map_err(HranaError::from)?;
             let body = String::from_utf8(body.into()).unwrap();
-            return Err(HranaError::Api(body));
+            return Err(HranaError::Api(format!("status={}, body={}", status, body)));
         }
 
         let body: super::HttpBody<ByteStream> = if resp.is_end_stream() {

--- a/libsql/src/rows.rs
+++ b/libsql/src/rows.rs
@@ -89,6 +89,12 @@ impl Rows {
     }
 }
 
+impl fmt::Debug for Rows {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Rows").finish()
+    }
+}
+
 /// A libsql row.
 pub struct Row {
     pub(crate) inner: Box<dyn RowInner + Send + Sync>,


### PR DESCRIPTION
This improves the `Hrana(Api("..."))` message to include the status code of the response rather than just the body as a string. This also adds a bunch of tests related to this api and updated snapshots for the new error message.