### PR TITLE
libsql: Fix build on older Rust toolchains

### DIFF
--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -309,7 +309,7 @@ impl SyncContext {
     async fn read_metadata(&mut self) -> Result<()> {
         let path = format!("{}-info", self.db_path);
 
-        if !std::fs::exists(&path).map_err(SyncError::io("metadata file exists"))? {
+        if !Path::new(&path).try_exists().map_err(SyncError::io("metadata file exists"))? {
             tracing::debug!("no metadata info file found");
             return Ok(());
         }


### PR DESCRIPTION
The JavaScript SDK is unfortunately stuck with Rust 1.78:

https://github.com/tursodatabase/libsql-js/issues/104

We should fix that, but since that's hard, let's just once again paper over it by fixing build on older Rust toolchains.