### PR TITLE
libsql: error on invalid frame_no on wal read

### DIFF
--- a/libsql/src/local/connection.rs
+++ b/libsql/src/local/connection.rs
@@ -462,6 +462,13 @@ impl Connection {
         // and more efficient buffer usage for extracting wal frames and spliting them off.
         let mut buf = bytes::BytesMut::with_capacity(frame_size);
 
+        if frame_no == 0 {
+            return Err(errors::Error::SqliteFailure(
+                1,
+                "frame_no must be non-zero".to_string(),
+            ));
+        }
+
         let rc = unsafe {
             libsql_sys::ffi::libsql_wal_get_frame(
                 self.handle(),


### PR DESCRIPTION
This prevents a potential panic that can happen in our ffi code when it expects a NonZero value but the input type into the unsafe function is a u32, meaning the compiler will not enforce the value and will result in a panic. This changes it so that when the code is called via the sys crate safe code it will return a sqlite failure.

Closes #1868