### PR TITLE
libsql: Fix WAL pull logic on last frame

### DIFF
--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -476,9 +476,12 @@ impl Database {
 
         loop {
             match sync_ctx.pull_one_frame(generation, frame_no).await {
-                Ok(frame) => {
+                Ok(Some(frame)) => {
                     conn.wal_insert_frame(&frame)?;
                     frame_no += 1;
+                }
+                Ok(None) => {
+                    break;
                 }
                 Err(e) => {
                     tracing::debug!("pull_one_frame error: {:?}", e);


### PR DESCRIPTION
The WAL sync protocol only allows you to fetch frames for a range. While the protocol does not have mechanism to determine what is the latest frame on the server for pull, it does signal with HTTP status code 400 when you attempt to read a frame that does not exists.

Let's use this signal to fix WAL pull logic not to fail always. In the future, we might want to consider extending the protocol to allow clients to proble for latest frame. That, however, will make the protocol a bit more chatty, so I am trying to avoid that as long as I can.