### PR TITLE
periodic checkpoint: Don't checkpoint at startup

### DIFF
--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -368,6 +368,8 @@ where
     tracing::info!("setting checkpoint interval to {:?}", period);
     let mut interval = interval(period);
     interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    // Make sure that we don't checkpoint immediately after startup
+    interval.tick().await;
     let mut retry: Option<Duration> = None;
     loop {
         if let Some(retry) = retry.take() {


### PR DESCRIPTION
Currently there's no way to disable checkpoint but one can emulate it by enabling periodic checkpoint with really long interval between checkpoints.

Unfortunately, current implementation runs checkpoint first before waiting for the interval to pass.

This change makes the periodic checkpoint to first wait and only after that checkpoint.