### PR TITLE
libsql: Add support for Connection::interrupt()

### DIFF
--- a/libsql/src/connection.rs
+++ b/libsql/src/connection.rs
@@ -21,6 +21,8 @@ pub(crate) trait Conn {
 
     async fn transaction(&self, tx_behavior: TransactionBehavior) -> Result<Transaction>;
 
+    fn interrupt(&self) -> Result<()>;
+
     fn is_autocommit(&self) -> bool;
 
     fn changes(&self) -> u64;
@@ -183,6 +185,11 @@ impl Connection {
     ) -> Result<Transaction> {
         tracing::trace!("starting {:?} transaction", tx_behavior);
         self.conn.transaction(tx_behavior).await
+    }
+
+    /// Cancel ongoing operations and return at earliest opportunity.
+    pub fn interrupt(&self) -> Result<()> {
+        self.conn.interrupt()
     }
 
     /// Check weather libsql is in `autocommit` or not.

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -163,6 +163,11 @@ impl Conn for HttpConnection<HttpSender> {
         })
     }
 
+    fn interrupt(&self) -> crate::Result<()> {
+        // Interrupt is a no-op for remote connections.
+        Ok(())
+    }
+
     fn is_autocommit(&self) -> bool {
         self.is_autocommit()
     }
@@ -341,6 +346,11 @@ impl Conn for HranaStream<HttpSender> {
         _tx_behavior: crate::TransactionBehavior,
     ) -> crate::Result<crate::transaction::Transaction> {
         todo!("sounds like nested transactions innit?")
+    }
+
+    fn interrupt(&self) -> crate::Result<()> {
+        // Interrupt is a no-op for remote connections.
+        Ok(())
     }
 
     fn is_autocommit(&self) -> bool {

--- a/libsql/src/local/connection.rs
+++ b/libsql/src/local/connection.rs
@@ -355,6 +355,11 @@ impl Connection {
         Transaction::begin(self.clone(), tx_behavior)
     }
 
+    pub fn interrupt(&self) -> Result<()> {
+        unsafe { ffi::sqlite3_interrupt(self.raw) };
+        Ok(())
+    }
+
     pub fn is_autocommit(&self) -> bool {
         unsafe { ffi::sqlite3_get_autocommit(self.raw) != 0 }
     }

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -54,6 +54,10 @@ impl Conn for LibsqlConnection {
         })
     }
 
+    fn interrupt(&self) -> Result<()> {
+        self.conn.interrupt()
+    }
+
     fn is_autocommit(&self) -> bool {
         self.conn.is_autocommit()
     }

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -503,6 +503,11 @@ impl Conn for RemoteConnection {
         })
     }
 
+    fn interrupt(&self) -> Result<()> {
+        // Interrupt is a no-op for remote connections.
+        Ok(())
+    }
+
     fn is_autocommit(&self) -> bool {
         self.is_state_init()
     }


### PR DESCRIPTION
Let's expose SQLite capability of interrupting long-running queries.