### PR TITLE
libsql-replication: Switch retry message to warn log level

### DIFF
--- a/libsql-replication/src/replicator.rs
+++ b/libsql-replication/src/replicator.rs
@@ -224,9 +224,9 @@ where
                 }
                 Err(Error::Client(e)) if !error_printed => {
                     if e.downcast_ref::<uuid::Error>().is_some() {
-                        tracing::error!("error connecting to primary. retrying. Verify that the libsql server version is `>=0.22` error: {e}");
+                        tracing::warn!("error connecting to primary. retrying. Verify that the libsql server version is `>=0.22` error: {e}");
                     } else {
-                        tracing::error!("error connecting to primary. retrying. error: {e}");
+                        tracing::warn!("error connecting to primary. retrying. error: {e}");
                     }
 
                     error_printed = true;


### PR DESCRIPTION
If we fail to contact the primary, we return an error message. Let's switch to warn log level to avoid scaring users.