### PR TITLE
libsql: add per-sync-url metadata

### DIFF
--- a/libsql/src/sync/test.rs
+++ b/libsql/src/sync/test.rs
@@ -113,8 +113,8 @@ async fn test_sync_context_corrupted_metadata() {
     assert_eq!(durable_frame, 0);
     assert_eq!(server.frame_count(), 1);
 
-    // Update metadata path to use -info instead of .meta
-    let metadata_path = format!("{}-info", db_path.to_str().unwrap());
+    // Inject invalid data into the metadata file to force a recovery
+    let metadata_path = sync_ctx.sync_metadata_filename().unwrap();
     std::fs::write(&metadata_path, b"invalid json data").unwrap();
 
     // Create new sync context with corrupted metadata


### PR DESCRIPTION
This commit changes the filename of the metadata file to contain `<db_path>-<sync_url>-info`. Where `db_path` is a full file path + filename and `sync_url` is the host of the authority of the URI. This also includes upfront uri parsing and two new errors that can be produced when trying to extract the host.

This approach trades off creating multiple files in exchange for allowing multiple sync context's to operate at the same time concurrently. Originally, I had approached updating the metadata to include a hashmap of endpoints and their metadata but this approach falls flat if you have multiple `Database` and thus `SyncContext` in the same process (and beyond).

This commit does NOT include updating from the original v0 metadata format but instead will force a full re-sync and a new meatadata file will be produced with verison set to `1`. Not implementing this mean't simpler code with less space to produce errors and since this only runs once when a user upgrades that cost is okay.

Closes #1837