### PR TITLE
Fix cross compilation and build for sandboxes enviroments.

### DIFF
--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -362,19 +362,28 @@ fn build_multiple_ciphers(target: &str, out_path: &Path) {
         .unwrap();
 
     if let Some(ref cc) = cross_cc {
-        if cc.contains("aarch64") && cc.contains("linux") {
-            cmake_opts.push(&cmake_toolchain_opt);
-            writeln!(toolchain_file, "set(CMAKE_SYSTEM_NAME \"Linux\")").unwrap();
-            writeln!(toolchain_file, "set(CMAKE_SYSTEM_PROCESSOR \"arm64\")").unwrap();
-        } else if cc.contains("x86_64") && cc.contains("darwin") {
-            cmake_opts.push(&cmake_toolchain_opt);
-            writeln!(toolchain_file, "set(CMAKE_SYSTEM_NAME \"Darwin\")").unwrap();
-            writeln!(toolchain_file, "set(CMAKE_SYSTEM_PROCESSOR \"x86_64\")").unwrap();
-        }
-    }
-    if let Some(cc) = cross_cc {
+        let system_name = if cc.contains("linux") {
+            "Linux"
+        } else if cc.contains("darwin") {
+            "Darwin"
+        } else {
+            panic!("Unsupported cross target {}", cc)
+        };
+
+        let system_processor = if cc.contains("x86_64") {
+            "x86_64"
+        } else if cc.contains("aarch64") {
+            "arm64"
+        } else {
+            panic!("Unsupported cross target {}", cc)
+        };
+
+        cmake_opts.push(&cmake_toolchain_opt);
+        writeln!(toolchain_file, "set(CMAKE_SYSTEM_NAME \"{}\")", system_name).unwrap();
+        writeln!(toolchain_file, "set(CMAKE_SYSTEM_PROCESSOR \"{}\")", system_processor).unwrap();
         writeln!(toolchain_file, "set(CMAKE_C_COMPILER {})", cc).unwrap();
     }
+
     if let Some(cxx) = cross_cxx {
         writeln!(toolchain_file, "set(CMAKE_CXX_COMPILER {})", cxx).unwrap();
     }

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -366,6 +366,8 @@ fn build_multiple_ciphers(target: &str, out_path: &Path) {
             "Linux"
         } else if cc.contains("darwin") {
             "Darwin"
+        } else if cc.contains("w64") {
+            "Windows"
         } else {
             panic!("Unsupported cross target {}", cc)
         };

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -62,28 +62,12 @@ fn copy_with_cp(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> 
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+/// This ensures that in sandboxed environments, such as Nix, permissions from other sources don't
+/// propagate into OUT_DIR. If not present, when trying to rewrite a file, a `Permission denied`
+/// error will occur.
 fn copy_with_cp(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     let status = Command::new("cp")
         .arg("--no-preserve=mode,ownership")
-        .arg("-R")
-        .arg(src.as_ref().to_str().unwrap())
-        .arg(dst.as_ref().to_str().unwrap())
-        .status()?;
-
-    if !status.success() {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "Failed to copy using cp",
-        ))
-    } else {
-        Ok(())
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn copy_with_cp(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-    let status = Command::new("cp")
         .arg("-R")
         .arg(src.as_ref().to_str().unwrap())
         .arg(dst.as_ref().to_str().unwrap())
@@ -143,7 +127,7 @@ pub fn build_bundled(out_dir: &str, out_path: &Path) {
     }
 
     let dir = env!("CARGO_MANIFEST_DIR");
-    std::fs::copy(format!("{dir}/{bindgen_rs_path}"), out_path).unwrap();
+    copy_with_cp(format!("{dir}/{bindgen_rs_path}"), out_path).unwrap();
 
     let mut cfg = cc::Build::new();
     cfg.file(format!("{BUNDLED_DIR}/src/sqlite3.c"))
@@ -382,7 +366,12 @@ fn build_multiple_ciphers(target: &str, out_path: &Path) {
 
         cmake_opts.push(&cmake_toolchain_opt);
         writeln!(toolchain_file, "set(CMAKE_SYSTEM_NAME \"{}\")", system_name).unwrap();
-        writeln!(toolchain_file, "set(CMAKE_SYSTEM_PROCESSOR \"{}\")", system_processor).unwrap();
+        writeln!(
+            toolchain_file,
+            "set(CMAKE_SYSTEM_PROCESSOR \"{}\")",
+            system_processor
+        )
+        .unwrap();
         writeln!(toolchain_file, "set(CMAKE_C_COMPILER {})", cc).unwrap();
     }
 

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -366,6 +366,10 @@ fn build_multiple_ciphers(target: &str, out_path: &Path) {
             cmake_opts.push(&cmake_toolchain_opt);
             writeln!(toolchain_file, "set(CMAKE_SYSTEM_NAME \"Linux\")").unwrap();
             writeln!(toolchain_file, "set(CMAKE_SYSTEM_PROCESSOR \"arm64\")").unwrap();
+        } else if cc.contains("x86_64") && cc.contains("darwin") {
+            cmake_opts.push(&cmake_toolchain_opt);
+            writeln!(toolchain_file, "set(CMAKE_SYSTEM_NAME \"Darwin\")").unwrap();
+            writeln!(toolchain_file, "set(CMAKE_SYSTEM_PROCESSOR \"x86_64\")").unwrap();
         }
     }
     if let Some(cc) = cross_cc {

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -102,12 +102,12 @@ fn make_amalgamation() {
         .output()
         .unwrap();
 
-    std::fs::copy(
+    copy_with_cp(
         (SQLITE_DIR.as_ref() as &Path).join("sqlite3.c"),
         (BUNDLED_DIR.as_ref() as &Path).join("src/sqlite3.c"),
     )
     .unwrap();
-    std::fs::copy(
+    copy_with_cp(
         (SQLITE_DIR.as_ref() as &Path).join("sqlite3.h"),
         (BUNDLED_DIR.as_ref() as &Path).join("src/sqlite3.h"),
     )
@@ -287,7 +287,7 @@ fn copy_multiple_ciphers(target: &str, out_dir: &str, out_path: &Path) {
         build_multiple_ciphers(target, out_path);
     }
 
-    std::fs::copy(dylib, format!("{out_dir}/libsqlite3mc.a")).unwrap();
+    copy_with_cp(dylib, format!("{out_dir}/libsqlite3mc.a")).unwrap();
     println!("cargo:rustc-link-lib=static=sqlite3mc");
     println!("cargo:rustc-link-search={out_dir}");
 }
@@ -303,9 +303,9 @@ fn build_multiple_ciphers(target: &str, out_path: &Path) {
         bindings::write_to_out_dir(header, bindgen_rs_path.as_ref());
     }
     let dir = env!("CARGO_MANIFEST_DIR");
-    std::fs::copy(format!("{dir}/{bindgen_rs_path}"), out_path).unwrap();
+    copy_with_cp(format!("{dir}/{bindgen_rs_path}"), out_path).unwrap();
 
-    std::fs::copy(
+    copy_with_cp(
         (BUNDLED_DIR.as_ref() as &Path)
             .join("src")
             .join("sqlite3.c"),

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -56,31 +56,41 @@ fn main() {
     build_bundled(&out_dir, &out_path);
 }
 
-#[cfg(target_os = "windows")]
-fn copy_with_cp(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-    fs::copy(src, dst)?; // do a regular file copy on Windows
+fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    let dst = dst.as_ref();
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            copy_dir_all(entry.path(), dst.join(entry.file_name()))?;
+        } else {
+            fs::copy(entry.path(), dst.join(entry.file_name()))?;
+        }
+    }
     Ok(())
 }
 
 /// This ensures that in sandboxed environments, such as Nix, permissions from other sources don't
 /// propagate into OUT_DIR. If not present, when trying to rewrite a file, a `Permission denied`
 /// error will occur.
-fn copy_with_cp(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+fn copy_with_cp(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
     let status = Command::new("cp")
         .arg("--no-preserve=mode,ownership")
         .arg("-R")
-        .arg(src.as_ref().to_str().unwrap())
-        .arg(dst.as_ref().to_str().unwrap())
+        .arg(from.as_ref().to_str().unwrap())
+        .arg(to.as_ref().to_str().unwrap())
         .status()?;
 
-    if !status.success() {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "Failed to copy using cp",
-        ))
-    } else {
-        Ok(())
+    if status.success() {
+        return Ok(());
     }
+
+    return match fs::copy(from.as_ref(), to.as_ref()) {
+        Err(err) if err.kind() == io::ErrorKind::InvalidInput => copy_dir_all(from, to),
+        Ok(_) => Ok(()),
+        Err(err) => Err(err),
+    };
 }
 
 fn make_amalgamation() {
@@ -97,6 +107,7 @@ fn make_amalgamation() {
         .env("CFLAGS", flags.join(" "))
         .output()
         .unwrap();
+
     Command::new("make")
         .current_dir(SQLITE_DIR)
         .output()
@@ -107,6 +118,7 @@ fn make_amalgamation() {
         (BUNDLED_DIR.as_ref() as &Path).join("src/sqlite3.c"),
     )
     .unwrap();
+
     copy_with_cp(
         (SQLITE_DIR.as_ref() as &Path).join("sqlite3.h"),
         (BUNDLED_DIR.as_ref() as &Path).join("src/sqlite3.h"),
@@ -298,32 +310,31 @@ fn build_multiple_ciphers(target: &str, out_path: &Path) {
     } else {
         "bundled/bindings/bindgen.rs"
     };
+
     if std::env::var("LIBSQL_DEV").is_ok() {
         let header = HeaderLocation::FromPath(format!("{BUNDLED_DIR}/src/sqlite3.h"));
         bindings::write_to_out_dir(header, bindgen_rs_path.as_ref());
     }
+
     let dir = env!("CARGO_MANIFEST_DIR");
     copy_with_cp(format!("{dir}/{bindgen_rs_path}"), out_path).unwrap();
 
+    let out_dir = env::var("OUT_DIR").unwrap();
+
     copy_with_cp(
-        (BUNDLED_DIR.as_ref() as &Path)
-            .join("src")
-            .join("sqlite3.c"),
-        (BUNDLED_DIR.as_ref() as &Path)
-            .join("SQLite3MultipleCiphers")
-            .join("src")
-            .join("sqlite3.c"),
+        dbg!(format!("{BUNDLED_DIR}/SQLite3MultipleCiphers")),
+        format!("{out_dir}/sqlite3mc"),
     )
     .unwrap();
 
-    let bundled_dir = env::current_dir()
-        .unwrap()
-        .join(BUNDLED_DIR)
-        .join("SQLite3MultipleCiphers");
-    let out_dir = env::var("OUT_DIR").unwrap();
+    copy_with_cp(
+        PathBuf::from(BUNDLED_DIR).join("src").join("sqlite3.c"),
+        format!("{out_dir}/sqlite3mc/src/sqlite3.c"),
+    )
+    .unwrap();
+
+    let bundled_dir = format!("{out_dir}/sqlite3mc");
     let sqlite3mc_build_dir = env::current_dir().unwrap().join(out_dir).join("sqlite3mc");
-    let _ = fs::remove_dir_all(sqlite3mc_build_dir.clone());
-    fs::create_dir_all(sqlite3mc_build_dir.clone()).unwrap();
 
     let mut cmake_opts: Vec<&str> = vec![];
 


### PR DESCRIPTION
Build scripts shouldn't write to anything but `OUT_DIR`. So, instead of copying `sqlite3.c` to sqlite3mc in source, copy it to `OUT_DIR` and build from there.

https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script
> Build scripts may save any output files or intermediate artifacts in the directory specified in the [OUT_DIR environment variable](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts). Scripts should not modify any files outside of that directory.

On some environments, Nix derivations, the permissions of source files are limited, and get copied over using the standard `fs::copy`. To prevent this, `cp --no-preserve=mode,ownership` is needed. Inside a Nix derivation, some coreutils are overridden and this is fine to use even on a MacOS device. To make this more reliable, if the `cp` command fails, do a normal copy with `fs` functions.

Some CMake configuration was added to allow cross-compilation of sqlite3mc for more targets.