### PR TITLE
Remove libsql_wal_checkpoint_seq_count() API

### DIFF
--- a/libsql-ffi/bundled/bindings/bindgen.rs
+++ b/libsql-ffi/bundled/bindings/bindgen.rs
@@ -940,7 +940,7 @@ extern "C" {
 extern "C" {
     pub fn sqlite3_vmprintf(
         arg1: *const ::std::os::raw::c_char,
-        arg2: va_list,
+        arg2: *mut __va_list_tag,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -956,7 +956,7 @@ extern "C" {
         arg1: ::std::os::raw::c_int,
         arg2: *mut ::std::os::raw::c_char,
         arg3: *const ::std::os::raw::c_char,
-        arg4: va_list,
+        arg4: *mut __va_list_tag,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2503,7 +2503,7 @@ extern "C" {
     pub fn sqlite3_str_vappendf(
         arg1: *mut sqlite3_str,
         zFormat: *const ::std::os::raw::c_char,
-        arg2: va_list,
+        arg2: *mut __va_list_tag,
     );
 }
 extern "C" {
@@ -2865,12 +2865,6 @@ extern "C" {
 }
 extern "C" {
     pub fn libsql_wal_disable_checkpoint(db: *mut sqlite3) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn libsql_wal_checkpoint_seq_count(
-        db: *mut sqlite3,
-        pnCkpt: *mut ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn libsql_wal_frame_count(
@@ -3361,12 +3355,6 @@ pub struct libsql_wal_methods {
             aWalData: *mut ::std::os::raw::c_uint,
         ) -> ::std::os::raw::c_int,
     >,
-    pub xCheckpointSeqCount: ::std::option::Option<
-        unsafe extern "C" fn(
-            pWal: *mut wal_impl,
-            pnCkpt: *mut ::std::os::raw::c_uint,
-        ) -> ::std::os::raw::c_int,
-    >,
     pub xFrameCount: ::std::option::Option<
         unsafe extern "C" fn(
             pWal: *mut wal_impl,
@@ -3582,4 +3570,12 @@ extern "C" {
 extern "C" {
     pub static sqlite3_wal_manager: libsql_wal_manager;
 }
-pub type __builtin_va_list = *mut ::std::os::raw::c_char;
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
+}

--- a/libsql-ffi/bundled/bindings/session_bindgen.rs
+++ b/libsql-ffi/bundled/bindings/session_bindgen.rs
@@ -2884,12 +2884,6 @@ extern "C" {
     pub fn libsql_wal_disable_checkpoint(db: *mut sqlite3) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn libsql_wal_checkpoint_seq_count(
-        db: *mut sqlite3,
-        pnCkpt: *mut ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
     pub fn libsql_wal_frame_count(
         arg1: *mut sqlite3,
         arg2: *mut ::std::os::raw::c_uint,
@@ -3871,12 +3865,6 @@ pub struct libsql_wal_methods {
         unsafe extern "C" fn(
             pWal: *mut wal_impl,
             aWalData: *mut ::std::os::raw::c_uint,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub xCheckpointSeqCount: ::std::option::Option<
-        unsafe extern "C" fn(
-            pWal: *mut wal_impl,
-            pnCkpt: *mut ::std::os::raw::c_uint,
         ) -> ::std::os::raw::c_int,
     >,
     pub xFrameCount: ::std::option::Option<

--- a/libsql-ffi/bundled/src/sqlite3.h
+++ b/libsql-ffi/bundled/src/sqlite3.h
@@ -10565,15 +10565,6 @@ SQLITE_API void *libsql_close_hook(sqlite3 *db, void (*xClose)(void *pCtx, sqlit
 SQLITE_API int libsql_wal_disable_checkpoint(sqlite3 *db);
 
 /*
-** CAPI3REF: Get the checkpoint sequence counter of the WAL file
-** METHOD: sqlite3
-**
-** ^The [libsql_wal_checkpoint_seq_count(D,P)] interface returns the checkpoint sequence counter
-** of the WAL file for [database connection] D into *P.
-*/
-SQLITE_API int libsql_wal_checkpoint_seq_count(sqlite3 *db, unsigned int *pnCkpt);
-
-/*
 ** CAPI3REF: Get the number of frames in the WAL file
 ** METHOD: sqlite3
 **
@@ -13655,9 +13646,6 @@ typedef struct libsql_wal_methods {
   /* Move the write position of the WAL back to iFrame.  Called in
   ** response to a ROLLBACK TO command. */
   int (*xSavepointUndo)(wal_impl* pWal, unsigned int *aWalData);
-
-  /* Return the current checkpoint generation in the WAL file. */
-  int (*xCheckpointSeqCount)(wal_impl* pWal, unsigned int *pnCkpt);
 
   /* Return the number of frames in the WAL */
   int (*xFrameCount)(wal_impl* pWal, int, unsigned int *);

--- a/libsql-replication/src/injector/sqlite_injector/injector_wal.rs
+++ b/libsql-replication/src/injector/sqlite_injector/injector_wal.rs
@@ -138,10 +138,6 @@ impl Wal for InjectorWal {
         self.inner.savepoint_undo(rollback_data)
     }
 
-    fn checkpoint_seq_count(&self) -> Result<u32> {
-        self.inner.checkpoint_seq_count()
-    }
-
     fn frame_count(&self, locked: i32) -> Result<u32> {
         self.inner.frame_count(locked)
     }

--- a/libsql-sqlite3/doc/libsql_extensions.md
+++ b/libsql-sqlite3/doc/libsql_extensions.md
@@ -362,7 +362,6 @@ The libSQL has the following WAL API functions, which are useful for
 syncing the WAL between databases:
 
 * `libsql_wal_disable_checkpoint` -- Disable checkpointing, including on database close.
-* `libsql_wal_checkpoint_seq_count` -- Return the checkpoint sequence number of the WAL.
 * `libsql_wal_frame_count` -- Get the number of frames in the WAL.
 * `libsql_wal_get_frame` -- Get a frame from the WAL.
 * `libsql_wal_insert_begin` -- Begin WAL insertion.

--- a/libsql-sqlite3/src/main.c
+++ b/libsql-sqlite3/src/main.c
@@ -2450,30 +2450,6 @@ int libsql_wal_disable_checkpoint(sqlite3 *db) {
 }
 
 /*
-** Return the checkpoint sequence counter of the given database.
-*/
-int libsql_wal_checkpoint_seq_count(sqlite3 *db, unsigned int *pnCkpt) {
-  int rc = SQLITE_OK;
-  Pager *pPager;
-
-#ifdef SQLITE_OMIT_WAL
-  *pnFrame = 0;
-  return SQLITE_OK;
-#else
-#ifdef SQLITE_ENABLE_API_ARMOR
-  if( !sqlite3SafetyCheckOk(db) ) return SQLITE_MISUSE_BKPT;
-#endif
-
-  sqlite3_mutex_enter(db->mutex);
-  pPager = sqlite3BtreePager(db->aDb[0].pBt);
-  rc = sqlite3PagerWalCheckpointSeqCount(pPager, pnCkpt);
-  sqlite3Error(db, rc);
-  sqlite3_mutex_leave(db->mutex);
-  return rc;
-#endif
-}
-
-/*
 ** Return the number of frames in the WAL of the given database.
 */
 int libsql_wal_frame_count(

--- a/libsql-sqlite3/src/pager.c
+++ b/libsql-sqlite3/src/pager.c
@@ -7772,18 +7772,6 @@ int sqlite3PagerCloseWal(Pager *pPager, sqlite3 *db){
 }
 
 /**
-** Return the current checkpoint generation in the WAL file.
-**/
-int sqlite3PagerWalCheckpointSeqCount(Pager *pPager, unsigned int *pnCkpt){
-  if( pagerUseWal(pPager) ){
-    return pPager->wal->methods.xCheckpointSeqCount(pPager->wal->pData, pnCkpt);
-  } else {
-    *pnCkpt = 0;
-    return SQLITE_OK;
-  }
-}
-
-/**
 ** Return the number of frames in the WAL file.
 **
 ** If the pager is not in WAL mode or we failed to obtain an exclusive write lock, returns -1.

--- a/libsql-sqlite3/src/sqlite.h.in
+++ b/libsql-sqlite3/src/sqlite.h.in
@@ -10565,15 +10565,6 @@ void *libsql_close_hook(sqlite3 *db, void (*xClose)(void *pCtx, sqlite3 *db), vo
 int libsql_wal_disable_checkpoint(sqlite3 *db);
 
 /*
-** CAPI3REF: Get the checkpoint sequence counter of the WAL file
-** METHOD: sqlite3
-**
-** ^The [libsql_wal_checkpoint_seq_count(D,P)] interface returns the checkpoint sequence counter
-** of the WAL file for [database connection] D into *P.
-*/
-int libsql_wal_checkpoint_seq_count(sqlite3 *db, unsigned int *pnCkpt);
-
-/*
 ** CAPI3REF: Get the number of frames in the WAL file
 ** METHOD: sqlite3
 **

--- a/libsql-sqlite3/src/wal.c
+++ b/libsql-sqlite3/src/wal.c
@@ -4024,11 +4024,6 @@ static int walFrames(
   return rc;
 }
 
-int sqlite3WalCheckpointSeqCount(Wal *pWal, unsigned int *pnCkpt){
-  *pnCkpt = pWal->nCkpt;
-  return SQLITE_OK;
-}
-
 int sqlite3WalFrameCount(Wal *pWal, int locked, unsigned int *pnFrames){
   int rc = SQLITE_OK;
   if( locked==0 ) {
@@ -4548,7 +4543,6 @@ static int sqlite3WalOpen(
     out->methods.xUndo = (int (*)(wal_impl *, int (*)(void *, unsigned int), void *))sqlite3WalUndo;
     out->methods.xSavepoint = (void (*)(wal_impl *, unsigned int *))sqlite3WalSavepoint;
     out->methods.xSavepointUndo = (int (*)(wal_impl *, unsigned int *))sqlite3WalSavepointUndo;
-    out->methods.xCheckpointSeqCount = (int (*)(wal_impl *, unsigned int *))sqlite3WalCheckpointSeqCount;
     out->methods.xFrameCount = (int (*)(wal_impl *, int, unsigned int *))sqlite3WalFrameCount;
     out->methods.xFrames = (int (*)(wal_impl *, int, libsql_pghdr *, unsigned int, int, int, int *))sqlite3WalFrames;
     out->methods.xCheckpoint = (int (*)(wal_impl *, sqlite3 *, int, int (*)(void *), void *, int, int, unsigned char *, int *, int *, int (*)(void*, int, const unsigned char*, int, int, int), void*))sqlite3WalCheckpoint;

--- a/libsql-sqlite3/src/wal.h
+++ b/libsql-sqlite3/src/wal.h
@@ -76,9 +76,6 @@ typedef struct libsql_wal_methods {
   ** response to a ROLLBACK TO command. */
   int (*xSavepointUndo)(wal_impl* pWal, unsigned int *aWalData);
 
-  /* Return the current checkpoint generation in the WAL file. */
-  int (*xCheckpointSeqCount)(wal_impl* pWal, unsigned int *pnCkpt);
-
   /* Return the number of frames in the WAL */
   int (*xFrameCount)(wal_impl* pWal, int, unsigned int *);
 

--- a/libsql-sqlite3/test/rust_suite/src/virtual_wal.rs
+++ b/libsql-sqlite3/test/rust_suite/src/virtual_wal.rs
@@ -106,10 +106,6 @@ mod tests {
             self.0.read_frame_raw(page_no, buffer)
         }
 
-        fn checkpoint_seq_count(&self) -> libsql_sys::wal::Result<u32> {
-            self.0.checkpoint_seq_count()
-        }
-
         fn frame_count(&self, locked: i32) -> libsql_sys::wal::Result<u32> {
             self.0.frame_count(locked)
         }

--- a/libsql-storage/src/lib.rs
+++ b/libsql-storage/src/lib.rs
@@ -270,10 +270,6 @@ impl Wal for DurableWal {
         todo!()
     }
 
-    fn checkpoint_seq_count(&self) -> Result<u32> {
-        todo!()
-    }
-
     fn frame_count(&self, _locked: i32) -> Result<u32> {
         todo!()
     }

--- a/libsql-sys/src/wal/either.rs
+++ b/libsql-sys/src/wal/either.rs
@@ -81,12 +81,6 @@ macro_rules! create_either {
                 }
             }
 
-            fn checkpoint_seq_count(&self) -> super::Result<u32> {
-                match self {
-                    $( $name::$t(inner) => inner.checkpoint_seq_count() ),*
-                }
-            }
-
             fn frame_count(&self, locked: i32) -> super::Result<u32> {
                 match self {
                     $( $name::$t(inner) => inner.frame_count(locked) ),*

--- a/libsql-sys/src/wal/ffi.rs
+++ b/libsql-sys/src/wal/ffi.rs
@@ -30,7 +30,6 @@ pub(crate) fn construct_libsql_wal<W: Wal>(wal: *mut W) -> libsql_wal {
             xUndo: Some(undo::<W>),
             xSavepoint: Some(savepoint::<W>),
             xSavepointUndo: Some(savepoint_undo::<W>),
-            xCheckpointSeqCount: Some(checkpoint_seq_count::<W>),
             xFrameCount: Some(frame_count::<W>),
             xFrames: Some(frames::<W>),
             xCheckpoint: Some(checkpoint::<W>),
@@ -292,24 +291,6 @@ pub unsafe extern "C" fn savepoint_undo<T: Wal>(wal: *mut wal_impl, wal_data: *m
     let data = std::slice::from_raw_parts_mut(wal_data, WAL_SAVEPOINT_NDATA as usize);
     match this.savepoint_undo(data) {
         Ok(_) => SQLITE_OK,
-        Err(code) => code.extended_code,
-    }
-}
-
-pub unsafe extern "C" fn checkpoint_seq_count<T: Wal>(
-    wal: *mut wal_impl,
-    out: *mut c_uint,
-) -> c_int {
-    let this = &mut (*(wal as *mut T));
-    match this.checkpoint_seq_count() {
-        Ok(n) => {
-            if !out.is_null() {
-                unsafe {
-                    *out = n as _;
-                }
-            }
-            SQLITE_OK
-        }
         Err(code) => code.extended_code,
     }
 }

--- a/libsql-sys/src/wal/mod.rs
+++ b/libsql-sys/src/wal/mod.rs
@@ -199,8 +199,6 @@ pub trait Wal {
     fn savepoint(&mut self, rollback_data: &mut [u32]);
     fn savepoint_undo(&mut self, rollback_data: &mut [u32]) -> Result<()>;
 
-    fn checkpoint_seq_count(&self) -> Result<u32>;
-
     fn frame_count(&self, locked: i32) -> Result<u32>;
 
     /// Insert frames in the wal. On commit, returns the number of inserted frames for that

--- a/libsql-sys/src/wal/sqlite3_wal.rs
+++ b/libsql-sys/src/wal/sqlite3_wal.rs
@@ -288,18 +288,6 @@ impl Wal for Sqlite3Wal {
         }
     }
 
-    fn checkpoint_seq_count(&self) -> Result<u32> {
-        let mut out: u32 = 0;
-        let rc = unsafe {
-            (self.inner.methods.xCheckpointSeqCount.unwrap())(self.inner.pData, &mut out)
-        };
-        if rc != 0 {
-            Err(Error::new(rc))
-        } else {
-            Ok(out)
-        }
-    }
-
     fn frame_count(&self, locked: i32) -> Result<u32> {
         let mut out: u32 = 0;
         let rc = unsafe {

--- a/libsql-sys/src/wal/wrapper.rs
+++ b/libsql-sys/src/wal/wrapper.rs
@@ -89,10 +89,6 @@ impl<T: WrapWal<W>, W: Wal> Wal for WalRef<T, W> {
         unsafe { (*self.wrapper).savepoint_undo(&mut *self.wrapped, rollback_data) }
     }
 
-    fn checkpoint_seq_count(&self) -> super::Result<u32> {
-        unsafe { (*self.wrapper).checkpoint_seq_count(&*self.wrapped) }
-    }
-
     fn frame_count(&self, locked: i32) -> super::Result<u32> {
         unsafe { (*self.wrapper).frame_count(&*self.wrapped, locked) }
     }
@@ -276,10 +272,6 @@ where
             .savepoint_undo(&mut self.wrapped, rollback_data)
     }
 
-    fn checkpoint_seq_count(&self) -> super::Result<u32> {
-        self.wrapper.checkpoint_seq_count(&self.wrapped)
-    }
-
     fn frame_count(&self, locked: i32) -> super::Result<u32> {
         self.wrapper.frame_count(&self.wrapped, locked)
     }
@@ -415,10 +407,6 @@ pub trait WrapWal<W: Wal> {
 
     fn savepoint_undo(&mut self, wrapped: &mut W, rollback_data: &mut [u32]) -> super::Result<()> {
         wrapped.savepoint_undo(rollback_data)
-    }
-
-    fn checkpoint_seq_count(&self, wrapped: &W) -> super::Result<u32> {
-        wrapped.checkpoint_seq_count()
     }
 
     fn frame_count(&self, wrapped: &W, locked: i32) -> super::Result<u32> {

--- a/libsql-wal/src/wal.rs
+++ b/libsql-wal/src/wal.rs
@@ -276,11 +276,6 @@ where
     }
 
     #[tracing::instrument(skip_all, fields(id = self.conn_id))]
-    fn checkpoint_seq_count(&self) -> libsql_sys::wal::Result<u32> {
-        Err(libsql_sys::wal::Error::new(10)) // SQLITE_IOERR
-    }
-
-    #[tracing::instrument(skip_all, fields(id = self.conn_id))]
     fn frame_count(&self, _locked: i32) -> libsql_sys::wal::Result<u32> {
         Err(libsql_sys::wal::Error::new(10)) // SQLITE_IOERR
     }


### PR DESCRIPTION
The `libsql_wal_checkpoint_seq_count()` API is not very useful for WAL sync because SQLite resets the counter when database is closed.