### PR TITLE
Remote writes for offline databases

### DIFF
--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -99,6 +99,8 @@ sync = [
   "parser",
   "serde",
   "stream",
+  "remote",
+  "replication",
   "dep:tower",
   "dep:hyper",
   "dep:http",

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -8,11 +8,8 @@ pub use builder::Builder;
 pub use libsql_sys::{Cipher, EncryptionConfig};
 
 use crate::{Connection, Result};
-use std::{
-    fmt,
-    sync::{atomic::AtomicU64, Arc},
-};
-use tokio::sync::Mutex;
+use std::fmt;
+use std::sync::atomic::AtomicU64;
 
 cfg_core! {
     bitflags::bitflags! {
@@ -126,7 +123,7 @@ pub struct Database {
     db_type: DbType,
     /// The maximum replication index returned from a write performed using any connection created using this Database object.
     #[allow(dead_code)]
-    max_write_replication_index: Arc<AtomicU64>,
+    max_write_replication_index: std::sync::Arc<AtomicU64>,
 }
 
 cfg_core! {
@@ -551,7 +548,7 @@ impl Database {
 
                 let conn = db.connect()?;
 
-                let conn = Arc::new(LibsqlConnection { conn });
+                let conn = std::sync::Arc::new(LibsqlConnection { conn });
 
                 Ok(Connection { conn })
             }
@@ -599,7 +596,7 @@ impl Database {
                     }
                 }
 
-                let conn = Arc::new(LibsqlConnection { conn });
+                let conn = std::sync::Arc::new(LibsqlConnection { conn });
 
                 Ok(Connection { conn })
             }
@@ -645,7 +642,7 @@ impl Database {
                     writer,
                     self.max_write_replication_index.clone(),
                 );
-                let conn = Arc::new(remote);
+                let conn = std::sync::Arc::new(remote);
 
                 Ok(Connection { conn })
             }
@@ -665,6 +662,7 @@ impl Database {
                     replication::connection::State,
                     sync::connection::SyncedConnection,
                 };
+                use tokio::sync::Mutex;
 
                 let local = db.connect()?;
 
@@ -678,14 +676,14 @@ impl Database {
                         ),
                         read_your_writes: *read_your_writes,
                         context: db.sync_ctx.clone().unwrap(),
-                        state: Arc::new(Mutex::new(State::Init)),
+                        state: std::sync::Arc::new(Mutex::new(State::Init)),
                     };
 
-                    let conn = Arc::new(synced);
+                    let conn = std::sync::Arc::new(synced);
                     return Ok(Connection { conn });
                 }
 
-                let conn = Arc::new(LibsqlConnection { conn: local });
+                let conn = std::sync::Arc::new(LibsqlConnection { conn: local });
                 Ok(Connection { conn })
             }
 
@@ -696,7 +694,7 @@ impl Database {
                 connector,
                 version,
             } => {
-                let conn = Arc::new(
+                let conn = std::sync::Arc::new(
                     crate::hrana::connection::HttpConnection::new_with_connector(
                         url,
                         auth_token,

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -305,14 +305,17 @@ impl Conn for HranaStream<HttpSender> {
         let parse = crate::parser::Statement::parse(sql);
         for s in parse {
             let s = s?;
-            if s.kind == crate::parser::StmtKind::TxnBegin
-                || s.kind == crate::parser::StmtKind::TxnBeginReadOnly
-                || s.kind == crate::parser::StmtKind::TxnEnd
-            {
+
+            use crate::parser::StmtKind;
+            if matches!(
+                s.kind,
+                StmtKind::TxnBegin | StmtKind::TxnBeginReadOnly | StmtKind::TxnEnd
+            ) {
                 return Err(Error::TransactionalBatchError(
                     "Transactions forbidden inside transactional batch".to_string(),
                 ));
             }
+
             stmts.push(Stmt::new(s.stmt, false));
         }
         let res = self

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -3,7 +3,7 @@
 pub mod connection;
 
 cfg_remote! {
-    mod hyper;
+    pub mod hyper;
 }
 
 mod cursor;

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -20,11 +20,11 @@ cfg_replication!(
 
 cfg_sync! {
     use crate::sync::SyncContext;
+    use tokio::sync::Mutex;
 }
 
 use crate::{database::OpenFlags, local::connection::Connection, Error::ConnectionFailed, Result};
 use libsql_sys::ffi;
-use tokio::sync::Mutex;
 
 // A libSQL database.
 pub struct Database {
@@ -212,8 +212,6 @@ impl Database {
         endpoint: String,
         auth_token: String,
     ) -> Result<Database> {
-        use tokio::sync::Mutex;
-
         let db_path = db_path.into();
         let endpoint = if endpoint.starts_with("libsql:") {
             endpoint.replace("libsql:", "https:")

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Once};
+use std::sync::Once;
 
 cfg_replication!(
     use http::uri::InvalidUri;
@@ -21,6 +21,7 @@ cfg_replication!(
 cfg_sync! {
     use crate::sync::SyncContext;
     use tokio::sync::Mutex;
+    use std::sync::Arc;
 }
 
 use crate::{database::OpenFlags, local::connection::Connection, Error::ConnectionFailed, Result};

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -1,4 +1,4 @@
-use std::sync::Once;
+use std::sync::{Arc, Once};
 
 cfg_replication!(
     use http::uri::InvalidUri;
@@ -22,9 +22,9 @@ cfg_sync! {
     use crate::sync::SyncContext;
 }
 
-use crate::{database::OpenFlags, local::connection::Connection};
-use crate::{Error::ConnectionFailed, Result};
+use crate::{database::OpenFlags, local::connection::Connection, Error::ConnectionFailed, Result};
 use libsql_sys::ffi;
+use tokio::sync::Mutex;
 
 // A libSQL database.
 pub struct Database {
@@ -33,7 +33,7 @@ pub struct Database {
     #[cfg(feature = "replication")]
     pub replication_ctx: Option<ReplicationContext>,
     #[cfg(feature = "sync")]
-    pub sync_ctx: Option<tokio::sync::Mutex<SyncContext>>,
+    pub sync_ctx: Option<Arc<Mutex<SyncContext>>>,
 }
 
 impl Database {
@@ -212,6 +212,8 @@ impl Database {
         endpoint: String,
         auth_token: String,
     ) -> Result<Database> {
+        use tokio::sync::Mutex;
+
         let db_path = db_path.into();
         let endpoint = if endpoint.starts_with("libsql:") {
             endpoint.replace("libsql:", "https:")
@@ -222,7 +224,7 @@ impl Database {
 
         let sync_ctx =
             SyncContext::new(connector, db_path.into(), endpoint, Some(auth_token)).await?;
-        db.sync_ctx = Some(tokio::sync::Mutex::new(sync_ctx));
+        db.sync_ctx = Some(Arc::new(Mutex::new(sync_ctx)));
 
         Ok(db)
     }
@@ -463,137 +465,10 @@ impl Database {
     #[cfg(feature = "sync")]
     /// Sync WAL frames to remote.
     pub async fn sync_offline(&self) -> Result<crate::database::Replicated> {
-        use crate::sync::SyncError;
-        use crate::Error;
-
         let mut sync_ctx = self.sync_ctx.as_ref().unwrap().lock().await;
         let conn = self.connect()?;
 
-        let durable_frame_no = sync_ctx.durable_frame_num();
-        let max_frame_no = conn.wal_frame_count();
-
-        if max_frame_no > durable_frame_no {
-            match self.try_push(&mut sync_ctx, &conn).await {
-                Ok(rep) => Ok(rep),
-                Err(Error::Sync(err)) => {
-                    // Retry the sync because we are ahead of the server and we need to push some older
-                    // frames.
-                    if let Some(SyncError::InvalidPushFrameNoLow(_, _)) = err.downcast_ref() {
-                        tracing::debug!("got InvalidPushFrameNo, retrying push");
-                        self.try_push(&mut sync_ctx, &conn).await
-                    } else {
-                        Err(Error::Sync(err))
-                    }
-                }
-                Err(e) => Err(e),
-            }
-        } else {
-            self.try_pull(&mut sync_ctx, &conn).await
-        }
-        .or_else(|err| {
-            let Error::Sync(err) = err else {
-                return Err(err);
-            };
-
-            // TODO(levy): upcasting should be done *only* at the API boundary, doing this in
-            // internal code just sucks.
-            let Some(SyncError::HttpDispatch(_)) = err.downcast_ref() else {
-                return Err(Error::Sync(err));
-            };
-
-            Ok(crate::database::Replicated {
-                frame_no: None,
-                frames_synced: 0,
-            })
-        })
-    }
-
-    #[cfg(feature = "sync")]
-    async fn try_push(
-        &self,
-        sync_ctx: &mut SyncContext,
-        conn: &Connection,
-    ) -> Result<crate::database::Replicated> {
-        let page_size = {
-            let rows = conn
-                .query("PRAGMA page_size", crate::params::Params::None)?
-                .unwrap();
-            let row = rows.next()?.unwrap();
-            let page_size = row.get::<u32>(0)?;
-            page_size
-        };
-
-        let max_frame_no = conn.wal_frame_count();
-        if max_frame_no == 0 {
-            return Ok(crate::database::Replicated {
-                frame_no: None,
-                frames_synced: 0,
-            });
-        }
-
-        let generation = sync_ctx.generation(); // TODO: Probe from WAL.
-        let start_frame_no = sync_ctx.durable_frame_num() + 1;
-        let end_frame_no = max_frame_no;
-
-        let mut frame_no = start_frame_no;
-        while frame_no <= end_frame_no {
-            let frame = conn.wal_get_frame(frame_no, page_size)?;
-
-            // The server returns its maximum frame number. To avoid resending
-            // frames the server already knows about, we need to update the
-            // frame number to the one returned by the server.
-            let max_frame_no = sync_ctx
-                .push_one_frame(frame.freeze(), generation, frame_no)
-                .await?;
-
-            if max_frame_no > frame_no {
-                frame_no = max_frame_no;
-            }
-            frame_no += 1;
-        }
-
-        sync_ctx.write_metadata().await?;
-
-        // TODO(lucio): this can underflow if the server previously returned a higher max_frame_no
-        // than what we have stored here.
-        let frame_count = end_frame_no - start_frame_no + 1;
-        Ok(crate::database::Replicated {
-            frame_no: None,
-            frames_synced: frame_count as usize,
-        })
-    }
-
-    #[cfg(feature = "sync")]
-    async fn try_pull(
-        &self,
-        sync_ctx: &mut SyncContext,
-        conn: &Connection,
-    ) -> Result<crate::database::Replicated> {
-        let generation = sync_ctx.generation();
-        let mut frame_no = sync_ctx.durable_frame_num() + 1;
-
-        let insert_handle = conn.wal_insert_handle()?;
-
-        loop {
-            match sync_ctx.pull_one_frame(generation, frame_no).await {
-                Ok(Some(frame)) => {
-                    insert_handle.insert(&frame)?;
-                    frame_no += 1;
-                }
-                Ok(None) => {
-                    sync_ctx.write_metadata().await?;
-                    return Ok(crate::database::Replicated {
-                        frame_no: None,
-                        frames_synced: 1,
-                    });
-                }
-                Err(err) => {
-                    tracing::debug!("pull_one_frame error: {:?}", err);
-                    sync_ctx.write_metadata().await?;
-                    return Err(err);
-                }
-            }
-        }
+        crate::sync::sync_offline(&mut sync_ctx, &conn).await
     }
 
     pub(crate) fn path(&self) -> &str {

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -91,7 +91,7 @@ impl Drop for LibsqlConnection {
     }
 }
 
-pub(crate) struct LibsqlStmt(pub(super) crate::local::Statement);
+pub(crate) struct LibsqlStmt(pub crate::local::Statement);
 
 #[async_trait::async_trait]
 impl Stmt for LibsqlStmt {

--- a/libsql/src/params.rs
+++ b/libsql/src/params.rs
@@ -141,6 +141,13 @@ impl IntoParams for Params {
     }
 }
 
+impl Sealed for &Params {}
+impl IntoParams for &Params {
+    fn into_params(self) -> Result<Params> {
+        Ok(self.clone())
+    }
+}
+
 impl<T: IntoValue> Sealed for Vec<T> {}
 impl<T: IntoValue> IntoParams for Vec<T> {
     fn into_params(self) -> Result<Params> {

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -40,7 +40,7 @@ struct Inner {
 }
 
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
-enum State {
+pub enum State {
     #[default]
     Init,
     Invalid,
@@ -106,7 +106,7 @@ fn predict_final_state<'a>(
 /// parsed. This means that we only take into account the entire passed sql statement set and
 /// for example will reject writes if we are in a readonly txn to start with even if we commit
 /// and start a new transaction with the write in it.
-fn should_execute_local(state: &mut State, stmts: &[parser::Statement]) -> Result<bool> {
+pub fn should_execute_local(state: &mut State, stmts: &[parser::Statement]) -> Result<bool> {
     let predicted_end_state = predict_final_state(*state, stmts.iter());
 
     let should_execute_local = match (*state, predicted_end_state) {

--- a/libsql/src/replication/mod.rs
+++ b/libsql/src/replication/mod.rs
@@ -30,7 +30,7 @@ use self::local_client::LocalClient;
 use self::remote_client::RemoteClient;
 
 pub(crate) mod client;
-mod connection;
+pub(crate) mod connection;
 pub(crate) mod local_client;
 pub(crate) mod remote_client;
 

--- a/libsql/src/sync/connection.rs
+++ b/libsql/src/sync/connection.rs
@@ -1,0 +1,120 @@
+use crate::{
+    connection::Conn,
+    hrana::{connection::HttpConnection, hyper::HttpSender},
+    local::{self, impls::LibsqlStmt},
+    params::Params,
+    replication::connection::State,
+    sync::SyncContext,
+    BatchRows, Error, Result, Statement, Transaction, TransactionBehavior,
+};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use super::{statement::SyncedStatement, transaction::SyncedTx};
+
+#[derive(Clone)]
+pub struct SyncedConnection {
+    pub remote: HttpConnection<HttpSender>,
+    pub local: local::Connection,
+    pub read_your_writes: bool,
+    pub context: Arc<Mutex<SyncContext>>,
+    pub state: Arc<Mutex<State>>,
+}
+
+impl SyncedConnection {
+    async fn should_execute_local(&self, sql: &str) -> Result<bool> {
+        let stmts = crate::parser::Statement::parse(sql)
+            .collect::<Result<Vec<_>>>()
+            .or_else(|err| match err {
+                Error::Sqlite3UnsupportedStatement => Ok(vec![]),
+                err => Err(err),
+            })?;
+
+        let mut state = self.state.lock().await;
+
+        crate::replication::connection::should_execute_local(&mut state, stmts.as_slice())
+    }
+}
+
+#[async_trait::async_trait]
+impl Conn for SyncedConnection {
+    async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
+        let mut stmt = self.prepare(sql).await?;
+        stmt.execute(params).await.map(|v| v as u64)
+    }
+
+    async fn execute_batch(&self, sql: &str) -> Result<BatchRows> {
+        if self.should_execute_local(sql).await? {
+            self.local.execute_batch(sql)
+        } else {
+            self.remote.execute_batch(sql).await
+        }
+    }
+
+    async fn execute_transactional_batch(&self, sql: &str) -> Result<BatchRows> {
+        if self.should_execute_local(sql).await? {
+            self.local.execute_transactional_batch(sql)?;
+            Ok(BatchRows::empty())
+        } else {
+            self.remote.execute_transactional_batch(sql).await
+        }
+    }
+
+    async fn prepare(&self, sql: &str) -> Result<Statement> {
+        if self.should_execute_local(sql).await? {
+            Ok(Statement {
+                inner: Box::new(LibsqlStmt(self.local.prepare(sql)?)),
+            })
+        } else {
+            let stmt = Statement {
+                inner: Box::new(self.remote.prepare(sql)?),
+            };
+
+            if self.read_your_writes {
+                Ok(Statement {
+                    inner: Box::new(SyncedStatement {
+                        conn: self.local.clone(),
+                        context: self.context.clone(),
+                        inner: stmt,
+                    }),
+                })
+            } else {
+                Ok(stmt)
+            }
+        }
+    }
+
+    async fn transaction(&self, tx_behavior: TransactionBehavior) -> Result<Transaction> {
+        let tx = SyncedTx::begin(self.clone(), tx_behavior).await?;
+
+        Ok(Transaction {
+            inner: Box::new(tx),
+            conn: crate::Connection {
+                conn: Arc::new(self.clone()),
+            },
+            close: None,
+        })
+    }
+
+    fn interrupt(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_autocommit(&self) -> bool {
+        self.remote.is_autocommit()
+    }
+
+    fn changes(&self) -> u64 {
+        self.remote.changes()
+    }
+
+    fn total_changes(&self) -> u64 {
+        self.remote.total_changes()
+    }
+
+    fn last_insert_rowid(&self) -> i64 {
+        self.remote.last_insert_rowid()
+    }
+
+    async fn reset(&self) {}
+}

--- a/libsql/src/sync/statement.rs
+++ b/libsql/src/sync/statement.rs
@@ -1,0 +1,58 @@
+use crate::{
+    local::{self},
+    params::Params,
+    statement::Stmt,
+    sync::SyncContext, Column, Result, Rows, Statement,
+};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+pub struct SyncedStatement {
+    pub conn: local::Connection,
+    pub context: Arc<Mutex<SyncContext>>,
+    pub inner: Statement,
+}
+
+#[async_trait::async_trait]
+impl Stmt for SyncedStatement {
+    fn finalize(&mut self) {
+        self.inner.finalize()
+    }
+
+    async fn execute(&mut self, params: &Params) -> Result<usize> {
+        let result = self.inner.execute(params).await;
+        let mut context = self.context.lock().await;
+        let _ = crate::sync::sync_offline(&mut context, &self.conn).await;
+        result
+    }
+
+    async fn query(&mut self, params: &Params) -> Result<Rows> {
+        let result = self.inner.query(params).await;
+        let mut context = self.context.lock().await;
+        let _ = crate::sync::sync_offline(&mut context, &self.conn).await;
+        result
+    }
+
+    async fn run(&mut self, params: &Params) -> Result<()> {
+        let result = self.inner.run(params).await;
+        let mut context = self.context.lock().await;
+        let _ = crate::sync::sync_offline(&mut context, &self.conn).await;
+        result
+    }
+
+    fn reset(&mut self) {
+        self.inner.reset()
+    }
+
+    fn parameter_count(&self) -> usize {
+        self.inner.parameter_count()
+    }
+
+    fn parameter_name(&self, idx: i32) -> Option<&str> {
+        self.inner.parameter_name(idx)
+    }
+
+    fn columns(&self) -> Vec<Column> {
+        self.inner.columns()
+    }
+}

--- a/libsql/src/sync/transaction.rs
+++ b/libsql/src/sync/transaction.rs
@@ -1,0 +1,41 @@
+use crate::{
+    connection::Conn,
+    params::Params,
+    transaction::Tx, Result, TransactionBehavior,
+};
+
+use super::connection::SyncedConnection;
+
+pub struct SyncedTx(SyncedConnection);
+
+impl SyncedTx {
+    pub(crate) async fn begin(
+        conn: SyncedConnection,
+        tx_behavior: TransactionBehavior,
+    ) -> Result<Self> {
+        conn.execute(
+            match tx_behavior {
+                TransactionBehavior::Deferred => "BEGIN DEFERRED",
+                TransactionBehavior::Immediate => "BEGIN IMMEDIATE",
+                TransactionBehavior::Exclusive => "BEGIN EXCLUSIVE",
+                TransactionBehavior::ReadOnly => "BEGIN READONLY",
+            },
+            Params::None,
+        )
+        .await?;
+        Ok(Self(conn.clone()))
+    }
+}
+
+#[async_trait::async_trait]
+impl Tx for SyncedTx {
+    async fn commit(&mut self) -> Result<()> {
+        self.0.execute("COMMIT", Params::None).await?;
+        Ok(())
+    }
+
+    async fn rollback(&mut self) -> Result<()> {
+        self.0.execute("ROLLBACK", Params::None).await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Resolves #1920 by adding the capability of delegating writes a remote connection.

Following embedded replica convention, `read_your_writes` is enabled by default (after all write operations, `sync_offline` will be called), this can be disabled by adding `.read_your_writes(false)` to the builder.

```rust
libsql::Builder::new_synced_database(
    "local.db",
    "http://test.localhost:8080".to_string(),
    "".to_string(),
)
.remote_writes(true) // NEW!
.build()
.await?
```
