### PR TITLE
bindings/c: Add `offline` to config struct

### DIFF
--- a/bindings/c/include/libsql.h
+++ b/bindings/c/include/libsql.h
@@ -40,6 +40,7 @@ typedef struct {
   const char *encryption_key;
   int sync_interval;
   char with_webpki;
+  char offline;
 } libsql_config;
 
 typedef const libsql_connection *libsql_connection_t;

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -97,6 +97,7 @@ pub unsafe extern "C" fn libsql_open_sync(
         encryption_key,
         sync_interval: 0,
         with_webpki: 0,
+        offline: 0,
     };
     libsql_open_sync_with_config(config, out_db, out_err_msg)
 }
@@ -119,6 +120,7 @@ pub unsafe extern "C" fn libsql_open_sync_with_webpki(
         encryption_key,
         sync_interval: 0,
         with_webpki: 1,
+        offline: 0,
     };
     libsql_open_sync_with_config(config, out_db, out_err_msg)
 }
@@ -256,7 +258,9 @@ pub unsafe extern "C" fn libsql_open_sync_with_config(
             return 100;
         }
     };
-    if let Some(primary_url) = primary_url_with_offline_removed {
+    let offline = config.offline != 0 || primary_url_with_offline_removed.is_some();
+    if offline {
+        let primary_url = primary_url_with_offline_removed.unwrap_or(primary_url.to_owned());
         let mut builder =
             Builder::new_synced_database(db_path, primary_url.to_owned(), auth_token.to_owned());
         if config.with_webpki != 0 {

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -14,6 +14,7 @@ pub struct libsql_config {
     pub encryption_key: *const std::ffi::c_char,
     pub sync_interval: std::ffi::c_int,
     pub with_webpki: std::ffi::c_char,
+    pub offline: std::ffi::c_char,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Make it possible to configure offline writes via the normal `libsql_config` struct too.