### PR TITLE
Push up to 128 frames in sync

### DIFF
--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -120,6 +120,10 @@ impl SyncContext {
         Ok(me)
     }
 
+    pub fn set_push_batch_size(&mut self, push_batch_size: u32) {
+        self.push_batch_size = push_batch_size;
+    }
+
     #[tracing::instrument(skip(self))]
     pub(crate) async fn pull_one_frame(
         &mut self,

--- a/libsql/src/sync/test.rs
+++ b/libsql/src/sync/test.rs
@@ -28,7 +28,7 @@ async fn test_sync_context_push_frame() {
     let mut sync_ctx = sync_ctx;
 
     // Push a frame and verify the response
-    let durable_frame = sync_ctx.push_one_frame(frame, 1, 0).await.unwrap();
+    let durable_frame = sync_ctx.push_frames(frame, 1, 0, 1).await.unwrap();
     sync_ctx.write_metadata().await.unwrap();
     assert_eq!(durable_frame, 0); // First frame should return max_frame_no = 0
 
@@ -56,7 +56,7 @@ async fn test_sync_context_with_auth() {
     let frame = Bytes::from("test frame with auth");
     let mut sync_ctx = sync_ctx;
 
-    let durable_frame = sync_ctx.push_one_frame(frame, 1, 0).await.unwrap();
+    let durable_frame = sync_ctx.push_frames(frame, 1, 0, 1).await.unwrap();
     sync_ctx.write_metadata().await.unwrap();
     assert_eq!(durable_frame, 0);
     assert_eq!(server.frame_count(), 1);
@@ -82,7 +82,7 @@ async fn test_sync_context_multiple_frames() {
     // Push multiple frames and verify incrementing frame numbers
     for i in 0..3 {
         let frame = Bytes::from(format!("frame data {}", i));
-        let durable_frame = sync_ctx.push_one_frame(frame, 1, i).await.unwrap();
+        let durable_frame = sync_ctx.push_frames(frame, 1, i, 1).await.unwrap();
         sync_ctx.write_metadata().await.unwrap();
         assert_eq!(durable_frame, i);
         assert_eq!(sync_ctx.durable_frame_num(), i);
@@ -108,7 +108,7 @@ async fn test_sync_context_corrupted_metadata() {
 
     let mut sync_ctx = sync_ctx;
     let frame = Bytes::from("test frame data");
-    let durable_frame = sync_ctx.push_one_frame(frame, 1, 0).await.unwrap();
+    let durable_frame = sync_ctx.push_frames(frame, 1, 0, 1).await.unwrap();
     sync_ctx.write_metadata().await.unwrap();
     assert_eq!(durable_frame, 0);
     assert_eq!(server.frame_count(), 1);
@@ -152,7 +152,7 @@ async fn test_sync_restarts_with_lower_max_frame_no() {
 
     let mut sync_ctx = sync_ctx;
     let frame = Bytes::from("test frame data");
-    let durable_frame = sync_ctx.push_one_frame(frame.clone(), 1, 0).await.unwrap();
+    let durable_frame = sync_ctx.push_frames(frame.clone(), 1, 0, 1).await.unwrap();
     sync_ctx.write_metadata().await.unwrap();
     assert_eq!(durable_frame, 0);
     assert_eq!(server.frame_count(), 1);
@@ -180,14 +180,14 @@ async fn test_sync_restarts_with_lower_max_frame_no() {
     // This push should fail because we are ahead of the server and thus should get an invalid
     // frame no error.
     sync_ctx
-        .push_one_frame(frame.clone(), 1, frame_no)
+        .push_frames(frame.clone(), 1, frame_no, 1)
         .await
         .unwrap_err();
 
     let frame_no = sync_ctx.durable_frame_num() + 1;
     // This then should work because when the last one failed it updated our state of the server
     // durable_frame_num and we should then start writing from there.
-    sync_ctx.push_one_frame(frame, 1, frame_no).await.unwrap();
+    sync_ctx.push_frames(frame, 1, frame_no, 1).await.unwrap();
 }
 
 #[tokio::test]
@@ -215,7 +215,7 @@ async fn test_sync_context_retry_on_error() {
     server.return_error.store(true, Ordering::SeqCst);
 
     // First attempt should fail but retry
-    let result = sync_ctx.push_one_frame(frame.clone(), 1, 0).await;
+    let result = sync_ctx.push_frames(frame.clone(), 1, 0, 1).await;
     assert!(result.is_err());
 
     // Advance time to trigger retries faster
@@ -228,7 +228,7 @@ async fn test_sync_context_retry_on_error() {
     server.return_error.store(false, Ordering::SeqCst);
 
     // Next attempt should succeed
-    let durable_frame = sync_ctx.push_one_frame(frame, 1, 0).await.unwrap();
+    let durable_frame = sync_ctx.push_frames(frame, 1, 0, 1).await.unwrap();
     sync_ctx.write_metadata().await.unwrap();
     assert_eq!(durable_frame, 0);
     assert_eq!(server.frame_count(), 1);


### PR DESCRIPTION
In my tests, this speeds up push 4-5 times.
Making push of 300 frames take 4-5s instead of 20s.