### PR TITLE
Fix busy timeouts

### DIFF
--- a/libsql-server/src/connection/connection_core.rs
+++ b/libsql-server/src/connection/connection_core.rs
@@ -1,4 +1,3 @@
-use std::ffi::{c_int, c_void};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -87,18 +86,6 @@ impl<W: Wal + Send + 'static> CoreConnection<W> {
             rusqlite::limits::Limit::SQLITE_LIMIT_LENGTH,
             config.max_row_size as i32,
         );
-
-        unsafe {
-            const MAX_RETRIES: c_int = 8;
-            extern "C" fn do_nothing(_: *mut c_void, n: c_int) -> c_int {
-                (n < MAX_RETRIES) as _
-            }
-            libsql_sys::ffi::sqlite3_busy_handler(
-                conn.handle(),
-                Some(do_nothing),
-                std::ptr::null_mut(),
-            );
-        }
 
         let canceled = Arc::new(AtomicBool::new(false));
 

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -383,6 +383,7 @@ where
         }
         retry = match connection_maker.untracked().await {
             Ok(conn) => {
+                conn.with_raw(|c| c.busy_timeout(std::time::Duration::from_secs(5)))?;
                 if let Err(e) = conn.vacuum_if_needed().await {
                     tracing::warn!("vacuum failed: {}", e);
                 }

--- a/libsql-sys/src/connection.rs
+++ b/libsql-sys/src/connection.rs
@@ -266,7 +266,7 @@ impl<W: Wal> Connection<W> {
                 }
             }
 
-            conn.busy_timeout(std::time::Duration::from_secs(5000))?;
+            conn.busy_timeout(std::time::Duration::from_millis(100))?;
 
             conn
         };


### PR DESCRIPTION
This PR setup properly setup busy timeout for `libsql-server` connections:
1. It uses 100ms busy timeout by default
2. It uses 5s busy timeout for connection which execute `wal_checkpoint(TRUNCATE)`
