### PR TITLE
wal.c: do not ignore the result code of xCb in walCheckpoint

### DIFF
--- a/libsql-sqlite3/src/wal.c
+++ b/libsql-sqlite3/src/wal.c
@@ -2134,9 +2134,11 @@ static int walCheckpoint(
           if (xCb) {
               rc = (xCb)(pCbData, mxSafeFrame, NULL, 0, 0, 0);
           }
-          i64 szDb = pWal->hdr.nPage*(i64)szPage;
-          testcase( IS_BIG_INT(szDb) );
-          rc = sqlite3OsTruncate(pWal->pDbFd, szDb);
+          if( rc==SQLITE_OK ){
+            i64 szDb = pWal->hdr.nPage*(i64)szPage;
+            testcase( IS_BIG_INT(szDb) );
+            rc = sqlite3OsTruncate(pWal->pDbFd, szDb);
+          }
           if( rc==SQLITE_OK ){
             rc = sqlite3OsSync(pWal->pDbFd, CKPT_SYNC_FLAGS(sync_flags));
           }


### PR DESCRIPTION
libsql exposes a WAL checkpoint callback that is called once for each frame and right when checkpointing is about to finish.

before this change, the result code returned by the checkpoint callback was ignored on the 'finish' invocation, which resulted in the checkpoint completing successfully despite the callback returning an error.

this commit propagates the callback's error code and thus prevents the wal_checkpoint() routine from returning SQLITE_OK in cases where the callback failed.