### PR TITLE
make wal checkpoint not fallback to passive mode if busy lock not acq…

### DIFF
--- a/libsql-sqlite3/src/wal.c
+++ b/libsql-sqlite3/src/wal.c
@@ -4131,12 +4131,9 @@ static int sqlite3WalCheckpoint(
     */
     if( eMode!=SQLITE_CHECKPOINT_PASSIVE ){
       rc = walBusyLock(pWal, xBusy2, pBusyArg, WAL_WRITE_LOCK, 1);
-      if( rc!=SQLITE_OK ){
-        walUnlockExclusive(pWal, WAL_CKPT_LOCK, 1);
-        pWal->ckptLock = 0;
-        return rc;
+      if( rc==SQLITE_OK ){
+        pWal->writeLock = 1;
       }
-      pWal->writeLock = 1;
     }
   }
 

--- a/libsql-sqlite3/src/wal.c
+++ b/libsql-sqlite3/src/wal.c
@@ -4131,13 +4131,12 @@ static int sqlite3WalCheckpoint(
     */
     if( eMode!=SQLITE_CHECKPOINT_PASSIVE ){
       rc = walBusyLock(pWal, xBusy2, pBusyArg, WAL_WRITE_LOCK, 1);
-      if( rc==SQLITE_OK ){
-        pWal->writeLock = 1;
-      }else if( rc==SQLITE_BUSY ){
-        eMode2 = SQLITE_CHECKPOINT_PASSIVE;
-        xBusy2 = 0;
-        rc = SQLITE_OK;
+      if( rc!=SQLITE_OK ){
+        walUnlockExclusive(pWal, WAL_CKPT_LOCK, 1);
+        pWal->ckptLock = 0;
+        return rc;
       }
+      pWal->writeLock = 1;
     }
   }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -76,7 +76,7 @@ fn build_wasm(_arg: &str) -> Result<()> {
 
 fn run_tests(arg: &str) -> Result<()> {
     println!("installing nextest");
-    run_cargo(&["install", "cargo-nextest"])?;
+    install_nextest()?;
     println!("running nextest run");
     run_cargo(&["nextest", "run", arg])?;
 
@@ -85,7 +85,7 @@ fn run_tests(arg: &str) -> Result<()> {
 
 fn run_tests_encryption(arg: &str) -> Result<()> {
     println!("installing nextest");
-    run_cargo(&["install", "--force", "cargo-nextest"])?;
+    install_nextest()?;
     println!("running nextest run");
     run_cargo(&[
         "nextest",
@@ -165,5 +165,15 @@ fn run_cp(cmd: &[&str]) -> Result<()> {
         anyhow::bail!("non 0 exit code: {}", exit);
     }
 
+    Ok(())
+}
+
+fn install_nextest() -> Result<()> {
+    run_cargo(&[
+        "install",
+        "--force",
+        "cargo-nextest@0.9.88",
+        "--no-default-features",
+    ])?;
     Ok(())
 }


### PR DESCRIPTION
…uired

Wal truncate checkpoint may not acquire write lock on WAL and it will fallback to passive mode making it proceed with checkpoint even though we wanted to skip checkpoint altogether.