### PR TITLE
libsql-sys: Fix checkpoint logging to use trace level

### DIFF
--- a/libsql-sys/src/wal/ffi.rs
+++ b/libsql-sys/src/wal/ffi.rs
@@ -346,7 +346,7 @@ pub unsafe extern "C" fn frames<T: Wal>(
     }
 }
 
-#[tracing::instrument(skip(wal, db))]
+#[tracing::instrument(skip(wal, db), level = "trace")]
 pub unsafe extern "C" fn checkpoint<T: Wal>(
     wal: *mut wal_impl,
     db: *mut libsql_ffi::sqlite3,


### PR DESCRIPTION
The instrument macro uses info level by default. Let's switch to trace level instead to avoid spamming logs like crazy.