### PR TITLE
bindings/c: Fix libsql_query_stmt() error reporting

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -720,13 +720,13 @@ pub unsafe extern "C" fn libsql_query_stmt(
         Ok(rows) => {
             let rows = Box::leak(Box::new(libsql_rows { result: rows }));
             *out_rows = libsql_rows_t::from(rows);
+            0
         }
         Err(e) => {
             set_err_msg(format!("Error executing statement: {}", e), out_err_msg);
-            return 1;
+            1
         }
-    };
-    0
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
Let's propagate the error code from the future we block on to the caller of `libsql_query_stmt()`.