### PR TITLE
libsql: Improve sync protocol probe error handling

### DIFF
--- a/libsql/src/database/builder.rs
+++ b/libsql/src/database/builder.rs
@@ -381,6 +381,10 @@ cfg_replication! {
                             .await
                             .map_err(|err| crate::Error::Sync(err.into()))?;
 
+                        if res.status() == http::StatusCode::UNAUTHORIZED {
+                            return Err(crate::Error::Sync("Unauthorized".into()));
+                        }
+
                         if matches!(p, SyncProtocol::V2) {
                             if !res.status().is_success() {
                                 let status = res.status();


### PR DESCRIPTION
If we have an invalid access token, let's continue with gRPC protocol, because it produces odd error messages.