### PR TITLE
plumb connector through when syncing

### DIFF
--- a/libsql/src/database/builder.rs
+++ b/libsql/src/database/builder.rs
@@ -402,6 +402,7 @@ cfg_replication! {
                         if res.status().is_success() {
                             tracing::trace!("Using sync protocol v2 for {}", url);
                             return Builder::new_synced_database(path, url, auth_token)
+                                .connector(connector)
                                 .remote_writes(true)
                                 .read_your_writes(read_your_writes)
                                 .build()


### PR DESCRIPTION
Right now, despite providing your own connector, the code unconditionally calls its own connect function.
This has the side-effect of making sync incompatible with platforms which do not have native certs ready.
