### PR TITLE
Fix large sync sessions by reusing the same session

### DIFF
--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -98,6 +98,7 @@ struct InfoResult {
     current_generation: u32,
 }
 
+#[derive(Debug)]
 struct PushFramesResult {
     max_frame_no: u32,
     baton: Option<String>,


### PR DESCRIPTION
Currently, we have a bug where each `push` request creates a new sync session in the server. Each push request can send up to 128 frames.
However, if a transaction spans more than 128 frames, then it needs to reuse the same sync session. Otherwise, the first push will succeed, but the rest of the pushes will fail due to the write lock held by the previous session.

This patch reuses the sync session. The way we do this is by using batons. If the server sends a baton, then we pass it back. Reusing the same baton ensures that we are using the same sync session.