### PR TITLE
fix(libsql-sys): fix non-Unix compilation when rusqlite feature is disabled

### DIFF
--- a/libsql-sys/src/connection.rs
+++ b/libsql-sys/src/connection.rs
@@ -284,6 +284,7 @@ impl<W: Wal> Connection<W> {
             };
             #[cfg(not(unix))]
             let path = path
+                .as_ref()
                 .to_str()
                 .ok_or_else(|| crate::error::Error::Bug("database path is not valid unicode"))
                 .and_then(|x| {


### PR DESCRIPTION
This commit fixes a compilation error introduced in commit 8ea257afe9534e58cf90c5ee8ccad4fc7545d416 on non-Unix systems.