### PR TITLE
feature to move checkpoint callback if any frames is written

### DIFF
--- a/libsql-ffi/Cargo.toml
+++ b/libsql-ffi/Cargo.toml
@@ -7,7 +7,10 @@ license.workspace = true
 repository.workspace = true
 description = "Native bindings to libSQL"
 build = "build.rs"
-exclude = ["bundled/SQLite3MultipleCiphers/build", "bundled/SQLite3MultipleCiphers/test"]
+exclude = [
+  "bundled/SQLite3MultipleCiphers/build",
+  "bundled/SQLite3MultipleCiphers/test",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -37,11 +40,12 @@ sqlean-extension-math = []
 sqlean-extension-stats = []
 sqlean-extension-text = []
 sqlean-extensions = [
-    "sqlean-extension-uuid",
-    "sqlean-extension-crypto",
-    "sqlean-extension-fuzzy",
-    "sqlean-extension-math",
-    "sqlean-extension-stats",
-    "sqlean-extension-text"
+  "sqlean-extension-uuid",
+  "sqlean-extension-crypto",
+  "sqlean-extension-fuzzy",
+  "sqlean-extension-math",
+  "sqlean-extension-stats",
+  "sqlean-extension-text",
 ]
 libsql-disable-checkpoint-downgrade = []
+libsql-checkpoint-callback-on-any-frame-written = []

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -276,6 +276,9 @@ pub fn build_bundled(out_dir: &str, out_path: &Path) {
     if cfg!(feature = "libsql-disable-checkpoint-downgrade") {
         cfg.flag("-DLIBSQL_DISABLE_CHECKPOINT_DOWNGRADE=1");
     }
+    if cfg!(feature = "libsql-checkpoint-callback-on-any-frame-written") {
+        cfg.flag("-DLIBSQL_CHECKPOINT_CALLBACK_ON_ANY_FRAME_WRITTEN=1");
+    }
 
     if cfg!(feature = "bundled-sqlcipher") {
         cfg.flag("-DSQLITE_HAS_CODEC").flag("-DSQLITE_TEMP_STORE=2");

--- a/libsql-sqlite3/src/wal.c
+++ b/libsql-sqlite3/src/wal.c
@@ -2130,10 +2130,18 @@ static int walCheckpoint(
 
       /* If work was actually accomplished... */
       if( rc==SQLITE_OK ){
+#ifdef LIBSQL_CHECKPOINT_CALLBACK_ON_ANY_FRAME_WRITTEN
+        if (xCb) {
+          rc = (xCb)(pCbData, mxSafeFrame, NULL, 0, 0, 0);
+        }
+#endif
+          
         if( mxSafeFrame==walIndexHdr(pWal)->mxFrame ){
+#ifndef LIBSQL_CHECKPOINT_CALLBACK_ON_ANY_FRAME_WRITTEN
           if (xCb) {
               rc = (xCb)(pCbData, mxSafeFrame, NULL, 0, 0, 0);
           }
+#endif
           if( rc==SQLITE_OK ){
             i64 szDb = pWal->hdr.nPage*(i64)szPage;
             testcase( IS_BIG_INT(szDb) );

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.81.0"
+channel = "1.82.0"


### PR DESCRIPTION
Currently we report a checkpoint is finished only when `mxSafeFrame == mxFrame` in wal
it is useful to have finish callback to be triggered in case any work moving frames was accomplished.