### PR TITLE
Libsql checkpoint only full

### DIFF
--- a/libsql-ffi/Cargo.toml
+++ b/libsql-ffi/Cargo.toml
@@ -48,4 +48,4 @@ sqlean-extensions = [
   "sqlean-extension-text",
 ]
 libsql-disable-checkpoint-downgrade = []
-libsql-checkpoint-callback-on-any-frame-written = []
+libsql-checkpoint-only-full= []

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -276,8 +276,8 @@ pub fn build_bundled(out_dir: &str, out_path: &Path) {
     if cfg!(feature = "libsql-disable-checkpoint-downgrade") {
         cfg.flag("-DLIBSQL_DISABLE_CHECKPOINT_DOWNGRADE=1");
     }
-    if cfg!(feature = "libsql-checkpoint-callback-on-any-frame-written") {
-        cfg.flag("-DLIBSQL_CHECKPOINT_CALLBACK_ON_ANY_FRAME_WRITTEN=1");
+    if cfg!(feature = "libsql-checkpoint-only-full") {
+        cfg.flag("-DLIBSQL_CHECKPOINT_ONLY_FULL=1");
     }
 
     if cfg!(feature = "bundled-sqlcipher") {

--- a/libsql-ffi/bundled/bindings/bindgen.rs
+++ b/libsql-ffi/bundled/bindings/bindgen.rs
@@ -23,6 +23,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 
+pub const __GNUC_VA_LIST: i32 = 1;
 pub const SQLITE_VERSION: &[u8; 7] = b"3.45.1\0";
 pub const SQLITE_VERSION_NUMBER: i32 = 3045001;
 pub const SQLITE_SOURCE_ID: &[u8; 85] =
@@ -501,8 +502,8 @@ pub const FTS5_TOKENIZE_DOCUMENT: i32 = 4;
 pub const FTS5_TOKENIZE_AUX: i32 = 8;
 pub const FTS5_TOKEN_COLOCATED: i32 = 1;
 pub const WAL_SAVEPOINT_NDATA: i32 = 4;
-pub type __gnuc_va_list = __builtin_va_list;
 pub type va_list = __builtin_va_list;
+pub type __gnuc_va_list = __builtin_va_list;
 extern "C" {
     pub static sqlite3_version: [::std::os::raw::c_char; 0usize];
 }
@@ -939,7 +940,7 @@ extern "C" {
 extern "C" {
     pub fn sqlite3_vmprintf(
         arg1: *const ::std::os::raw::c_char,
-        arg2: va_list,
+        arg2: *mut __va_list_tag,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -955,7 +956,7 @@ extern "C" {
         arg1: ::std::os::raw::c_int,
         arg2: *mut ::std::os::raw::c_char,
         arg3: *const ::std::os::raw::c_char,
-        arg4: va_list,
+        arg4: *mut __va_list_tag,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2505,7 +2506,7 @@ extern "C" {
     pub fn sqlite3_str_vappendf(
         arg1: *mut sqlite3_str,
         zFormat: *const ::std::os::raw::c_char,
-        arg2: va_list,
+        arg2: *mut __va_list_tag,
     );
 }
 extern "C" {
@@ -3573,4 +3574,12 @@ extern "C" {
 extern "C" {
     pub static sqlite3_wal_manager: libsql_wal_manager;
 }
-pub type __builtin_va_list = *mut ::std::os::raw::c_char;
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
+}


### PR DESCRIPTION
Replace `libsql-checkpoint-callback-on-any-frame-written` feature (introduced in https://github.com/tursodatabase/libsql/pull/2054) with `libsql-checkpoint-only-full` which will force checkpoint to either abort immediately or transfer whole WAL file to the DB.