### PR TITLE
Fix synced database boostrapping

### DIFF
--- a/libsql/src/database/builder.rs
+++ b/libsql/src/database/builder.rs
@@ -644,11 +644,11 @@ cfg_sync! {
             }
 
             let mut bg_abort: Option<std::sync::Arc<crate::sync::DropAbort>> = None;
-            let conn = db.connect()?;
-
-            let sync_ctx = db.sync_ctx.as_ref().unwrap().clone();
 
             if let Some(sync_interval) = sync_interval {
+                let conn = db.connect()?;
+                let sync_ctx = db.sync_ctx.as_ref().unwrap().clone();
+
                 let jh = tokio::spawn(
                     async move {
                         loop {


### PR DESCRIPTION
fixes #2064 

this patch fixes the regression introduced in https://github.com/tursodatabase/libsql/pull/2055

`bootstrap_db` calls the `export` endpoint and bootstraps the db
quickly. If we call `connect` before calling `bootstrap_db`, it will
create a local `.db` file and sync falls back to incremental
bootstrap which is super slow