### PR TITLE
Add `GET /v1/namespaces` endpoint to admin API

### DIFF
--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -142,6 +142,7 @@ where
     };
     let router = axum::Router::new()
         .route("/", get(handle_get_index))
+        .route("/v1/namespaces", get(handle_get_namespaces))
         .route(
             "/v1/namespaces/:namespace/config",
             get(handle_get_config).post(handle_post_config),
@@ -236,6 +237,19 @@ async fn auth_middleware<B>(
 
 async fn handle_get_index() -> &'static str {
     "Welcome to the sqld admin API"
+}
+
+async fn handle_get_namespaces<C: Connector>(
+    State(app_state): State<Arc<AppState<C>>>,
+) -> Json<Vec<String>> {
+    let store = app_state.namespaces.meta_store();
+    let namespaces = store
+        .list_names()
+        .await
+        .iter()
+        .map(|n| n.to_string())
+        .collect();
+    Json(namespaces)
 }
 
 async fn handle_metrics(State(metrics): State<Metrics>) -> String {

--- a/libsql-server/src/namespace/meta_store.rs
+++ b/libsql-server/src/namespace/meta_store.rs
@@ -562,6 +562,10 @@ impl MetaStore {
         self.inner.configs.lock().await.contains_key(namespace)
     }
 
+    pub async fn list_names(&self) -> Vec<NamespaceName> {
+        self.inner.configs.lock().await.keys().cloned().collect()
+    }
+
     pub(crate) async fn shutdown(&self) -> crate::Result<()> {
         let replicator = self.inner.wal_manager.wrapper().as_ref();
 


### PR DESCRIPTION
The new endpoint will return the list of all namespaces currently available.
This is required for building a proper UI for the admin portion of the application.
Before this change this was only doable by listing directories in the DB storage directory.