### PR TITLE
Use `/info` to probe if the server supports `sync`

### DIFF
--- a/libsql/src/database/builder.rs
+++ b/libsql/src/database/builder.rs
@@ -372,7 +372,7 @@ cfg_replication! {
                         } else {
                             url.to_string()
                         };
-                        let req = http::Request::get(format!("{prefix}/sync/0/0/0"))
+                        let req = http::Request::get(format!("{prefix}/info"))
                             .header("Authorization", format!("Bearer {}", auth_token))
                             .body(hyper::Body::empty())
                             .unwrap();


### PR DESCRIPTION
fixes #2087

Instead of using `/sync/0/0/0` use info endpoint which is supported by the new server only, to identify the sync protocol URL