### PR TITLE
Update rust version to 1.85.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.82.0"
+channel = "1.85.0"


### PR DESCRIPTION
The CI is failing with following error:

```
installing nextest
    Updating crates.io index
error: cannot install package `cargo-nextest 0.9.97`, it requires rustc 1.85 or newer, while the currently active rustc version is 1.82.0
`cargo-nextest 0.9.97-b.2` supports rustc 1.81
non 0 exit code: exit status: 101
Error: Process completed with exit code 255.
```

https://github.com/tursodatabase/libsql/actions/runs/15376592072/job/43262042664

So this patch updates the rust version 