### PR TITLE
fix: make keyword_token safe by validating UTF-8 input

### DIFF
--- a/vendored/sqlite3-parser/src/dialect/mod.rs
+++ b/vendored/sqlite3-parser/src/dialect/mod.rs
@@ -65,9 +65,8 @@ include!(concat!(env!("OUT_DIR"), "/keywords.rs"));
 pub(crate) const MAX_KEYWORD_LEN: usize = 17;
 
 pub fn keyword_token(word: &[u8]) -> Option<TokenType> {
-    KEYWORDS
-        .get(UncasedStr::new(unsafe { str::from_utf8_unchecked(word) }))
-        .cloned()
+    let s = std::str::from_utf8(word).ok()?;
+    KEYWORDS.get(UncasedStr::new(s)).cloned()
 }
 
 pub(crate) fn is_identifier(name: &str) -> bool {


### PR DESCRIPTION
This PR fixes an unsound usage of unsafe { str::from_utf8_unchecked(word) } in the public function keyword_token in mod.rs.

The function now uses std::str::from_utf8(word).ok()? to safely handle invalid UTF-8, eliminating the unsoundness.
No logic or API changes.
Code compiles and tests pass (where possible).

Closes: https://github.com/tursodatabase/libsql/issues/1859