### PR TITLE
Simplify build script with cmake crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +2969,7 @@ version = "0.9.9"
 dependencies = [
  "bindgen",
  "cc",
+ "cmake",
  "glob",
  "libsql-wasmtime-bindings",
 ]

--- a/libsql-ffi/Cargo.toml
+++ b/libsql-ffi/Cargo.toml
@@ -18,6 +18,7 @@ exclude = [
 libsql-wasmtime-bindings = { version = "0.2.1", optional = true }
 
 [build-dependencies]
+cmake = "0.1.54"
 bindgen = "0.66.1"
 cc = "1.0"
 glob = "0.3"

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -50,7 +50,7 @@ fn main() {
     }
 
     if cfg!(feature = "multiple-ciphers") {
-        copy_multiple_ciphers(&out_dir, &out_path);
+        copy_multiple_ciphers(&out_path);
         return;
     }
 
@@ -409,16 +409,11 @@ pub fn build_bundled(out_dir: &str, out_path: &Path) {
     println!("cargo:lib_dir={out_dir}");
 }
 
-fn copy_multiple_ciphers(out_dir: &str, out_path: &Path) {
+fn copy_multiple_ciphers(out_path: &Path) {
     let dst = dbg!(build_multiple_ciphers(out_path));
 
-    copy_with_cp(
-        dbg!(dst.join("build").join("libsqlite3mc_static.a")),
-        dbg!(format!("{out_dir}/libsqlite3mc.a")),
-    )
-    .unwrap();
-    println!("cargo:rustc-link-lib=static=sqlite3mc");
-    println!("cargo:rustc-link-search={out_dir}");
+    println!("cargo:rustc-link-lib=static=sqlite3mc_static");
+    println!("cargo:rustc-link-search={}", dst.join("build").display());
 }
 
 fn build_multiple_ciphers(out_path: &Path) -> PathBuf {

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -468,7 +468,7 @@ fn build_multiple_ciphers(out_path: &Path) -> PathBuf {
         .define("SQLITE_ENABLE_COLUMN_METADATA", "ON")
         .define("SQLITE_USE_URI", "ON")
         .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
-        .define("CMAKE_BUILD_TYPE", "Release");
+        .profile("Release");
 
     if cfg!(feature = "wasmtime-bindings") {
         config.define("LIBSQL_ENABLE_WASM_RUNTIME", "1");

--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -412,8 +412,16 @@ pub fn build_bundled(out_dir: &str, out_path: &Path) {
 fn copy_multiple_ciphers(out_path: &Path) {
     let dst = dbg!(build_multiple_ciphers(out_path));
 
-    println!("cargo:rustc-link-lib=static=sqlite3mc_static");
     println!("cargo:rustc-link-search={}", dst.join("build").display());
+    println!(
+        "cargo:rustc-link-search={}",
+        dst.join("build").join("Release").display()
+    );
+    println!(
+        "cargo:rustc-link-search={}",
+        dst.join("build").join("Debug").display()
+    );
+    println!("cargo:rustc-link-lib=static=sqlite3mc_static");
 }
 
 fn build_multiple_ciphers(out_path: &Path) -> PathBuf {
@@ -450,7 +458,7 @@ fn build_multiple_ciphers(out_path: &Path) -> PathBuf {
     let mut config = cmake::Config::new(&bundled_dir);
 
     config
-        .define("CMAKE_BUILD_TYPE", "Release")
+        .build_target("sqlite3mc_static")
         .define("SQLITE3MC_STATIC", "ON")
         .define("CODEC_TYPE", "AES256")
         .define("SQLITE3MC_BUILD_SHELL", "OFF")


### PR DESCRIPTION
This also implements everything that is needed for cross-compilation to various targets (including mobile).

Fixes encryption build for all targets: https://github.com/tursodatabase/libsql-c/actions/runs/15577857992