### PR TITLE
Fix: fix osx cp warning.

### DIFF
--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -76,8 +76,12 @@ fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> 
 /// propagate into OUT_DIR. If not present, when trying to rewrite a file, a `Permission denied`
 /// error will occur.
 fn copy_with_cp(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
-    match Command::new("cp")
-        .arg("--no-preserve=mode,ownership")
+    let mut command = Command::new("cp");
+    // --no-preserve is enabled by default on macos
+    // preserve must be explicitly enabled with the -p flag
+    #[cfg(not(target_os = "macos"))]
+    let command = command.arg("--no-preserve=mode,ownership");
+    match command
         .arg("-R")
         .arg(from.as_ref().to_str().unwrap())
         .arg(to.as_ref().to_str().unwrap())


### PR DESCRIPTION
On macos, cp's `--no-preserve` option does not exist. It is enabled by default, and can be disabled with the explicit `-p` (preserve) flag. This lead libsql-ffi's build.rs to warn about an illegal option used:

```
  cp: illegal option -- -
  usage: cp [-R [-H | -L | -P]] [-fi | -n] [-aclpSsvXx] source_file target_file
         cp [-R [-H | -L | -P]] [-fi | -n] [-aclpSsvXx] source_file ... target_directory
```

This changeset makes sure the option is only passed in non `macos` target_os.

It seems like the build.rs file has had quite a lot of bugfixes over time, especially the CP function, so feel free to dismiss this PR if you're not comfortable landing it, as it's just a warning, and if the cp command does not work it will fallback to `copy_dir_all`.

I'm also lacking context on this library so if I'm missing anything please let me know!

Thanks