### PR TITLE
libsql: Open a fresh stream in HttpConnection::prepare()

### DIFF
--- a/libsql/src/hrana/connection.rs
+++ b/libsql/src/hrana/connection.rs
@@ -81,7 +81,7 @@ where
     }
 
     pub async fn prepare(&self, sql: &str) -> crate::Result<Statement<T>> {
-        let stream = self.current_stream().clone();
+        let stream = self.open_stream();
         Statement::new(stream, sql.to_string(), true).await
     }
 }


### PR DESCRIPTION
The server expires idle streams in 10 seconds. Therefore, let's not even attempt to reuse the same stream for preparing a new SQL statement.