### PR TITLE
Update README.md links for language clients to the new tursodatabase repos

### DIFF
--- a/libsql-server/README.md
+++ b/libsql-server/README.md
@@ -34,10 +34,10 @@ cargo xtask test
 
 The following client libraries enable your app to query `sqld` programmatically:
 
-* [TypeScript and JavaScript](https://github.com/libsql/libsql-client-ts)
+* [TypeScript and JavaScript](https://github.com/tursodatabase/libsql-client-ts)
 * [Rust](https://github.com/libsql/libsql-client-rs)
-* [Go](https://github.com/libsql/libsql-client-go)
-* [Python](https://github.com/libsql/libsql-client-py)
+* [Go](https://github.com/tursodatabase/libsql-client-go)
+* [Python](https://github.com/tursodatabase/libsql-python)
 
 ## SQLite extensions support
 


### PR DESCRIPTION
Simple change to readme so people don't get sent to dead links. I left the Rust client link to the deprecated one because the docs at the link it sends people to are not as good as the ones in the current link. 