### PR TITLE
Update clients to interact with (new) server encrypted databases

### DIFF
--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -102,6 +102,7 @@ sync = [
   "stream",
   "remote",
   "replication",
+  "dep:base64",
   "dep:tower",
   "dep:hyper",
   "dep:http",
@@ -131,6 +132,7 @@ hrana = [
 serde = ["dep:serde"]
 remote = [
   "hrana",
+  "dep:base64",
   "dep:tower",
   "dep:hyper",
   "dep:hyper",

--- a/libsql/examples/encryption_sync.rs
+++ b/libsql/examples/encryption_sync.rs
@@ -1,6 +1,7 @@
 // Example of using offline writes with encryption
 
-use libsql::{params, Builder, EncryptionContext, EncryptionKey};
+use libsql::{params, Builder};
+use libsql::{EncryptionContext, EncryptionKey};
 
 #[tokio::main]
 async fn main() {
@@ -24,7 +25,8 @@ async fn main() {
         None
     };
 
-    let db_builder = Builder::new_synced_database(db_path, sync_url, auth_token, encryption);
+    let db_builder =
+        Builder::new_synced_database(db_path, sync_url, auth_token).remote_encryption(encryption);
 
     let db = match db_builder.build().await {
         Ok(db) => db,

--- a/libsql/examples/encryption_sync.rs
+++ b/libsql/examples/encryption_sync.rs
@@ -1,0 +1,81 @@
+// Example of using offline writes with encryption
+
+use libsql::{params, Builder, EncryptionContext};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    // The local database path where the data will be stored.
+    let db_path = std::env::var("LIBSQL_DB_PATH").unwrap();
+
+    // The remote sync URL to use.
+    let sync_url = std::env::var("LIBSQL_SYNC_URL").unwrap();
+
+    // The authentication token for the remote sync server.
+    let auth_token = std::env::var("LIBSQL_AUTH_TOKEN").unwrap_or("".to_string());
+
+    // Optional encryption key for the database, if provided.
+    let encryption = if let Ok(key) = std::env::var("LIBSQL_ENCRYPTION_KEY") {
+        Some(EncryptionContext {
+            key_32_bytes_base64_encoded: key.to_string(),
+        })
+    } else {
+        None
+    };
+
+    let db_builder = Builder::new_synced_database(db_path, sync_url, auth_token, encryption);
+
+    let db = match db_builder.build().await {
+        Ok(db) => db,
+        Err(error) => {
+            eprintln!("Error connecting to remote sync server: {}", error);
+            return;
+        }
+    };
+
+    let conn = db.connect().unwrap();
+
+    print!("Syncing with remote database...");
+    db.sync().await.unwrap();
+    println!(" done");
+
+    let mut results = conn.query("SELECT count(*) FROM dummy", ()).await.unwrap();
+    let count: u32 = results.next().await.unwrap().unwrap().get(0).unwrap();
+    println!("dummy table has {} entries", count);
+
+    conn.execute(
+        r#"
+        CREATE TABLE IF NOT EXISTS guest_book_entries (
+            text TEXT
+        )"#,
+        (),
+    )
+    .await
+    .unwrap();
+
+    let mut input = String::new();
+    println!("Please write your entry to the guestbook:");
+    match std::io::stdin().read_line(&mut input) {
+        Ok(_) => {
+            println!("You entered: {}", input);
+            let params = params![input.as_str()];
+            conn.execute("INSERT INTO guest_book_entries (text) VALUES (?)", params)
+                .await
+                .unwrap();
+        }
+        Err(error) => {
+            eprintln!("Error reading input: {}", error);
+        }
+    }
+    db.sync().await.unwrap();
+    let mut results = conn
+        .query("SELECT * FROM guest_book_entries", ())
+        .await
+        .unwrap();
+    println!("Guest book entries:");
+    while let Some(row) = results.next().await.unwrap() {
+        let text: String = row.get(0).unwrap();
+        println!("  {}", text);
+    }
+}

--- a/libsql/examples/encryption_sync.rs
+++ b/libsql/examples/encryption_sync.rs
@@ -1,6 +1,6 @@
 // Example of using offline writes with encryption
 
-use libsql::{params, Builder, EncryptionContext};
+use libsql::{params, Builder, EncryptionContext, EncryptionKey};
 
 #[tokio::main]
 async fn main() {
@@ -18,7 +18,7 @@ async fn main() {
     // Optional encryption key for the database, if provided.
     let encryption = if let Ok(key) = std::env::var("LIBSQL_ENCRYPTION_KEY") {
         Some(EncryptionContext {
-            key_32_bytes_base64_encoded: key.to_string(),
+            key: EncryptionKey::Base64Encoded(key),
         })
     } else {
         None

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -710,7 +710,7 @@ impl Database {
                             connector.clone(),
                             None,
                             None,
-                            remote_encryption.clone()
+                            remote_encryption.clone(),
                         ),
                         read_your_writes: *read_your_writes,
                         context: db.sync_ctx.clone().unwrap(),

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -100,6 +100,7 @@ enum DbType {
         auth_token: String,
         connector: crate::util::ConnectorService,
         _bg_abort: Option<std::sync::Arc<crate::sync::DropAbort>>,
+        remote_encryption: Option<crate::sync::EncryptionContext>,
     },
     #[cfg(feature = "remote")]
     Remote {
@@ -214,7 +215,7 @@ cfg_replication! {
                 endpoint,
                 auth_token,
                 https,
-                encryption_config
+                encryption_config,
             ).await
         }
 
@@ -524,7 +525,7 @@ cfg_remote! {
             url: impl Into<String>,
             auth_token: impl Into<String>,
             connector: C,
-            version: Option<String>
+            version: Option<String>,
         ) -> Result<Self>
         where
             C: tower::Service<http::Uri> + Send + Clone + Sync + 'static,
@@ -677,6 +678,7 @@ impl Database {
                 url,
                 auth_token,
                 connector,
+                remote_encryption,
                 ..
             } => {
                 use crate::{
@@ -708,6 +710,7 @@ impl Database {
                             connector.clone(),
                             None,
                             None,
+                            remote_encryption.clone()
                         ),
                         read_your_writes: *read_your_writes,
                         context: db.sync_ctx.clone().unwrap(),
@@ -738,6 +741,7 @@ impl Database {
                         connector.clone(),
                         version.as_ref().map(|s| s.as_str()),
                         namespace.as_ref().map(|s| s.as_str()),
+                        None,
                     ),
                 );
 

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -27,8 +27,8 @@ pub struct HttpSender {
     inner: hyper::Client<ConnectorService, hyper::Body>,
     version: HeaderValue,
     namespace: Option<HeaderValue>,
-    #[cfg(feature = "sync")]
-    remote_encryption: Option<crate::sync::EncryptionContext>,
+    #[cfg(any(feature = "remote", feature = "sync"))]
+    remote_encryption: Option<crate::database::EncryptionContext>,
 }
 
 impl HttpSender {
@@ -36,7 +36,9 @@ impl HttpSender {
         connector: ConnectorService,
         version: Option<&str>,
         namespace: Option<&str>,
-        #[cfg(feature = "sync")] remote_encryption: Option<crate::sync::EncryptionContext>,
+        #[cfg(any(feature = "remote", feature = "sync"))] remote_encryption: Option<
+            crate::database::EncryptionContext,
+        >,
     ) -> Self {
         let ver = version.unwrap_or(env!("CARGO_PKG_VERSION"));
 
@@ -48,7 +50,7 @@ impl HttpSender {
             inner,
             version,
             namespace,
-            #[cfg(feature = "sync")]
+            #[cfg(any(feature = "remote", feature = "sync"))]
             remote_encryption,
         }
     }
@@ -67,6 +69,7 @@ impl HttpSender {
             req_builder = req_builder.header("x-namespace", namespace);
         }
 
+        #[cfg(any(feature = "remote", feature = "sync"))]
         if let Some(remote_encryption) = &self.remote_encryption {
             req_builder =
                 req_builder.header("x-turso-encryption-key", remote_encryption.key.as_string());
@@ -135,13 +138,15 @@ impl HttpConnection<HttpSender> {
         connector: ConnectorService,
         version: Option<&str>,
         namespace: Option<&str>,
-        #[cfg(feature = "sync")] remote_encryption: Option<crate::sync::EncryptionContext>,
+        #[cfg(any(feature = "remote", feature = "sync"))] remote_encryption: Option<
+            crate::database::EncryptionContext,
+        >,
     ) -> Self {
         let inner = HttpSender::new(
             connector,
             version,
             namespace,
-            #[cfg(feature = "sync")]
+            #[cfg(any(feature = "remote", feature = "sync"))]
             remote_encryption,
         );
         Self::new(url.into(), token.into(), inner)

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -68,10 +68,8 @@ impl HttpSender {
         }
 
         if let Some(remote_encryption) = &self.remote_encryption {
-            req_builder = req_builder.header(
-                "x-turso-encryption-key",
-                remote_encryption.key_32_bytes_base64_encoded.as_str(),
-            );
+            req_builder =
+                req_builder.header("x-turso-encryption-key", remote_encryption.key.as_string());
         }
 
         let req = req_builder

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -70,7 +70,7 @@ impl HttpSender {
         if let Some(remote_encryption) = &self.remote_encryption {
             req_builder = req_builder.header(
                 "x-turso-encryption-key",
-                remote_encryption.key_16_bytes_base64_encoded.as_str(),
+                remote_encryption.key_32_bytes_base64_encoded.as_str(),
             );
         }
 

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -132,6 +132,7 @@ pub mod params;
 cfg_sync! {
     mod sync;
     pub use database::SyncProtocol;
+    pub use sync::EncryptionContext;
 }
 
 cfg_replication! {

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -133,6 +133,7 @@ cfg_sync! {
     mod sync;
     pub use database::SyncProtocol;
     pub use sync::EncryptionContext;
+    pub use sync::EncryptionKey;
 }
 
 cfg_replication! {

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -132,8 +132,8 @@ pub mod params;
 cfg_sync! {
     mod sync;
     pub use database::SyncProtocol;
-    pub use sync::EncryptionContext;
-    pub use sync::EncryptionKey;
+    pub use database::EncryptionContext;
+    pub use database::EncryptionKey;
 }
 
 cfg_replication! {

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -212,7 +212,7 @@ impl Database {
         flags: OpenFlags,
         endpoint: String,
         auth_token: String,
-        remote_encryption: Option<crate::sync::EncryptionContext>,
+        remote_encryption: Option<crate::database::EncryptionContext>,
     ) -> Result<Database> {
         let db_path = db_path.into();
         let endpoint = if endpoint.starts_with("libsql:") {
@@ -222,8 +222,14 @@ impl Database {
         };
         let mut db = Database::open(&db_path, flags)?;
 
-        let sync_ctx =
-            SyncContext::new(connector, db_path.into(), endpoint, Some(auth_token), remote_encryption).await?;
+        let sync_ctx = SyncContext::new(
+            connector,
+            db_path.into(),
+            endpoint,
+            Some(auth_token),
+            remote_encryption,
+        )
+        .await?;
         db.sync_ctx = Some(Arc::new(Mutex::new(sync_ctx)));
 
         Ok(db)

--- a/libsql/src/local/database.rs
+++ b/libsql/src/local/database.rs
@@ -212,6 +212,7 @@ impl Database {
         flags: OpenFlags,
         endpoint: String,
         auth_token: String,
+        remote_encryption: Option<crate::sync::EncryptionContext>,
     ) -> Result<Database> {
         let db_path = db_path.into();
         let endpoint = if endpoint.starts_with("libsql:") {
@@ -222,7 +223,7 @@ impl Database {
         let mut db = Database::open(&db_path, flags)?;
 
         let sync_ctx =
-            SyncContext::new(connector, db_path.into(), endpoint, Some(auth_token)).await?;
+            SyncContext::new(connector, db_path.into(), endpoint, Some(auth_token), remote_encryption).await?;
         db.sync_ctx = Some(Arc::new(Mutex::new(sync_ctx)));
 
         Ok(db)

--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -1,7 +1,6 @@
 use crate::{local::Connection, util::ConnectorService, Error, Result};
 
-use base64::engine::general_purpose;
-use base64::Engine;
+use crate::database::EncryptionContext;
 use bytes::Bytes;
 use chrono::Utc;
 use http::{HeaderValue, StatusCode};
@@ -117,29 +116,6 @@ struct InfoResult {
 struct PushFramesResult {
     max_frame_no: u32,
     baton: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-pub enum EncryptionKey {
-    /// The key is a base64-encoded string.
-    Base64Encoded(String),
-    /// The key is a byte array.
-    Bytes(Vec<u8>),
-}
-
-impl EncryptionKey {
-    pub fn as_string(&self) -> String {
-        match self {
-            EncryptionKey::Base64Encoded(s) => s.clone(),
-            EncryptionKey::Bytes(b) => general_purpose::STANDARD.encode(b),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct EncryptionContext {
-    /// The base64-encoded key for the encryption, sent on every request.
-    pub key: EncryptionKey,
 }
 
 pub struct SyncContext {

--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -121,11 +121,7 @@ struct PushFramesResult {
 #[derive(Debug, Clone)]
 pub struct EncryptionContext {
     /// The base64-encoded key for the encryption, sent on every request.
-    pub key_16_bytes_base64_encoded: String,
-    /// Whether the pushed frames are already encrypted.
-    pub push_is_encrypted: bool,
-    /// Whether to request the server to decrypt the pulled frames.
-    pub decrypt_pull: bool,
+    pub key_32_bytes_base64_encoded: String,
 }
 
 pub struct SyncContext {
@@ -318,13 +314,10 @@ impl SyncContext {
             }
 
             if let Some(remote_encryption) = &self.remote_encryption {
-                if remote_encryption.decrypt_pull {
-                    req = req.header("x-turso-decrypt-response", "true");
-                }
-                if remote_encryption.push_is_encrypted {
-                    req = req.header("x-turso-encrypted-request", "true");
-                }
-                req = req.header("x-turso-encryption-key", remote_encryption.key_16_bytes_base64_encoded.as_str());
+                req = req.header(
+                    "x-turso-encryption-key",
+                    remote_encryption.key_32_bytes_base64_encoded.as_str(),
+                );
             }
 
             let req = req.body(body.clone().into()).expect("valid body");
@@ -439,13 +432,10 @@ impl SyncContext {
             }
 
             if let Some(remote_encryption) = &self.remote_encryption {
-                if remote_encryption.decrypt_pull {
-                    req = req.header("x-turso-decrypt-response", "true");
-                }
-                if remote_encryption.push_is_encrypted {
-                    req = req.header("x-turso-encrypted-request", "true");
-                }
-                req = req.header("x-turso-encryption-key", remote_encryption.key_16_bytes_base64_encoded.as_str());
+                req = req.header(
+                    "x-turso-encryption-key",
+                    remote_encryption.key_32_bytes_base64_encoded.as_str(),
+                );
             }
 
             let req = req.body(Body::empty()).expect("valid request");
@@ -612,13 +602,10 @@ impl SyncContext {
         }
 
         if let Some(remote_encryption) = &self.remote_encryption {
-            if remote_encryption.decrypt_pull {
-                req = req.header("x-turso-decrypt-response", "true");
-            }
-            if remote_encryption.push_is_encrypted {
-                req = req.header("x-turso-encrypted-request", "true");
-            }
-            req = req.header("x-turso-encryption-key", remote_encryption.key_16_bytes_base64_encoded.as_str());
+            req = req.header(
+                "x-turso-encryption-key",
+                remote_encryption.key_32_bytes_base64_encoded.as_str(),
+            );
         }
 
         let req = req.body(Body::empty()).expect("valid request");
@@ -718,13 +705,10 @@ impl SyncContext {
         }
 
         if let Some(remote_encryption) = &self.remote_encryption {
-            if remote_encryption.decrypt_pull {
-                req = req.header("x-turso-decrypt-response", "true");
-            }
-            if remote_encryption.push_is_encrypted {
-                req = req.header("x-turso-encrypted-request", "true");
-            }
-            req = req.header("x-turso-encryption-key", remote_encryption.key_16_bytes_base64_encoded.as_str());
+            req = req.header(
+                "x-turso-encryption-key",
+                remote_encryption.key_32_bytes_base64_encoded.as_str(),
+            );
         }
 
         let req = req.body(Body::empty()).expect("valid request");

--- a/libsql/src/sync/test.rs
+++ b/libsql/src/sync/test.rs
@@ -20,6 +20,7 @@ async fn test_sync_context_push_frame() {
         db_path.to_str().unwrap().to_string(),
         server.url(),
         None,
+        None,
     )
     .await
     .unwrap();
@@ -49,6 +50,7 @@ async fn test_sync_context_with_auth() {
         db_path.to_str().unwrap().to_string(),
         server.url(),
         Some("test_token".to_string()),
+        None,
     )
     .await
     .unwrap();
@@ -72,6 +74,7 @@ async fn test_sync_context_multiple_frames() {
         server.connector(),
         db_path.to_str().unwrap().to_string(),
         server.url(),
+        None,
         None,
     )
     .await
@@ -102,6 +105,7 @@ async fn test_sync_context_corrupted_metadata() {
         db_path.to_str().unwrap().to_string(),
         server.url(),
         None,
+        None,
     )
     .await
     .unwrap();
@@ -122,6 +126,7 @@ async fn test_sync_context_corrupted_metadata() {
         server.connector(),
         db_path.to_str().unwrap().to_string(),
         server.url(),
+        None,
         None,
     )
     .await
@@ -145,6 +150,7 @@ async fn test_sync_restarts_with_lower_max_frame_no() {
         server.connector(),
         db_path.to_str().unwrap().to_string(),
         server.url(),
+        None,
         None,
     )
     .await
@@ -170,6 +176,7 @@ async fn test_sync_restarts_with_lower_max_frame_no() {
         server.connector(),
         db_path.to_str().unwrap().to_string(),
         server.url(),
+        None,
         None,
     )
     .await
@@ -209,6 +216,7 @@ async fn test_sync_context_retry_on_error() {
         server.connector(),
         db_path.to_str().unwrap().to_string(),
         server.url(),
+        None,
         None,
     )
     .await


### PR DESCRIPTION
This patch enables client to send encryption key header for encrypted databases.  The header we are required to send is `x-turso-encryption-key`.

To connect with encrypted database, either remote or offline write, you may use the builder pattern to provide the encryption context. Ex.:

```rust
let encryption = if let Ok(key) = std::env::var("LIBSQL_ENCRYPTION_KEY") {
        Some(EncryptionContext {
            key: EncryptionKey::Base64Encoded(key),
        })
    } else {
        None
    };
let db_builder =
        Builder::new_synced_database(db_path, sync_url, auth_token).remote_encryption(encryption);
```

This patch also comes with a full example: https://github.com/avinassh/libsql/blob/5b95a1928b821855fced3880caf7871ce032c58b/libsql/examples/encryption_sync.rs