### PR TITLE
Fixed typos in `connection.rs` and `database\builder.rs`

### DIFF
--- a/libsql/src/connection.rs
+++ b/libsql/src/connection.rs
@@ -137,7 +137,7 @@ impl Connection {
     ///
     /// # Return
     ///
-    /// This returns a `BatchRows` currently only the `remote`  and `local` connection supports this feature and
+    /// This returns a `BatchRows` currently only the `remote` and `local` connection supports this feature and
     /// all other connection types will return an empty set always.
     pub async fn execute_batch(&self, sql: &str) -> Result<BatchRows> {
         tracing::trace!("executing batch `{}`", sql);
@@ -206,7 +206,7 @@ impl Connection {
         self.conn.busy_timeout(timeout)
     }
 
-    /// Check weather libsql is in `autocommit` or not.
+    /// Check whether libsql is in `autocommit` or not.
     pub fn is_autocommit(&self) -> bool {
         self.conn.is_autocommit()
     }

--- a/libsql/src/database/builder.rs
+++ b/libsql/src/database/builder.rs
@@ -25,7 +25,7 @@ pub use crate::database::EncryptionContext;
 ///
 /// # Note
 ///
-/// Embedded replica's require a clean database (no database file) or a previously synced database or else it will
+/// Embedded replicas require a clean database (no database file) or a previously synced database or else it will
 /// throw an error to prevent any misuse. To work around this error a user can delete the database
 /// and let it resync and create the wal_index metadata file.
 pub struct Builder<T = ()> {
@@ -276,7 +276,7 @@ cfg_replication! {
             self
         }
 
-        /// Set weather you want writes to be visible locally before the write query returns. This
+        /// Set whether you want writes to be visible locally before the write query returns. This
         /// means that you will be able to read your own writes if this is set to `true`.
         ///
         /// # Default
@@ -333,7 +333,7 @@ cfg_replication! {
             self
         }
 
-        /// Skip the saftey assert used to ensure that sqlite3 is configured correctly for the way
+        /// Skip the safety assert used to ensure that sqlite3 is configured correctly for the way
         /// that libsql uses the ffi code. By default, libsql will try to use the SERIALIZED
         /// threadsafe mode for sqlite3. This allows us to implement Send/Sync for all the types to
         /// allow them to move between threads safely. Due to the fact that sqlite3 has a global


### PR DESCRIPTION
Fix typos in comments.