### PR TITLE
Update `remote_encryption` builder to take encryption object instead of option

### DIFF
--- a/libsql/examples/encryption_sync.rs
+++ b/libsql/examples/encryption_sync.rs
@@ -25,8 +25,11 @@ async fn main() {
         None
     };
 
-    let db_builder =
-        Builder::new_synced_database(db_path, sync_url, auth_token).remote_encryption(encryption);
+    let mut db_builder = Builder::new_synced_database(db_path, sync_url, auth_token);
+
+    if let Some(enc) = encryption {
+        db_builder = db_builder.remote_encryption(enc);
+    }
 
     let db = match db_builder.build().await {
         Ok(db) => db,

--- a/libsql/src/database/builder.rs
+++ b/libsql/src/database/builder.rs
@@ -306,8 +306,8 @@ cfg_replication! {
 
         /// Set the encryption context if the database is encrypted in remote server.
         #[cfg(feature = "sync")]
-        pub fn remote_encryption(mut self, encryption_context: Option<EncryptionContext>) -> Builder<RemoteReplica> {
-            self.inner.remote_encryption = encryption_context;
+        pub fn remote_encryption(mut self, encryption_context: EncryptionContext) -> Builder<RemoteReplica> {
+            self.inner.remote_encryption = Some(encryption_context);
             self
         }
 
@@ -432,11 +432,14 @@ cfg_replication! {
 
                         if res.status().is_success() {
                             tracing::trace!("Using sync protocol v2 for {}", url);
-                            let builder = Builder::new_synced_database(path, url, auth_token)
+                            let mut builder = Builder::new_synced_database(path, url, auth_token)
                                 .connector(connector)
                                 .remote_writes(true)
-                                .read_your_writes(read_your_writes)
-                                .remote_encryption(remote_encryption);
+                                .read_your_writes(read_your_writes);
+
+                            if let Some(encryption) = remote_encryption {
+                                builder = builder.remote_encryption(encryption);
+                            }
 
                             let builder = if let Some(sync_interval) = sync_interval {
                                 builder.sync_interval(sync_interval)
@@ -621,8 +624,8 @@ cfg_sync! {
         }
 
          /// Set the encryption context if the database is encrypted in remote server.
-        pub fn remote_encryption(mut self, encryption_context: Option<EncryptionContext>) -> Builder<SyncedDatabase> {
-            self.inner.remote_encryption = encryption_context;
+        pub fn remote_encryption(mut self, encryption_context: EncryptionContext) -> Builder<SyncedDatabase> {
+            self.inner.remote_encryption = Some(encryption_context);
             self
         }
 
@@ -789,8 +792,8 @@ cfg_remote! {
         }
 
         /// Set the encryption context if the database is encrypted in remote server.
-        pub fn remote_encryption(mut self, encryption_context: Option<EncryptionContext>) -> Builder<Remote> {
-            self.inner.remote_encryption = encryption_context;
+        pub fn remote_encryption(mut self, encryption_context: EncryptionContext) -> Builder<Remote> {
+            self.inner.remote_encryption = Some(encryption_context);
             self
         }
 


### PR DESCRIPTION
In builder pattern, it is better to take the `Object` itself instead of `Option<Object>`. So 

```rust
pub fn remote_encryption(mut self, encryption_context: Option<EncryptionContext>) -> Builder<T> {}
```

changed to

```rust
pub fn remote_encryption(mut self, encryption_context: EncryptionContext) -> Builder<T> {}
```

This follows the existing practices, and consistent with the code. 