### PR TITLE
Fix wal api ffi

### DIFF
--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -974,8 +974,8 @@ pub async fn try_pull(
                     );
                     return Err(SyncError::InvalidPullFrameBytes(frames.len()).into());
                 }
-                for chunk in frames.chunks(FRAME_SIZE) {
-                    let r = insert_handle.insert(&chunk);
+                for (i, chunk) in frames.chunks(FRAME_SIZE).enumerate() {
+                    let r = insert_handle.insert_at(frame_no + i as u32, &chunk);
                     if let Err(e) = r {
                         tracing::error!(
                             "insert error (frame= {}) : {:?}",


### PR DESCRIPTION
Basically, right now, embedded replica will fail if WAL reached size of more than `4120` frame (familiar number, huh?).

The issue is that in the Rust API we pass `frame.len()` as a `frame_no` and 0 as a `frame.len()` 🤪
The failure happens because `wal_insert` C code will check frame for conflict in case when `if (iFrame <= mxFrame)` and then try to allocate `nBuf - 24` bytes (where `nBuf` equals to `0` due to bug)

This PR fixes this bug and also added simple test to check the API.