### PR TITLE
Fix durable frame tracking to follow transaction boundaries

### DIFF
--- a/libsql/src/local/connection.rs
+++ b/libsql/src/local/connection.rs
@@ -675,6 +675,10 @@ impl WalInsertHandle<'_> {
         self.conn.wal_insert_frame(frame_no, frame)
     }
 
+    pub fn in_session(&self) -> bool {
+        *self.in_session.borrow()
+    }
+
     pub fn begin(&self) -> Result<()> {
         assert!(!*self.in_session.borrow());
         self.conn.wal_insert_begin()?;


### PR DESCRIPTION
Pull logic used invalid property of WAL in its implementation and was written under assumption that any frames written to WAL are durable.

This is not true in case of frames written for unfinished transaction, because such frames will be omitted by any SQLite connection except from the one which created them. So, in case of restart - we will "loose" these frames, but `durable_frame_num` will incorrectly state that we already written "missed" portion of WAL.

This PR fix this issue and make pull to persist information about "durable_frame_num" only at transaction boundaries.