### PR TITLE
do not open wal session from the beginning - wait for pulled frames

### DIFF
--- a/libsql/src/sync.rs
+++ b/libsql/src/sync.rs
@@ -961,7 +961,7 @@ pub async fn try_pull(
 
     // libsql maintain consistent state about WAL sync session locally in the insert_handle
     // note, that insert_handle will always close the session on drop - so we never keep active WAL session after we exit from the method
-    let insert_handle = conn.wal_insert_handle()?;
+    let insert_handle = conn.wal_insert_handle();
 
     loop {
         // get current generation (it may be updated multiple times during execution)
@@ -990,8 +990,7 @@ pub async fn try_pull(
                     if !insert_handle.in_session() {
                         tracing::debug!(
                             "pull_frames: generation={}, frame={}, start wal transaction session",
-                            generation,
-                            next_frame_no
+                            generation, next_frame_no
                         );
                         insert_handle.begin()?;
                     }


### PR DESCRIPTION
Otherwise, if client is on the checkpoint boundary and immediately get checkpoint command - we will crash with assertion
```
assert!(
    !insert_handle.in_session(),
    "WAL transaction must be finished"
);
```