### PR TITLE
More immutable methods

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Run Checks
     env:
+      RUST_BACKTRACE: 1
       RUSTFLAGS: -D warnings --cfg tokio_unstable
     steps:
       - uses: hecrj/setup-rust-action@v2
@@ -179,6 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Run Tests
     env:
+      RUST_BACKTRACE: 1
       RUSTFLAGS: -D warnings --cfg tokio_unstable
     steps:
     - uses: hecrj/setup-rust-action@v2

--- a/libsql-server/tests/standalone/mod.rs
+++ b/libsql-server/tests/standalone/mod.rs
@@ -422,7 +422,7 @@ async fn insert_rows(conn: &Connection, start: u32, count: u32) -> libsql::Resul
 
 async fn insert_rows_with_args(conn: &Connection, start: u32, count: u32) -> libsql::Result<()> {
     for i in start..(start + count) {
-        let mut stmt = conn.prepare("INSERT INTO test(a, b) VALUES(?,?)").await?;
+        let stmt = conn.prepare("INSERT INTO test(a, b) VALUES(?,?)").await?;
         stmt.execute(params![i, i]).await?;
     }
     Ok(())

--- a/libsql/benches/benchmark.rs
+++ b/libsql/benches/benchmark.rs
@@ -93,7 +93,7 @@ fn bench(c: &mut Criterion) {
     group.bench_function("in-memory-select-1-prepared", |b| {
         b.to_async(&rt).iter_batched(
             || block_on(conn.prepare("SELECT 1")).unwrap(),
-            |mut stmt| async move {
+            |stmt| async move {
                 let mut rows = stmt.query(()).await.unwrap();
                 let row = rows.next().await.unwrap().unwrap();
                 assert_eq!(row.get::<i32>(0).unwrap(), 1);
@@ -113,7 +113,7 @@ fn bench(c: &mut Criterion) {
     group.bench_function("in-memory-select-star-from-users-limit-1-unprepared", |b| {
         b.to_async(&rt).iter_batched(
             || block_on(conn.prepare("SELECT * FROM users LIMIT 1")).unwrap(),
-            |mut stmt| async move {
+            |stmt| async move {
                 let mut rows = stmt.query(()).await.unwrap();
                 let row = rows.next().await.unwrap().unwrap();
                 assert_eq!(row.get::<i32>(0).unwrap(), 1);
@@ -128,7 +128,7 @@ fn bench(c: &mut Criterion) {
         |b| {
             b.to_async(&rt).iter_batched(
                 || block_on(conn.prepare("SELECT * FROM users LIMIT 100")).unwrap(),
-                |mut stmt| async move {
+                |stmt| async move {
                     let mut rows = stmt.query(()).await.unwrap();
                     let row = rows.next().await.unwrap().unwrap();
                     assert_eq!(row.get::<i32>(0).unwrap(), 1);
@@ -156,7 +156,7 @@ fn bench(c: &mut Criterion) {
     group.bench_function("local-replica-select-1-prepared", |b| {
         b.to_async(&rt).iter_batched(
             || block_on(conn.prepare("SELECT 1")).unwrap(),
-            |mut stmt| async move {
+            |stmt| async move {
                 let mut rows = stmt.query(()).await.unwrap();
                 let row = rows.next().await.unwrap().unwrap();
                 assert_eq!(row.get::<i32>(0).unwrap(), 1);
@@ -188,7 +188,7 @@ fn bench(c: &mut Criterion) {
         |b| {
             b.to_async(&rt).iter_batched(
                 || block_on(conn.prepare("SELECT * FROM users LIMIT 1")).unwrap(),
-                |mut stmt| async move {
+                |stmt| async move {
                     let mut rows = stmt.query(()).await.unwrap();
                     let row = rows.next().await.unwrap().unwrap();
                     assert_eq!(row.get::<i32>(0).unwrap(), 1);
@@ -204,7 +204,7 @@ fn bench(c: &mut Criterion) {
         |b| {
             b.to_async(&rt).iter_batched(
                 || block_on(conn.prepare("SELECT * FROM users LIMIT 100")).unwrap(),
-                |mut stmt| async move {
+                |stmt| async move {
                     let mut rows = stmt.query(()).await.unwrap();
                     let row = rows.next().await.unwrap().unwrap();
                     assert_eq!(row.get::<i32>(0).unwrap(), 1);

--- a/libsql/examples/deserialization.rs
+++ b/libsql/examples/deserialization.rs
@@ -22,7 +22,7 @@ async fn main() {
     .await
     .unwrap();
 
-    let mut stmt = conn
+    let stmt = conn
         .prepare("INSERT INTO users (name, age, vision, avatar) VALUES (?1, ?2, ?3, ?4)")
         .await
         .unwrap();
@@ -30,7 +30,7 @@ async fn main() {
         .await
         .unwrap();
 
-    let mut stmt = conn
+    let stmt = conn
         .prepare("SELECT * FROM users WHERE name = ?1")
         .await
         .unwrap();

--- a/libsql/examples/example.rs
+++ b/libsql/examples/example.rs
@@ -21,14 +21,14 @@ async fn main() {
         .await
         .unwrap();
 
-    let mut stmt = conn
+    let stmt = conn
         .prepare("INSERT INTO users (email) VALUES (?1)")
         .await
         .unwrap();
 
     stmt.execute(["foo@example.com"]).await.unwrap();
 
-    let mut stmt = conn
+    let stmt = conn
         .prepare("SELECT * FROM users WHERE email = ?1")
         .await
         .unwrap();

--- a/libsql/examples/example_v2.rs
+++ b/libsql/examples/example_v2.rs
@@ -21,14 +21,14 @@ async fn main() {
         .await
         .unwrap();
 
-    let mut stmt = conn
+    let stmt = conn
         .prepare("INSERT INTO users (email) VALUES (?1)")
         .await
         .unwrap();
 
     stmt.execute(["foo@example.com"]).await.unwrap();
 
-    let mut stmt = conn
+    let stmt = conn
         .prepare("SELECT * FROM users WHERE email = ?1")
         .await
         .unwrap();

--- a/libsql/examples/flutter.rs
+++ b/libsql/examples/flutter.rs
@@ -30,14 +30,14 @@ async fn main() {
         .await
         .unwrap();
 
-    let mut stmt = conn
+    let stmt = conn
         .prepare("INSERT INTO users (email) VALUES (?1)")
         .await
         .unwrap();
 
     stmt.execute(["foo@example.com"]).await.unwrap();
 
-    let mut stmt = conn
+    let stmt = conn
         .prepare("SELECT * FROM users WHERE email = ?1")
         .await
         .unwrap();

--- a/libsql/src/connection.rs
+++ b/libsql/src/connection.rs
@@ -170,7 +170,7 @@ impl Connection {
     /// For more info on how to pass params check [`IntoParams`]'s docs and on how to
     /// extract values out of the rows check the [`Rows`] docs.
     pub async fn query(&self, sql: &str, params: impl IntoParams) -> Result<Rows> {
-        let mut stmt = self.prepare(sql).await?;
+        let stmt = self.prepare(sql).await?;
 
         stmt.query(params).await
     }

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -245,7 +245,7 @@ impl crate::statement::Stmt for crate::hrana::Statement<HttpSender> {
         self.query(params).await
     }
 
-    async fn run(&mut self, params: &Params) -> crate::Result<()> {
+    async fn run(&self, params: &Params) -> crate::Result<()> {
         self.run(params).await
     }
 

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -237,7 +237,7 @@ impl Conn for HttpConnection<HttpSender> {
 impl crate::statement::Stmt for crate::hrana::Statement<HttpSender> {
     fn finalize(&mut self) {}
 
-    async fn execute(&mut self, params: &Params) -> crate::Result<usize> {
+    async fn execute(&self, params: &Params) -> crate::Result<usize> {
         self.execute(params).await
     }
 

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -241,7 +241,7 @@ impl crate::statement::Stmt for crate::hrana::Statement<HttpSender> {
         self.execute(params).await
     }
 
-    async fn query(&mut self, params: &Params) -> crate::Result<Rows> {
+    async fn query(&self, params: &Params) -> crate::Result<Rows> {
         self.query(params).await
     }
 

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -249,7 +249,7 @@ impl crate::statement::Stmt for crate::hrana::Statement<HttpSender> {
         self.run(params).await
     }
 
-    fn interrupt(&mut self) -> crate::Result<()> {
+    fn interrupt(&self) -> crate::Result<()> {
         Err(crate::Error::Misuse(
             "interrupt is not supported for remote connections".to_string(),
         ))

--- a/libsql/src/hrana/hyper.rs
+++ b/libsql/src/hrana/hyper.rs
@@ -255,7 +255,7 @@ impl crate::statement::Stmt for crate::hrana::Statement<HttpSender> {
         ))
     }
 
-    fn reset(&mut self) {}
+    fn reset(&self) {}
 
     fn parameter_count(&self) -> usize {
         let stmt = &self.inner;

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -179,7 +179,7 @@ where
     }
 
     pub(crate) async fn query_raw(
-        &mut self,
+        &self,
         params: &Params,
     ) -> crate::Result<HranaRows<T::Stream, T>> {
         let mut stmt = self.inner.clone();
@@ -197,7 +197,7 @@ where
     T: HttpSend + Send + Sync + 'static,
     <T as HttpSend>::Stream: Send + Sync + 'static,
 {
-    pub async fn query(&mut self, params: &Params) -> crate::Result<super::Rows> {
+    pub async fn query(&self, params: &Params) -> crate::Result<super::Rows> {
         let rows = self.query_raw(params).await?;
         Ok(super::Rows::new(rows))
     }

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -170,7 +170,7 @@ where
         Ok(result.affected_row_count as usize)
     }
 
-    pub async fn run(&mut self, params: &Params) -> crate::Result<()> {
+    pub async fn run(&self, params: &Params) -> crate::Result<()> {
         let mut stmt = self.inner.clone();
         bind_params(params.clone(), &mut stmt);
 

--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -162,7 +162,7 @@ where
         }
     }
 
-    pub async fn execute(&mut self, params: &Params) -> crate::Result<usize> {
+    pub async fn execute(&self, params: &Params) -> crate::Result<usize> {
         let mut stmt = self.inner.clone();
         bind_params(params.clone(), &mut stmt);
 

--- a/libsql/src/hrana/stream.rs
+++ b/libsql/src/hrana/stream.rs
@@ -445,7 +445,8 @@ where
     T: HttpSend,
 {
     fn drop(&mut self) {
-        if let Some(baton) = self.baton.borrow_mut().take() {
+        let baton = self.baton.get_mut().take();
+        if let Some(baton) = baton {
             // only send a close request if stream was ever used to send the data
             tracing::trace!("closing client stream (baton: `{}`)", baton);
             let req = serde_json::to_string(&PipelineReqBody {

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -133,7 +133,7 @@ impl Stmt for LibsqlStmt {
         self.0.interrupt()
     }
 
-    fn reset(&mut self) {
+    fn reset(&self) {
         self.0.reset();
     }
 

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -129,7 +129,7 @@ impl Stmt for LibsqlStmt {
         stmt.run(&params)
     }
 
-    fn interrupt(&mut self) -> Result<()> {
+    fn interrupt(&self) -> Result<()> {
         self.0.interrupt()
     }
 

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -122,7 +122,7 @@ impl Stmt for LibsqlStmt {
         stmt.query(&params).map(LibsqlRows).map(Rows::new)
     }
 
-    async fn run(&mut self, params: &Params) -> Result<()> {
+    async fn run(&self, params: &Params) -> Result<()> {
         let params = params.clone();
         let stmt = self.0.clone();
 

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -115,7 +115,7 @@ impl Stmt for LibsqlStmt {
         stmt.execute(&params).map(|i| i as usize)
     }
 
-    async fn query(&mut self, params: &Params) -> Result<Rows> {
+    async fn query(&self, params: &Params) -> Result<Rows> {
         let params = params.clone();
         let stmt = self.0.clone();
 

--- a/libsql/src/local/impls.rs
+++ b/libsql/src/local/impls.rs
@@ -108,7 +108,7 @@ impl Stmt for LibsqlStmt {
         self.0.finalize();
     }
 
-    async fn execute(&mut self, params: &Params) -> Result<usize> {
+    async fn execute(&self, params: &Params) -> Result<usize> {
         let params = params.clone();
         let stmt = self.0.clone();
 

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -755,7 +755,7 @@ impl Stmt for RemoteStatement {
         ))
     }
 
-    fn reset(&mut self) {}
+    fn reset(&self) {}
 
     fn parameter_count(&self) -> usize {
         if let Some(stmt) = self.local_statement.as_ref() {

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -722,8 +722,8 @@ impl Stmt for RemoteStatement {
         Ok(Rows::new(RemoteRows(rows, 0)))
     }
 
-    async fn run(&mut self, params: &Params) -> Result<()> {
-        if let Some(stmt) = &mut self.local_statement {
+    async fn run(&self, params: &Params) -> Result<()> {
+        if let Some(stmt) = &self.local_statement {
             return stmt.run(params.clone()).await;
         }
 

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -688,8 +688,8 @@ impl Stmt for RemoteStatement {
         Ok(affected_row_count as usize)
     }
 
-    async fn query(&mut self, params: &Params) -> Result<Rows> {
-        if let Some(stmt) = &mut self.local_statement {
+    async fn query(&self, params: &Params) -> Result<Rows> {
+        if let Some(stmt) = &self.local_statement {
             return stmt.query(params.clone()).await;
         }
 

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -654,8 +654,8 @@ async fn fetch_metas(
 impl Stmt for RemoteStatement {
     fn finalize(&mut self) {}
 
-    async fn execute(&mut self, params: &Params) -> Result<usize> {
-        if let Some(stmt) = &mut self.local_statement {
+    async fn execute(&self, params: &Params) -> Result<usize> {
+        if let Some(stmt) = &self.local_statement {
             return stmt.execute(params.clone()).await;
         }
 

--- a/libsql/src/replication/connection.rs
+++ b/libsql/src/replication/connection.rs
@@ -749,7 +749,7 @@ impl Stmt for RemoteStatement {
         Ok(())
     }
 
-    fn interrupt(&mut self) -> Result<()> {
+    fn interrupt(&self) -> Result<()> {
         Err(Error::Misuse(
             "interrupt is not supported for remote connections".to_string(),
         ))

--- a/libsql/src/statement.rs
+++ b/libsql/src/statement.rs
@@ -12,7 +12,7 @@ pub(crate) trait Stmt {
 
     async fn query(&self, params: &Params) -> Result<Rows>;
 
-    async fn run(&mut self, params: &Params) -> Result<()>;
+    async fn run(&self, params: &Params) -> Result<()>;
 
     fn interrupt(&self) -> Result<()>;
 
@@ -58,7 +58,7 @@ impl Statement {
     /// provided to execute any type of SQL statement.
     ///
     /// Note: This is an extension to the Rusqlite API.
-    pub async fn run(&mut self, params: impl IntoParams) -> Result<()> {
+    pub async fn run(&self, params: impl IntoParams) -> Result<()> {
         tracing::trace!("run for prepared statement");
         self.inner.run(&params.into_params()?).await?;
         Ok(())

--- a/libsql/src/statement.rs
+++ b/libsql/src/statement.rs
@@ -10,7 +10,7 @@ pub(crate) trait Stmt {
 
     async fn execute(&mut self, params: &Params) -> Result<usize>;
 
-    async fn query(&mut self, params: &Params) -> Result<Rows>;
+    async fn query(&self, params: &Params) -> Result<Rows>;
 
     async fn run(&mut self, params: &Params) -> Result<()>;
 
@@ -45,7 +45,7 @@ impl Statement {
     }
 
     /// Execute a query on the statement, check [`Connection::query`] for usage.
-    pub async fn query(&mut self, params: impl IntoParams) -> Result<Rows> {
+    pub async fn query(&self, params: impl IntoParams) -> Result<Rows> {
         tracing::trace!("query for prepared statement");
         self.inner.query(&params.into_params()?).await
     }

--- a/libsql/src/statement.rs
+++ b/libsql/src/statement.rs
@@ -8,7 +8,7 @@ use crate::{Row, Rows};
 pub(crate) trait Stmt {
     fn finalize(&mut self);
 
-    async fn execute(&mut self, params: &Params) -> Result<usize>;
+    async fn execute(&self, params: &Params) -> Result<usize>;
 
     async fn query(&self, params: &Params) -> Result<Rows>;
 
@@ -39,7 +39,7 @@ impl Statement {
     }
 
     /// Execute queries on the statement, check [`Connection::execute`] for usage.
-    pub async fn execute(&mut self, params: impl IntoParams) -> Result<usize> {
+    pub async fn execute(&self, params: impl IntoParams) -> Result<usize> {
         tracing::trace!("execute for prepared statement");
         self.inner.execute(&params.into_params()?).await
     }

--- a/libsql/src/statement.rs
+++ b/libsql/src/statement.rs
@@ -14,7 +14,7 @@ pub(crate) trait Stmt {
 
     async fn run(&mut self, params: &Params) -> Result<()>;
 
-    fn interrupt(&mut self) -> Result<()>;
+    fn interrupt(&self) -> Result<()>;
 
     fn reset(&mut self);
 
@@ -65,7 +65,7 @@ impl Statement {
     }
 
     /// Interrupt the statement.
-    pub fn interrupt(&mut self) -> Result<()> {
+    pub fn interrupt(&self) -> Result<()> {
         self.inner.interrupt()
     }
 

--- a/libsql/src/statement.rs
+++ b/libsql/src/statement.rs
@@ -16,7 +16,7 @@ pub(crate) trait Stmt {
 
     fn interrupt(&self) -> Result<()>;
 
-    fn reset(&mut self);
+    fn reset(&self);
 
     fn parameter_count(&self) -> usize;
 
@@ -83,7 +83,7 @@ impl Statement {
     }
 
     /// Reset the state of this prepared statement.
-    pub fn reset(&mut self) {
+    pub fn reset(&self) {
         self.inner.reset();
     }
 

--- a/libsql/src/sync/connection.rs
+++ b/libsql/src/sync/connection.rs
@@ -104,7 +104,7 @@ impl SyncedConnection {
 #[async_trait::async_trait]
 impl Conn for SyncedConnection {
     async fn execute(&self, sql: &str, params: Params) -> Result<u64> {
-        let mut stmt = self.prepare(sql).await?;
+        let stmt = self.prepare(sql).await?;
         stmt.execute(params).await.map(|v| v as u64)
     }
 

--- a/libsql/src/sync/statement.rs
+++ b/libsql/src/sync/statement.rs
@@ -38,7 +38,7 @@ impl Stmt for SyncedStatement {
         self.inner.query(params).await
     }
 
-    async fn run(&mut self, params: &Params) -> Result<()> {
+    async fn run(&self, params: &Params) -> Result<()> {
         if self.needs_pull.load(Ordering::Relaxed) {
             let mut context = self.context.lock().await;
             crate::sync::try_pull(&mut context, &self.conn).await?;

--- a/libsql/src/sync/statement.rs
+++ b/libsql/src/sync/statement.rs
@@ -29,7 +29,7 @@ impl Stmt for SyncedStatement {
         self.inner.execute(params).await
     }
 
-    async fn query(&mut self, params: &Params) -> Result<Rows> {
+    async fn query(&self, params: &Params) -> Result<Rows> {
         if self.needs_pull.load(Ordering::Relaxed) {
             let mut context = self.context.lock().await;
             crate::sync::try_pull(&mut context, &self.conn).await?;

--- a/libsql/src/sync/statement.rs
+++ b/libsql/src/sync/statement.rs
@@ -20,7 +20,7 @@ impl Stmt for SyncedStatement {
         self.inner.finalize()
     }
 
-    async fn execute(&mut self, params: &Params) -> Result<usize> {
+    async fn execute(&self, params: &Params) -> Result<usize> {
         if self.needs_pull.load(Ordering::Relaxed) {
             let mut context = self.context.lock().await;
             crate::sync::try_pull(&mut context, &self.conn).await?;

--- a/libsql/src/sync/statement.rs
+++ b/libsql/src/sync/statement.rs
@@ -51,7 +51,7 @@ impl Stmt for SyncedStatement {
         self.inner.interrupt()
     }
 
-    fn reset(&mut self) {
+    fn reset(&self) {
         self.inner.reset()
     }
 

--- a/libsql/src/sync/statement.rs
+++ b/libsql/src/sync/statement.rs
@@ -47,7 +47,7 @@ impl Stmt for SyncedStatement {
         self.inner.run(params).await
     }
 
-    fn interrupt(&mut self) -> Result<()> {
+    fn interrupt(&self) -> Result<()> {
         self.inner.interrupt()
     }
 

--- a/libsql/src/wasm/mod.rs
+++ b/libsql/src/wasm/mod.rs
@@ -70,7 +70,7 @@ where
 {
     pub async fn execute(&self, sql: &str, params: impl IntoParams) -> crate::Result<u64> {
         tracing::trace!("executing `{}`", sql);
-        let mut stmt = crate::hrana::Statement::new(
+        let stmt = crate::hrana::Statement::new(
             self.conn.current_stream().clone(),
             sql.to_string(),
             true,
@@ -100,7 +100,7 @@ where
 
     pub async fn query(&self, sql: &str, params: impl IntoParams) -> crate::Result<Rows> {
         tracing::trace!("querying `{}`", sql);
-        let mut stmt = crate::hrana::Statement::new(
+        let stmt = crate::hrana::Statement::new(
             self.conn.current_stream().clone(),
             sql.to_string(),
             true,
@@ -139,7 +139,7 @@ where
     pub async fn query(&self, sql: &str, params: impl IntoParams) -> crate::Result<Rows> {
         tracing::trace!("querying `{}`", sql);
         let stream = self.inner.stream().clone();
-        let mut stmt = crate::hrana::Statement::new(stream, sql.to_string(), true).await?;
+        let stmt = crate::hrana::Statement::new(stream, sql.to_string(), true).await?;
         let rows = stmt.query_raw(&params.into_params()?).await?;
         Ok(Rows {
             inner: Box::new(rows),
@@ -149,7 +149,7 @@ where
     pub async fn execute(&self, sql: &str, params: impl IntoParams) -> crate::Result<u64> {
         tracing::trace!("executing `{}`", sql);
         let stream = self.inner.stream().clone();
-        let mut stmt = crate::hrana::Statement::new(stream, sql.to_string(), true).await?;
+        let stmt = crate::hrana::Statement::new(stream, sql.to_string(), true).await?;
         let rows = stmt.execute(&params.into_params()?).await?;
         Ok(rows as u64)
     }

--- a/libsql/tests/integration_tests.rs
+++ b/libsql/tests/integration_tests.rs
@@ -600,7 +600,7 @@ async fn debug_print_row() {
     .await
     .unwrap();
 
-    let mut stmt = conn.prepare("SELECT * FROM users").await.unwrap();
+    let stmt = conn.prepare("SELECT * FROM users").await.unwrap();
     let mut rows = stmt.query(()).await.unwrap();
     assert_eq!(
         format!("{:?}", rows.next().await.unwrap().unwrap()),


### PR DESCRIPTION
The SQLite connection and statement objects are thread-safe. Let's mark more Rust methods as immutable so that applications don't need to keep wrapping `Connection` and  `Statement` with `Mutex`, for example, for mutability.