### PR TITLE
libsql: Remove lazy pulling optimization

### DIFF
--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -719,7 +719,6 @@ impl Database {
                         read_your_writes: *read_your_writes,
                         context: db.sync_ctx.clone().unwrap(),
                         state: std::sync::Arc::new(Mutex::new(State::Init)),
-                        needs_pull: std::sync::atomic::AtomicBool::new(false).into(),
                     };
 
                     let conn = std::sync::Arc::new(synced);


### PR DESCRIPTION
The optimization attempts to reduce pulling when an application is writing. However, the logic is embedded in prepare(), which is totally wrong because a statement can be reused. Let's remove the optimization as incorrect.

Refs: tursodatabase/turso-cloud#5