### PR TITLE
Add some missing statement functions to C bindings

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -980,7 +980,10 @@ pub unsafe extern "C" fn libsql_stmt_parameter_name(
             }
         }
     } else {
-        set_err_msg(format!("There is no named parameter at index {}", index), out_err_msg);
+        set_err_msg(
+            format!("There is no named parameter at index {}", index),
+            out_err_msg,
+        );
         return 1;
     }
 }


### PR DESCRIPTION
In this PR I have added some C bindings for some missing functionality w.r.t. prepared statements.

- Getting statement parameter count
- Getting a statement parameter name
- Finalizing a statement.

I'd also like to have a function for getting the column names but I lack the Rust knowledge to do this one without a memory leak.