### PR TITLE
bindings/c: Don't forward empty encryption key string

### DIFF
--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -282,9 +282,11 @@ pub unsafe extern "C" fn libsql_open_sync_with_config(
                     return 5;
                 }
             };
-            builder = builder.remote_encryption(libsql::EncryptionContext {
-                key: libsql::EncryptionKey::Base64Encoded(key.to_string()),
-            });
+            if !key.is_empty() {
+                builder = builder.remote_encryption(libsql::EncryptionContext {
+                    key: libsql::EncryptionKey::Base64Encoded(key.to_string()),
+                });
+            }
         };
         match RT.block_on(builder.build()) {
             Ok(db) => {


### PR DESCRIPTION
op-sqlite, for example, always passes the remote encryption key:

```
DB opsqlite_libsql_open_sync(std::string const &name,
                             std::string const &base_path,
                             std::string const &url,
                             std::string const &auth_token, int sync_interval,
                             bool offline, std::string const &encryption_key,
                             std::string const &remote_encryption_key) {
```

Therefore, ensure that remote encryption key is not null and non-empty before passing it as part of HTTP requests.