### PR TITLE
bindings/c: Fix Android build

### DIFF
--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -487,6 +487,10 @@ fn build_multiple_ciphers(out_path: &Path) -> PathBuf {
         .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
         .profile("Release");
 
+    if let Ok(ndk_home) = env::var("ANDROID_NDK_HOME") {
+        config.define("CMAKE_ANDROID_NDK", ndk_home);
+    }
+
     if let Ok(cc) = env::var("CMAKE_C_COMPILER") {
         let mut build = cc::Build::new();
         build.compiler(cc);


### PR DESCRIPTION
Fixes the following build failure:

```
  -- Configuring incomplete, errors occurred!

  --- stderr
  [libsql-ffi/build.rs:462:9] format!("{BUNDLED_DIR}/SQLite3MultipleCiphers") = "bundled/SQLite3MultipleCiphers"
  CMake Error at /opt/homebrew/share/cmake/Modules/Platform/Android-Determine.cmake:217 (message):
    Android: Neither the NDK or a standalone toolchain was found.
  Call Stack (most recent call first):
    /opt/homebrew/share/cmake/Modules/CMakeDetermineSystem.cmake:191 (include)
    CMakeLists.txt:2 (project)

  CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.

  thread 'main' panicked at /Users/penberg/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cmake-0.1.54/src/lib.rs:1119:5:

  command did not execute successfully, got: exit status: 1

  build script failed, must exit now
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```