### PR TITLE
bump version to 0.9.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "libsql"
-version = "0.9.24"
+version = "0.9.25"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-ffi"
-version = "0.9.24"
+version = "0.9.25"
 dependencies = [
  "bindgen",
  "cc",
@@ -2976,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-hrana"
-version = "0.9.24"
+version = "0.9.25"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -2987,7 +2987,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-rusqlite"
-version = "0.9.24"
+version = "0.9.25"
 dependencies = [
  "bencher",
  "bitflags 2.6.0",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-sys"
-version = "0.9.24"
+version = "0.9.25"
 dependencies = [
  "bytes",
  "libsql-ffi",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "libsql_replication"
-version = "0.9.24"
+version = "0.9.25"
 dependencies = [
  "aes",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,18 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.9.24"
+version = "0.9.25"
 authors = ["the libSQL authors"]
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/tursodatabase/libsql"
 
 [workspace.dependencies]
-libsql-ffi = { path = "libsql-ffi", version = "0.9.24" }
-libsql-sys = { path = "libsql-sys", version = "0.9.24", default-features = false }
-libsql-hrana = { path = "libsql-hrana", version = "0.9.24" }
-libsql_replication = { path = "libsql-replication", version = "0.9.24" }
-rusqlite = { package = "libsql-rusqlite", path = "vendored/rusqlite", version = "0.9.24", default-features = false, features = [
+libsql-ffi = { path = "libsql-ffi", version = "0.9.25" }
+libsql-sys = { path = "libsql-sys", version = "0.9.25", default-features = false }
+libsql-hrana = { path = "libsql-hrana", version = "0.9.25" }
+libsql_replication = { path = "libsql-replication", version = "0.9.25" }
+rusqlite = { package = "libsql-rusqlite", path = "vendored/rusqlite", version = "0.9.25", default-features = false, features = [
     "libsql-experimental",
     "column_decltype",
     "load_extension",

--- a/vendored/rusqlite/Cargo.toml
+++ b/vendored/rusqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libsql-rusqlite"
 # Note: Update version in README.md when you change this.
-version = "0.9.24"
+version = "0.9.25"
 authors = ["The rusqlite developers"]
 edition = "2018"
 description = "Ergonomic wrapper for SQLite (libsql fork)"


### PR DESCRIPTION
depends on https://github.com/tursodatabase/libsql/pull/2175 