### PR TITLE
fix: avoid rebuilding libsql-ffi every time when using Multiple Ciphers

### DIFF
--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -24,7 +24,7 @@ fn main() {
     println!("cargo:rerun-if-changed={BUNDLED_DIR}/src/sqlite3.c");
 
     if cfg!(feature = "multiple-ciphers") {
-        println!("cargo:rerun-if-changed={out_dir}/sqlite3mc/libsqlite3mc_static.a");
+        println!("cargo:rerun-if-changed={BUNDLED_DIR}/SQLite3MultipleCiphers");
     }
 
     if std::env::var("LIBSQL_DEV").is_ok() {


### PR DESCRIPTION
Fix https://github.com/tursodatabase/libsql/issues/2177

When using the Multiple Ciphers extension in libsql, I noticed that it was rebuilding libsql-ffi every time. This fixes the condition in `build.rs` to only check for changes in the Multiple Ciphers source