### PR TITLE
Fix Windows compilation in libsql-sys

### DIFF
--- a/libsql-sys/src/connection.rs
+++ b/libsql-sys/src/connection.rs
@@ -284,6 +284,7 @@ impl<W: Wal> Connection<W> {
             };
             #[cfg(not(unix))]
             let path = path
+                .as_ref()
                 .to_str()
                 .ok_or_else(|| crate::error::Error::Bug("database path is not valid unicode"))
                 .and_then(|x| {


### PR DESCRIPTION
This occurs on the latest released version 0.9.24 :
```
error[E0599]: no method named `to_str` found for type parameter `impl AsRef<Path>` in the current scope
Error:    --> C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\libsql-sys-0.9.24\src\connection.rs:287:18
    |
200 |           path: impl AsRef<Path>,
    |                 ---------------- method `to_str` not found for this type parameter
...
286 |               let path = path
    |  ________________________-
287 | |                 .to_str()
    | |                 -^^^^^^ method not found in `impl AsRef<Path>`
    | |_________________|
    |

For more information about this error, try `rustc --explain E0599`.
error: could not compile `libsql-sys` (lib) due to 1 previous error
```