### PR TITLE
fixed panic on OOB column access in hrana bindings.

### DIFF
--- a/libsql/src/hrana/mod.rs
+++ b/libsql/src/hrana/mod.rs
@@ -326,7 +326,7 @@ impl Row {
 
 impl RowInner for Row {
     fn column_value(&self, idx: i32) -> crate::Result<crate::Value> {
-        let v = self.inner.get(idx as usize).cloned().ok_or_else(|| crate::Error::InvalidColumnIndex(idx))?;
+        let v = self.inner.get(idx as usize).cloned().ok_or_else(|| crate::Error::InvalidColumnIndex)?;
         Ok(into_value2(v))
     }
 


### PR DESCRIPTION
After fixing [#4339](https://github.com/tursodatabase/turso/issues/4339) in Turso, thought to check libsql as well. Rust bindings are fine, but after doing some checking with Claude, noticed that Hrana bindings unwrap the `.get()` call. Function already returns a result, so we can just return an error on an out-of-bounds column access instead.