### PR TITLE
Docs: Enhance USER_GUIDE with JWT authentication and key generation

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -116,6 +116,86 @@ curl -d '{"statements": ["SELECT * FROM users"]}' 127.0.0.1:8081
 You can configure client authentication by passing the `--auth-jwt-key-file FILENAME` command line option to `sqld`.
 The key is either a PKCS#8-encoded Ed25519 public key in PEM, or just plain bytes of the Ed25519 public key in URL-safe base64.
 
+### Generate Keys using Node/Bun
+
+Generate a private key and public key pair for JWT authentication:
+
+```typescript
+import fs from "node:fs";
+import { generateKeyPairSync } from "crypto";
+
+const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+// Export private key in PKCS#8 PEM format
+const privPem = privateKey.export({ format: "pem", type: "pkcs8" });
+fs.writeFileSync("private.pem", privPem);
+
+// Export public key in SPKI PEM format
+const pubPem = publicKey.export({ format: "pem", type: "spki" });
+fs.writeFileSync("public.pem", pubPem);
+```
+
+The snippet code generate two files: `private.pem` and `public.pem`, use the `public.pem` in the configuration `--auth-jwt-key-file public.pem`.
+
+> [!CAUTION]
+> Always keep in mind that the `private.pem` file must not be shared publicly; you should store it in a secure location, unlike the `public.pem` file, which can be shared without any risk.
+
+### Generate a Token using Node/Bun
+
+For generate the JWT you can install `jose` library and sign a JWT using the `private.pem`.
+
+```console
+npm install jose
+```
+
+```typescript
+import fs from "node:fs";
+import { importPKCS8, SignJWT } from "jose";
+
+const privateKeyPem = fs.readFileSync("private.pem", "utf-8");
+const privateKey = await importPKCS8(privateKeyPem, "EdDSA");
+
+const payload = {
+  sub: "username",
+  name: "Name User",
+};
+const jwt = await new SignJWT(payload)
+  .setProtectedHeader({ alg: "EdDSA" })
+  .setIssuedAt() // Issued At
+  .setExpirationTime("1h") // Expiration time in 1 hour
+  .sign(privateKey); // Pass the private key object
+
+fs.writeFileSync("token.txt", jwt);
+```
+
+The generated token could be used for authentication:
+
+```console
+npm install @libsql/client
+```
+
+```typescript
+import { createClient } from "@libsql/client";
+
+const client = createClient({
+  url: "https://example.domain/",
+  authToken: jwt,
+});
+
+await client.batch(
+  [
+    "CREATE TABLE IF NOT EXISTS users (email TEXT)",
+    "INSERT INTO users VALUES ('a@example.com')",
+    "INSERT INTO users VALUES ('b@example.com')",
+    "INSERT INTO users VALUES ('c@example.com')",
+  ],
+  "write",
+);
+
+const result = await client.execute("SELECT * FROM users");
+
+console.log("Users:", result.rows);
+```
+
 ## Deployment
 
 ### Deploying with Docker

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -118,7 +118,7 @@ The key is either a PKCS#8-encoded Ed25519 public key in PEM, or just plain byte
 
 ### Generate Keys using Node/Bun
 
-Generate a private key and public key pair for JWT authentication:
+To generate a public and private key pair for JWT authentication, you can use the built-in Node.js `crypto` module:
 
 ```typescript
 import fs from "node:fs";
@@ -134,14 +134,14 @@ const pubPem = publicKey.export({ format: "pem", type: "spki" });
 fs.writeFileSync("public.pem", pubPem);
 ```
 
-The snippet code generate two files: `private.pem` and `public.pem`, use the `public.pem` in the configuration `--auth-jwt-key-file public.pem`.
+This snippet generates two files: `private.pem` and `public.pem`. Pass the `public.pem` file to your server using the `--auth-jwt-key-file public.pem` flag.
 
 > [!CAUTION]
-> Always keep in mind that the `private.pem` file must not be shared publicly; you should store it in a secure location, unlike the `public.pem` file, which can be shared without any risk.
+> Never share your `private.pem` file. It must be stored in a secure location. The `public.pem` file, however, is safe to distribute publicly.
 
 ### Generate a Token using Node/Bun
 
-For generate the JWT you can install `jose` library and sign a JWT using the `private.pem`.
+To generate the JWT, install the `jose` library and sign a new token using your `private.pem` file:
 
 ```console
 npm install jose
@@ -166,8 +166,10 @@ const jwt = await new SignJWT(payload)
 
 fs.writeFileSync("token.txt", jwt);
 ```
+> [!NOTE]
+> Token Expiration: In the example above, the token is configured to be valid for exactly one hour. Once this hour passes, the token will expire and the client will lose access. You will need to generate and provide a new token to re-authenticate.
 
-The generated token could be used for authentication:
+You can now use the generated token to authenticate your `@libsql/client`:
 
 ```console
 npm install @libsql/client


### PR DESCRIPTION
Added complete Javascript/Typescript examples to the documentation for generating Ed25519 keys, signing JWTs with the `jose` library, and authenticating the `@libsql/client`, including token expiration details.