### PR TITLE
docs(libsql-server): fix LIBSQL_BOTTOMLESS_AWS_DEFAULT_REGION env var name

### DIFF
--- a/libsql-server/README.md
+++ b/libsql-server/README.md
@@ -89,10 +89,15 @@ environment variables can be used to configure the replication:
 ```bash
 LIBSQL_BOTTOMLESS_BUCKET=my-bucket                 # Default bucket name: bottomless
 LIBSQL_BOTTOMLESS_ENDPOINT='http://localhost:9000' # address can be overridden for local testing, e.g. with Minio
-LIBSQL_BOTTOMLESS_AWS_SECRET_ACCESS_KEY=           # regular AWS variables are used
-LIBSQL_BOTTOMLESS_AWS_ACCESS_KEY_ID=               # ... to set up auth, regions, etc.
-LIBSQL_BOTTOMLESS_AWS_REGION=                      # .
+LIBSQL_BOTTOMLESS_AWS_ACCESS_KEY_ID=               # AWS access key ID (or S3-compatible provider)
+LIBSQL_BOTTOMLESS_AWS_SECRET_ACCESS_KEY=           # AWS secret access key (or S3-compatible provider)
+LIBSQL_BOTTOMLESS_AWS_DEFAULT_REGION=us-east-1     # AWS region (required; use us-east-1 for MinIO/local dev)
+LIBSQL_BOTTOMLESS_AWS_SESSION_TOKEN=               # Optional, for temporary AWS credentials
 ```
+
+> **Note:** The region variable is `LIBSQL_BOTTOMLESS_AWS_DEFAULT_REGION`, not `LIBSQL_BOTTOMLESS_AWS_REGION`.
+> If unset, `sqld` will fail to start with the error:
+> `Error: Internal Error: LIBSQL_BOTTOMLESS_AWS_DEFAULT_REGION was not set`
 
 ### bottomless-cli
 


### PR DESCRIPTION
## Problem

The `libsql-server/README.md` documents the bottomless region environment variable as `LIBSQL_BOTTOMLESS_AWS_REGION`, but the actual implementation in `bottomless/src/replicator.rs` reads `LIBSQL_BOTTOMLESS_AWS_DEFAULT_REGION`:

https://github.com/tursodatabase/libsql/blob/main/bottomless/src/replicator.rs#L139
https://github.com/tursodatabase/libsql/blob/main/bottomless/src/replicator.rs#L201

Users following the README will set the wrong variable and see `sqld` fail with:

```
Error: Internal Error: LIBSQL_BOTTOMLESS_AWS_DEFAULT_REGION was not set
```

## Changes

- Correct the region environment variable name in `libsql-server/README.md` to match `replicator.rs`
- Add `LIBSQL_BOTTOMLESS_AWS_SESSION_TOKEN` (also supported in `replicator.rs:200` but previously undocumented)
- Improve the comment descriptions for each variable
- Add an explicit note with the exact error message users will encounter when the variable is missing — makes this page findable via a Google search of the error

## Verification

Verified by:
1. Reading `bottomless/src/replicator.rs` lines 139, 198-201 (env_var calls)
2. Encountering this exact error during a self-hosted deployment using MinIO as S3 backend

## Impact

Docs-only change, no code or behaviour changes. Should reduce time-to-first-success for new self-hosters using bottomless replication, particularly those using MinIO, Cloudflare R2, Wasabi, or other S3-compatible providers in local / EU-only deployments.