### PR TITLE
fix(ffi): Resolve PermissionDenied (OS Error 5) on Windows during build.rs fallback

### DIFF
--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -89,7 +89,12 @@ fn copy_with_cp(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> 
     {
         Ok(status) if status.success() => Ok(()),
         _ => match fs::copy(from.as_ref(), to.as_ref()) {
-            Err(err) if err.kind() == io::ErrorKind::InvalidInput => copy_dir_all(from, to),
+            Err(err)
+                if err.kind() == io::ErrorKind::InvalidInput
+                    || err.kind() == io::ErrorKind::PermissionDenied =>
+            {
+                copy_dir_all(from, to)
+            }
             Ok(_) => Ok(()),
             Err(err) => Err(err),
         },


### PR DESCRIPTION
### Description
This PR fixes an issue where compiling `libsql-ffi` on Windows panics with `PermissionDenied (OS Error 5)`.

Inside `build.rs`, the `copy_with_cp` function attempts to use `cp -R`, which naturally fails on Windows. It then falls back to `std::fs::copy()`. However, `fs::copy()` cannot copy directories on Windows—it throws `PermissionDenied` instead of `InvalidInput`. The previous error handler only caught `ErrorKind::InvalidInput` to trigger `copy_dir_all`, causing Windows builds to panic.

This fix extends the error handling to catch both `InvalidInput` and `PermissionDenied` error kinds, routing both to `copy_dir_all` which properly handles directory copying.

### Changes
- Modified `copy_with_cp` fallback logic in `libsql-ffi/build.rs` to catch both `InvalidInput` and `PermissionDenied` error kinds
- Both error types now correctly route to `copy_dir_all`
- Maintains backward compatibility with existing Unix-like behavior

### Testing
This fix allows `libsql-ffi` to build successfully on Windows platforms without panicking during the copy operation.
`libsql = { version = "0.9.30", features = ["encryption"] }`

*Note: This patch and PR description were generated with the assistance of AI to identify and resolve the Windows-specific build constraint.*