### PR TITLE
Deprecate sync(), sync_until(), and sync_frames() APIs

### DIFF
--- a/bindings/c/include/libsql.h
+++ b/bindings/c/include/libsql.h
@@ -59,14 +59,24 @@ typedef struct {
   int len;
 } blob;
 
+#if defined(__GNUC__) || defined(__clang__)
+#define LIBSQL_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+#define LIBSQL_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+#define LIBSQL_DEPRECATED(msg)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
 
 int libsql_enable_internal_tracing(void);
 
+LIBSQL_DEPRECATED("sync() is deprecated and will be removed in a future release. Learn more: https://tur.so/newsync")
 int libsql_sync(libsql_database_t db, const char **out_err_msg);
 
+LIBSQL_DEPRECATED("sync() is deprecated and will be removed in a future release. Learn more: https://tur.so/newsync")
 int libsql_sync2(libsql_database_t db, replicated *out_replicated, const char **out_err_msg);
 
 int libsql_open_sync(const char *db_path,

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -394,6 +394,7 @@ cfg_replication! {
 
         /// Sync database from remote, and returns the committed frame_no after syncing, if
         /// applicable.
+        #[deprecated(note = "sync() is deprecated and will be removed in a future release. Use the `turso` crate instead. Learn more: https://tur.so/newsync")]
         pub async fn sync(&self) -> Result<Replicated> {
             match &self.db_type {
                 #[cfg(feature = "replication")]
@@ -413,6 +414,7 @@ cfg_replication! {
 
         /// Sync database from remote until it gets to a given replication_index or further,
         /// and returns the committed frame_no after syncing, if applicable.
+        #[deprecated(note = "sync_until() is deprecated and will be removed in a future release. Use the `turso` crate instead. Learn more: https://tur.so/newsync")]
         pub async fn sync_until(&self, replication_index: FrameNo) -> Result<Replicated> {
             if let DbType::Sync { db, encryption_config: _ } = &self.db_type {
                 db.sync_until(replication_index).await
@@ -423,6 +425,7 @@ cfg_replication! {
 
         /// Apply a set of frames to the database and returns the committed frame_no after syncing, if
         /// applicable.
+        #[deprecated(note = "sync_frames() is deprecated and will be removed in a future release. Use the `turso` crate instead. Learn more: https://tur.so/newsync")]
         pub async fn sync_frames(&self, frames: crate::replication::Frames) -> Result<Option<FrameNo>> {
             if let DbType::Sync { db, encryption_config: _ } = &self.db_type {
                 db.sync_frames(frames).await


### PR DESCRIPTION
Mark the sync family of functions as deprecated across the Rust public API and the C header bindings. Users are directed to the `turso` crate as a replacement. Learn more: https://tur.so/newsync