### PR TITLE
libsql-server: fix duplicated "the" in doc-comments

### DIFF
--- a/libsql-server/src/main.rs
+++ b/libsql-server/src/main.rs
@@ -153,7 +153,7 @@ struct Cli {
     heartbeat_auth: Option<String>,
 
     /// The heartbeat time period in seconds.
-    /// By default, the the period is 30 seconds.
+    /// By default, the period is 30 seconds.
     #[clap(long, env = "SQLD_HEARTBEAT_PERIOD_S", default_value = "30")]
     heartbeat_period_s: u64,
 

--- a/libsql-server/src/rpc/streaming_exec.rs
+++ b/libsql-server/src/rpc/streaming_exec.rs
@@ -206,7 +206,7 @@ impl StreamResponseBuilder {
     }
 }
 
-/// Apply the response to the the builder, and return whether the builder need more steps
+/// Apply the response to the builder, and return whether the builder need more steps
 pub fn apply_program_resp_to_builder<B: QueryResultBuilder>(
     config: &QueryBuilderConfig,
     builder: &mut B,


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in `libsql-server` doc-comments:
- `libsql-server/src/main.rs` — "By default, the the period is 30 seconds." → "By default, the period is 30 seconds."
- `libsql-server/src/rpc/streaming_exec.rs` — "/// Apply the response to the the builder, and return whether..." → "/// Apply the response to the builder, ..."

No code/behavior change.