### PR TITLE
Switch to minimum supported Rust version compatible resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
   "bindings/c",
   "bindings/wasm",

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,15 +28,15 @@ FROM chef AS builder
 ARG BUILD_DEBUG=false
 ENV CARGO_PROFILE_RELEASE_DEBUG=$BUILD_DEBUG
 COPY --from=planner /recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --locked --recipe-path recipe.json
 COPY . .
 ARG ENABLE_FEATURES=""
 RUN if [ "$ENABLE_FEATURES" == "" ]; then \
-        cargo build -p libsql-server --release ; \
+        cargo build -p libsql-server --release --locked ; \
     else \
-        cargo build -p libsql-server --features "$ENABLE_FEATURES" --release ; \
+        cargo build -p libsql-server --features "$ENABLE_FEATURES" --release --locked ; \
     fi
-RUN cargo build -p bottomless-cli --release
+RUN cargo build -p bottomless-cli --release --locked
 
 # official gosu install instruction (https://github.com/tianon/gosu/blob/master/INSTALL.md)
 FROM debian:bullseye-slim as gosu

--- a/libsql-sqlite3/ext/crr/rs/bundle/Cargo.toml
+++ b/libsql-sqlite3/ext/crr/rs/bundle/Cargo.toml
@@ -41,3 +41,5 @@ omit_load_extension = [
   "crsql_fractindex_core/omit_load_extension",
   "crsql_core/omit_load_extension"
 ]
+
+[workspace]

--- a/libsql-sqlite3/ext/crr/rs/bundle_static/Cargo.toml
+++ b/libsql-sqlite3/ext/crr/rs/bundle_static/Cargo.toml
@@ -33,3 +33,5 @@ static = [
 omit_load_extension = [
   "crsql_bundle/omit_load_extension"
 ]
+
+[workspace]

--- a/libsql-sqlite3/ext/crr/rs/core/Cargo.toml
+++ b/libsql-sqlite3/ext/crr/rs/core/Cargo.toml
@@ -30,3 +30,5 @@ libsql = []
 loadable_extension = ["sqlite_nostd/loadable_extension"]
 static = ["sqlite_nostd/static"]
 omit_load_extension = ["sqlite_nostd/omit_load_extension"]
+
+[workspace]

--- a/libsql-sqlite3/ext/crr/rs/fractindex-core/Cargo.toml
+++ b/libsql-sqlite3/ext/crr/rs/fractindex-core/Cargo.toml
@@ -29,3 +29,5 @@ target = "wasm32-unknown-emscripten"
 loadable_extension = ["sqlite_nostd/loadable_extension"]
 static = ["sqlite_nostd/static"]
 omit_load_extension = ["sqlite_nostd/omit_load_extension"]
+
+[workspace]

--- a/libsql-sqlite3/ext/crr/rs/integration_check/Cargo.toml
+++ b/libsql-sqlite3/ext/crr/rs/integration_check/Cargo.toml
@@ -24,3 +24,5 @@ cc = "1.0"
 libsql = ["crsql_bundle/libsql"]
 static = []
 omit_load_extension = []
+
+[workspace]

--- a/libsql-sqlite3/ext/crr/rs/sqlite-rs-embedded/sqlite3_allocator/Cargo.toml
+++ b/libsql-sqlite3/ext/crr/rs/sqlite-rs-embedded/sqlite3_allocator/Cargo.toml
@@ -16,3 +16,5 @@ sqlite3_capi = {version="0.1.0", path="../sqlite3_capi"}
 
 # dev dependencies for examples
 [dev-dependencies]
+
+[workspace]

--- a/libsql-sqlite3/ext/crr/rs/sqlite-rs-embedded/sqlite3_capi/Cargo.toml
+++ b/libsql-sqlite3/ext/crr/rs/sqlite-rs-embedded/sqlite3_capi/Cargo.toml
@@ -16,3 +16,5 @@ bindgen = "0.68.1"
 loadable_extension = []
 static = []
 omit_load_extension = []
+
+[workspace]

--- a/libsql-sqlite3/ext/crr/rs/sqlite-rs-embedded/sqlite_nostd/Cargo.toml
+++ b/libsql-sqlite3/ext/crr/rs/sqlite-rs-embedded/sqlite_nostd/Cargo.toml
@@ -17,3 +17,5 @@ num-derive = "0.4.1"
 loadable_extension = ["sqlite3_capi/loadable_extension"]
 static = ["sqlite3_capi/static"]
 omit_load_extension = ["sqlite3_capi/omit_load_extension"]
+
+[workspace]

--- a/libsql-sqlite3/ext/crr/rs/sqlite-rs-embedded/sqlite_web/Cargo.toml
+++ b/libsql-sqlite3/ext/crr/rs/sqlite-rs-embedded/sqlite_web/Cargo.toml
@@ -14,3 +14,5 @@ sqlite_nostd = { path="../sqlite_nostd"}
 loadable_extension = ["sqlite_nostd/loadable_extension"]
 static = ["sqlite_nostd/static"]
 
+
+[workspace]

--- a/libsql-sqlite3/test/rust_suite/Cargo.toml
+++ b/libsql-sqlite3/test/rust_suite/Cargo.toml
@@ -3,7 +3,13 @@ name = "libsql_rust_suite"
 version = "0.2.0"
 edition = "2021"
 
+# This crate is its own workspace root with no committed Cargo.lock, so CI
+# resolves it from scratch every run. resolver = "3" makes that resolution
+# MSRV-aware (it honors the 1.85.0 toolchain in rust-toolchain.toml) so it does
+# not pull in deps that require a newer compiler (e.g. icu_*/idna_adapter @ 1.86,
+# wasip2/wit-bindgen @ 1.87).
 [workspace]
+resolver = "3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The url 2.5.4+ crate pulls idna 1.x -> idna_adapter -> icu_* 2.2.0, which
require rustc 1.86. A fresh dependency resolution (e.g. the Docker build,
which did not pass --locked) would select those and fail against the 1.85.0
toolchain pinned in rust-toolchain.toml.

Bump the workspace to resolver = "3". With no rust-version declared, cargo's
MSRV-aware resolver falls back to the installed toolchain version (1.85.0, per
rust-toolchain.toml) and resolves to the latest compatible deps. Also pass
--locked in the Dockerfile so the image builds the exact pinned dependency
tree.
