### PR TITLE
github: Build the Windows CI job with the MSVC toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -242,11 +242,14 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+      - name: Install x86_64-pc-windows-msvc target
+        run: rustup target add x86_64-pc-windows-msvc
       - name: build libsql all features
-        run: cargo build -p libsql --all-features 
+        run: |
+          cargo clean -p libsql-ffi
+          cargo build -p libsql --all-features --release --target x86_64-pc-windows-msvc
 
   # test-rust-wasm:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
The Windows job's `cargo build -p libsql --all-features` was being built with the `x86_64-pc-windows-gnu` toolchain (MinGW/GCC), set as the default host triple by `hecrj/setup-rust-action@v2`. MSVC was never exercised. So breaks that only fail under MSVC -- like the SQLite 3.47.0 `#warning` that errors with C1021 -- compiled green here. We discovered the gap when libsql-js (which builds with `--target x86_64-pc-windows-msvc`) failed downstream on the same code.

Add `--target x86_64-pc-windows-msvc --release` so the Windows job actually compiles the bundled SQLite encryption amalgamation (sqlite3mc) with MSVC, and breaks surface in CI.

`cargo clean -p libsql-ffi` runs first so sqlite3mc is rebuilt from source rather than restored from a cached target/.