### PR TITLE
fix(libsql-sqlite3-parser): cross-compilation for `lemon` generator

### DIFF
--- a/vendored/sqlite3-parser/build.rs
+++ b/vendored/sqlite3-parser/build.rs
@@ -18,7 +18,7 @@ fn main() -> Result<()> {
     // compile rlemon:
     {
         assert!(Build::new()
-            .target(&env::var("HOST").unwrap())
+            .host(&env::var("HOST").unwrap())
             .get_compiler()
             .to_command()
             .arg("-o")


### PR DESCRIPTION
Force the `cc` crate to ignore cross-compilation environment variables and use the host's native compiler and architecture settings.

Fixes an issue where `libsql-sqlite3-parser` fails to cross-compile on Windows (e.g., building for `aarch64-pc-windows-msvc` on an `x86_64` host).

During the build process, the `build.rs` script compiles `lemon.c` into a helper executable (`rlemon`). Previously, the build configuration was not strictly isolating the host environment. This resulted in the MSVC cross-compiler attempting to build the `lemon` binary for the target architecture (`arm64`), causing an `ERROR_EXE_MACHINE_TYPE_MISMATCH` (Error 216) when the build script attempted to execute the resulting binary on the `x64` host machine.