### PR TITLE
Use CARGO_MANIFEST_DIR from buildscript run time

### DIFF
--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -38,9 +38,9 @@ fn main() {
         "bundled/bindings/bindgen.rs"
     };
 
-    let dir = env!("CARGO_MANIFEST_DIR");
+    let dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
 
-    let full_src_path = Path::new(dir).join(bindgen_rs_path);
+    let full_src_path = dir.join(bindgen_rs_path);
     copy_with_cp(full_src_path, &out_path).unwrap();
 
     println!("cargo:lib_dir={out_dir}");
@@ -192,8 +192,8 @@ pub fn build_bundled(out_dir: &str, out_path: &Path) {
         bindings::write_to_out_dir(header, bindgen_rs_path.as_ref());
     }
 
-    let dir = env!("CARGO_MANIFEST_DIR");
-    copy_with_cp(format!("{dir}/{bindgen_rs_path}"), out_path).unwrap();
+    let dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    copy_with_cp(dir.join(bindgen_rs_path), out_path).unwrap();
 
     let mut cfg = cc::Build::new();
     cfg.flag("-std=c11")
@@ -453,8 +453,8 @@ fn build_multiple_ciphers(out_path: &Path) -> PathBuf {
         bindings::write_to_out_dir(header, bindgen_rs_path.as_ref());
     }
 
-    let dir = env!("CARGO_MANIFEST_DIR");
-    copy_with_cp(format!("{dir}/{bindgen_rs_path}"), out_path).unwrap();
+    let dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    copy_with_cp(dir.join(bindgen_rs_path), out_path).unwrap();
 
     let out_dir = env::var("OUT_DIR").unwrap();
 


### PR DESCRIPTION
The libsql-ffi build script is assuming things about Cargo's implementation of build scripts which are not guaranteed by Cargo. In particular, the build script API does not make a guarantee that the following 3 directory paths would necessarily be identical:

1. the crate's manifest directory during build script compilation
2. the crate's manifest directory during build script execution
3. the crate's manifest directory during library compilation

It only guarantees that $CARGO_MANIFEST_DIR will be suitably set during each of the 3 steps. But it could be 3 different values.

The build script in libsql-ffi is taking a path from step 1 and trying to resolve its contents during step 2. That is not going to work in general, for example in an sccache-like remote execution scenario.