### PR TITLE
fix: null sqlite3 handle after close to prevent double-free (#2251)

### DIFF
--- a/libsql/src/local/connection.rs
+++ b/libsql/src/local/connection.rs
@@ -107,7 +107,10 @@ impl Connection {
     /// Disconnect from the database.
     pub fn disconnect(&mut self) {
         if Arc::get_mut(&mut self.drop_ref).is_some() {
-            unsafe { libsql_sys::ffi::sqlite3_close_v2(self.raw) };
+            unsafe {
+                libsql_sys::ffi::sqlite3_close_v2(self.raw);
+                self.raw = std::ptr::null_mut();
+            };
         }
     }
 


### PR DESCRIPTION
## Problem

Closes #2251

The local connection's `sqlite3` handle is `sqlite3_close_v2`'d **twice** on teardown. `LibsqlConnection`'s `Drop` calls `disconnect()`, then the inner `Connection`'s `Drop` calls it again. Both go through `Connection::disconnect` (connection.rs:110). `disconnect()` isn't idempotent — the `Arc::get_mut(drop_ref)` guard only checks unique ownership (true both times) and doesn't record that the handle was already closed.

On Windows this is a hard `STATUS_ACCESS_VIOLATION` (0xC0000005); on Linux it doesn't fault (glibc keeps the freed page mapped) but the double free is real, as valgrind shows — 800 errors from 1 context at 800 iterations, one per connection.

## Root Cause

```
LibsqlConnection::drop -> self.conn.disconnect()   <- first close
Connection::drop       -> self.disconnect()         <- second close
```

Both calls succeed because `Arc::get_mut(drop_ref)` returns `Some` both times (the first close doesn't mark the handle as closed).

## Fix

After calling `sqlite3_close_v2`, set `self.raw` to `std::ptr::null_mut()`. This makes `disconnect()` idempotent — the second call sees a null pointer, and even if `Arc::get_mut` passes, calling `sqlite3_close_v2(null)` is documented as safe (no-op) in SQLite.

## Changes

- `libsql/src/local/connection.rs`: Null `raw` after `sqlite3_close_v2` in `disconnect()`

## Reproduction (from issue)

```rust
for _ in 0..50_000 {
    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
    rt.block_on(async {
        let db = libsql::Builder::new_local(":memory:").build().await.unwrap();
        let conn = db.connect().unwrap();
        conn.execute("CREATE TABLE t(x INTEGER)", ()).await.unwrap();
    });
}
```

With valgrind: 800 errors at 800 iterations. On Windows: `STATUS_ACCESS_VIOLATION` within first few hundred iterations.

## Testing

- `cargo check` passes
- The fix is minimal and makes `disconnect()` idempotent as suggested in the issue

Co-Authored-By: Claude <noreply@anthropic.com>
