### PR TITLE
libsql-ffi: Fix Windows build with encryption feature enabled

### DIFF
--- a/libsql-ffi/build.rs
+++ b/libsql-ffi/build.rs
@@ -88,11 +88,9 @@ fn copy_with_cp(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> 
         .status()
     {
         Ok(status) if status.success() => Ok(()),
-        _ => match fs::copy(from.as_ref(), to.as_ref()) {
-            Err(err) if err.kind() == io::ErrorKind::InvalidInput => copy_dir_all(from, to),
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        },
+        // Fall back to a pure-Rust copy where `cp` is unavailable (e.g. Windows).
+        _ if from.as_ref().is_dir() => copy_dir_all(from, to),
+        _ => fs::copy(from.as_ref(), to.as_ref()).map(|_| ()),
     }
 }
 


### PR DESCRIPTION
When the encryption feature is enabled, `copy_with_cp` copies the `SQLite3MultipleCiphers` directory into OUT_DIR. `cp` isn't available on Windows, so it falls back to `fs::copy`, which cannot copy a directory.

The previous fallback only routed to `copy_dir_all` when `fs::copy` returned `ErrorKind::InvalidInput`, but Windows returns `PermissionDenied` for a directory, so the copy was never retried and the build failed.

Detect directories explicitly with `is_dir()` instead of relying on a platform-specific error kind. Unix/macOS/Nix behavior is unchanged.