### PR TITLE
ci: install protoc from apt instead of arduino/setup-protoc

### DIFF
--- a/.github/workflows/c-bindings.yml
+++ b/.github/workflows/c-bindings.yml
@@ -46,7 +46,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
 
     - name: Install Protoc
-      uses: arduino/setup-protoc@v2
+      run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
     - name: Set up cargo cache
       uses: actions/cache@v3

--- a/.github/workflows/golang-bindings.yml
+++ b/.github/workflows/golang-bindings.yml
@@ -42,7 +42,7 @@ jobs:
       run: sudo apt-get install -y tcl8.6-dev
 
     - name: Install Protoc
-      uses: arduino/setup-protoc@v2
+      run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
     - name: Set up cargo cache
       uses: actions/cache@v3


### PR DESCRIPTION
The setup-protoc action downloads protoc via unauthenticated GitHub API requests, which share a rate limit across all runners on the same IP and intermittently fail with "API rate limit exceeded". Our proto files are all plain proto3, so the protobuf-compiler package from the Ubuntu archive is sufficient and involves no GitHub API at all.