### PR TITLE
Add ring/aws-lc-rs features to select the TLS crypto provider

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,22 @@ jobs:
       - uses: taiki-e/install-action@cargo-udeps
       - uses: Swatinem/rust-cache@v2
       - run: cargo +nightly hack udeps -p libsql --each-feature
+      # udeps ignores hyper-rustls and rustls, so these check compilability instead.
+      - run: RUSTFLAGS="-D warnings --cfg tokio_unstable" cargo check -p libsql --no-default-features --features remote,tls
+      - run: RUSTFLAGS="-D warnings --cfg tokio_unstable" cargo check -p libsql --no-default-features --features remote,tls,aws-lc-rs
+      - run: RUSTFLAGS="-D warnings --cfg tokio_unstable" cargo check -p libsql --no-default-features --features remote,tls-no-provider,aws-lc-rs
+      # The single-provider mobile config; no other job builds it.
+      - run: RUSTFLAGS="-D warnings --cfg tokio_unstable" cargo check -p sql-experimental --no-default-features --features aws-lc-rs
+      - name: tls-no-provider without a provider must fail
+        run: |
+          if out=$(cargo check -p libsql --no-default-features --features remote,tls-no-provider 2>&1); then
+            echo "expected the crypto-provider compile_error, but the build succeeded"
+            exit 1
+          elif ! grep -q "needs a crypto provider" <<< "$out"; then
+            echo "$out"
+            echo "build failed, but not with the expected compile_error"
+            exit 1
+          fi
       - run: RUSTFLAGS="-D warnings --cfg tokio_unstable" cargo check -p libsql --no-default-features --features core 
       - run: RUSTFLAGS="-D warnings --cfg tokio_unstable" cargo check -p libsql --no-default-features --features replication 
       - run: RUSTFLAGS="-D warnings --cfg tokio_unstable" cargo check -p libsql --no-default-features --features remote
@@ -247,6 +263,9 @@ jobs:
       - name: Install x86_64-pc-windows-msvc target
         run: rustup target add x86_64-pc-windows-msvc
       - name: build libsql all features
+        # --all-features pulls aws-lc-sys, which shells out to nasm; the runner has none.
+        env:
+          AWS_LC_SYS_PREBUILT_NASM: 1
         run: |
           cargo clean -p libsql-ffi
           cargo build -p libsql --all-features --release --target x86_64-pc-windows-msvc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "aws-runtime"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +1831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2103,12 @@ dependencies = [
  "rustix 0.38.34",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -2930,6 +2965,7 @@ dependencies = [
  "parking_lot",
  "pprof",
  "rand",
+ "rustls 0.22.4",
  "serde",
  "serde_json",
  "tempfile",
@@ -4363,7 +4399,7 @@ dependencies = [
  "getrandom",
  "libc",
  "spin",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -4435,6 +4471,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "ring",
  "rustls-pki-types",
@@ -4500,7 +4537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4509,9 +4546,10 @@ version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4649,7 +4687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4966,9 +5004,11 @@ dependencies = [
  "bytes",
  "cbindgen",
  "http 1.3.1",
+ "hyper",
  "hyper-rustls 0.25.0",
  "lazy_static",
  "libsql",
+ "rustls 0.22.4",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5719,6 +5759,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -14,12 +14,20 @@ cbindgen = "0.24.0"
 bytes = "1.5.0"
 lazy_static = "1.4.0"
 tokio = { version = "1.29.1", features = [ "rt-multi-thread" ] }
-hyper-rustls = { version = "0.25", features = ["webpki-roots"]}
+hyper-rustls = { version = "0.25", default-features = false, features = ["http1", "logging", "native-tokio", "tls12", "webpki-roots"] }
+rustls = { version = "0.22", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 http = "1.1.0"
 anyhow = "1.0.86"
-libsql = { path = "../../libsql", features = ["encryption"] }
+hyper = { workspace = true, features = ["client", "tcp"] }
+libsql = { path = "../../libsql", default-features = false, features = ["core", "replication", "remote", "sync", "tls-no-provider", "encryption"] }
+
+[features]
+default = ["ring"]
+# At least one is required; `aws-lc-rs` wins when both are enabled.
+ring = ["libsql/ring", "rustls/ring"]
+aws-lc-rs = ["libsql/aws-lc-rs", "rustls/aws_lc_rs"]
 
 
 # The produced binaries are too large for mobiles

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -32,6 +32,38 @@ unsafe fn set_err_msg(msg: String, output: *mut *const std::ffi::c_char) {
     }
 }
 
+#[cfg(not(any(feature = "ring", feature = "aws-lc-rs")))]
+compile_error!("enable either the `ring` (default) or `aws-lc-rs` feature");
+
+/// `aws-lc-rs` wins when both features are enabled, matching libsql.
+#[cfg(feature = "aws-lc-rs")]
+fn crypto_provider() -> rustls::crypto::CryptoProvider {
+    rustls::crypto::aws_lc_rs::default_provider()
+}
+
+#[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+fn crypto_provider() -> rustls::crypto::CryptoProvider {
+    rustls::crypto::ring::default_provider()
+}
+
+/// On failure, sets `out_err_msg` and returns `None`.
+unsafe fn webpki_connector(
+    out_err_msg: *mut *const std::ffi::c_char,
+) -> Option<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>> {
+    let mut http = hyper::client::HttpConnector::new();
+    http.enforce_http(false);
+    http.set_nodelay(true);
+    match hyper_rustls::HttpsConnectorBuilder::new()
+        .with_provider_and_webpki_roots(crypto_provider())
+    {
+        Ok(builder) => Some(builder.https_or_http().enable_http1().wrap_connector(http)),
+        Err(e) => {
+            set_err_msg(format!("Wrong TLS configuration: {e}"), out_err_msg);
+            None
+        }
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn libsql_enable_internal_tracing() -> std::ffi::c_int {
     if tracing_subscriber::fmt::try_init().is_ok() {
@@ -266,11 +298,10 @@ pub unsafe extern "C" fn libsql_open_sync_with_config(
         let mut builder =
             Builder::new_synced_database(db_path, primary_url.to_owned(), auth_token.to_owned());
         if config.with_webpki != 0 {
-            let https = hyper_rustls::HttpsConnectorBuilder::new()
-                .with_webpki_roots()
-                .https_or_http()
-                .enable_http1()
-                .build();
+            let https = match webpki_connector(out_err_msg) {
+                Some(https) => https,
+                None => return 7,
+            };
             builder = builder.connector(https);
         }
         if !config.remote_encryption_key.is_null() {
@@ -311,11 +342,10 @@ pub unsafe extern "C" fn libsql_open_sync_with_config(
         auth_token.to_string(),
     );
     if config.with_webpki != 0 {
-        let https = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_or_http()
-            .enable_http1()
-            .build();
+        let https = match webpki_connector(out_err_msg) {
+            Some(https) => https,
+            None => return 7,
+        };
         builder = builder.connector(https);
     }
     if config.sync_interval > 0 {
@@ -493,11 +523,10 @@ unsafe fn libsql_open_remote_internal(
     };
 
     if with_webpki {
-        let https = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_or_http()
-            .enable_http1()
-            .build();
+        let https = match webpki_connector(out_err_msg) {
+            Some(https) => https,
+            None => return 7,
+        };
         builder = builder.connector(https);
     }
     match RT.block_on(builder.build()) {

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -18,7 +18,8 @@ tokio = { version = "1.29.1", features = ["sync"], optional = true }
 tokio-util = { version = "0.7", features = ["io-util", "codec"], optional = true }
 parking_lot = { version = "0.12.1", optional = true }
 hyper = { version = "0.14", features = ["client", "http1", "http2", "stream", "runtime"], optional = true }
-hyper-rustls = { version = "0.25", features = ["webpki-roots"], optional = true }
+hyper-rustls = { version = "0.25", default-features = false, features = ["http1", "logging", "native-tokio", "tls12", "webpki-roots"], optional = true }
+rustls = { version = "0.22", default-features = false, features = ["logging", "tls12"], optional = true }
 base64 = { version = "0.21", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", features = ["float_roundtrip"], optional = true }
@@ -148,14 +149,22 @@ cloudflare = [
   "dep:worker"
 ]
 encryption = ["core", "libsql-sys/encryption", "dep:bytes"]
-tls = ["dep:hyper-rustls"]
+tls = ["tls-no-provider", "ring"]
+tls-no-provider = ["dep:hyper-rustls", "dep:rustls"]
+# `aws-lc-rs` wins when both are enabled.
+ring = ["tls-no-provider", "rustls?/ring"]
+aws-lc-rs = ["tls-no-provider", "rustls?/aws_lc_rs"]
 
 [[bench]]
 name = "benchmark"
 harness = false
 
+[[example]]
+name = "flutter"
+required-features = ["core", "remote", "tls-no-provider"]
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["hyper-rustls"]
+normal = ["hyper-rustls", "rustls"]

--- a/libsql/examples/flutter.rs
+++ b/libsql/examples/flutter.rs
@@ -8,8 +8,16 @@ async fn main() {
             "".to_string()
         });
 
+        // A custom connector also picks the crypto provider. The cfgs check libsql's
+        // own features only because this example lives inside the libsql package.
+        #[cfg(feature = "aws-lc-rs")]
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
+        #[cfg(not(feature = "aws-lc-rs"))]
+        let provider = rustls::crypto::ring::default_provider();
+
         let https = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_webpki_roots()
+            .with_provider_and_webpki_roots(provider)
+            .unwrap()
             .https_or_http()
             .enable_http1()
             .build();

--- a/libsql/src/database.rs
+++ b/libsql/src/database.rs
@@ -756,10 +756,9 @@ impl Database {
     }
 }
 
-#[cfg(any(
-    all(feature = "tls", feature = "replication"),
-    all(feature = "tls", feature = "remote"),
-    all(feature = "tls", feature = "sync")
+#[cfg(all(
+    feature = "tls-no-provider",
+    any(feature = "replication", feature = "remote", feature = "sync")
 ))]
 fn connector() -> Result<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>> {
     let mut http = hyper::client::HttpConnector::new();
@@ -767,20 +766,52 @@ fn connector() -> Result<hyper_rustls::HttpsConnector<hyper::client::HttpConnect
     http.set_nodelay(true);
 
     Ok(hyper_rustls::HttpsConnectorBuilder::new()
-        .with_native_roots()
+        .with_provider_and_native_roots(crypto_provider::get())
         .map_err(crate::Error::InvalidTlsConfiguration)?
         .https_or_http()
         .enable_http1()
         .wrap_connector(http))
 }
 
-#[cfg(any(
-    all(not(feature = "tls"), feature = "replication"),
-    all(not(feature = "tls"), feature = "remote"),
-    all(not(feature = "tls"), feature = "sync")
+#[cfg(all(
+    feature = "tls-no-provider",
+    any(feature = "replication", feature = "remote", feature = "sync")
+))]
+mod crypto_provider {
+    /// `aws-lc-rs` wins when both are enabled: `tls` pulls in `ring`, which would
+    /// otherwise silently beat an explicit opt-in.
+    #[cfg(feature = "aws-lc-rs")]
+    pub(super) fn get() -> rustls::crypto::CryptoProvider {
+        rustls::crypto::aws_lc_rs::default_provider()
+    }
+
+    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+    pub(super) fn get() -> rustls::crypto::CryptoProvider {
+        rustls::crypto::ring::default_provider()
+    }
+
+    #[cfg(not(any(feature = "ring", feature = "aws-lc-rs")))]
+    compile_error!(
+        "the `tls-no-provider` feature needs a crypto provider: enable `ring` or `aws-lc-rs`, or use `tls` instead"
+    );
+
+    /// Never reached: the `compile_error!` above rejects this configuration. It
+    /// exists so that the `compile_error!` is the only diagnostic.
+    #[cfg(not(any(feature = "ring", feature = "aws-lc-rs")))]
+    pub(super) fn get() -> rustls::crypto::CryptoProvider {
+        unreachable!()
+    }
+}
+
+#[cfg(all(
+    not(feature = "tls-no-provider"),
+    any(feature = "replication", feature = "remote", feature = "sync")
 ))]
 fn connector() -> Result<hyper::client::HttpConnector> {
-    panic!("The `tls` feature is disabled, you must provide your own http connector");
+    panic!(
+        "no builtin connector: enable `tls`, or `tls-no-provider` with `ring`/`aws-lc-rs`, \
+         or supply your own connector"
+    );
 }
 
 impl std::fmt::Debug for Database {

--- a/libsql/src/lib.rs
+++ b/libsql/src/lib.rs
@@ -75,7 +75,7 @@
 //! flags may be used by including the libsql crate like:
 //!
 //! ```toml
-//! libsql = { version = "*", default-features = false, features = ["core", "replication", "remote" ]
+//! libsql = { version = "*", default-features = false, features = ["core", "replication", "remote"] }
 //! ```
 //!
 //! By default, all the features are enabled but by providing `default-features = false` it will
@@ -88,8 +88,30 @@
 //! that will allow you to sync you remote database locally.
 //! - `remote` this feature flag only includes HTTP code that will allow you to run queries against
 //! a remote database.
-//! - `tls` this feature flag disables the builtin TLS connector and instead requires that you pass
-//! your own connector for any of the features that require HTTP.
+//! - `tls` this feature flag enables the builtin TLS connector with the [ring] crypto
+//! provider. Without either `tls` or `tls-no-provider` you must pass your own connector for
+//! any of the features that require HTTP.
+//! - `tls-no-provider` this feature flag enables the builtin TLS connector without a crypto
+//! provider; pair it with `ring` or `aws-lc-rs`. Omitting both is a compile error in builds
+//! that construct the connector, i.e. ones that also enable `replication`, `remote` or `sync`.
+//! - `ring` this feature flag backs the builtin TLS connector with the [ring] crypto provider.
+//! It is pulled in by `tls` and needs no extra build tooling.
+//! - `aws-lc-rs` this feature flag backs the builtin TLS connector with the [aws-lc-rs]
+//! crypto provider instead. It takes precedence over `ring`, so it can simply be added on
+//! top of the default features, although that compiles both providers. For a single-provider
+//! build, use `tls-no-provider`:
+//!
+//! ```toml
+//! libsql = { version = "*", default-features = false, features = ["core", "replication", "remote", "sync", "tls-no-provider", "aws-lc-rs"] }
+//! ```
+//!
+//! aws-lc-rs needs a C compiler and, on some targets, extra build tooling (see the
+//! [aws-lc-rs requirements]); ring needs a C compiler but no extra tooling, which is why
+//! it is the default.
+//!
+//! [ring]: https://docs.rs/ring
+//! [aws-lc-rs]: https://docs.rs/aws-lc-rs
+//! [aws-lc-rs requirements]: https://aws.github.io/aws-lc-rs/requirements/index.html
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(
@@ -99,7 +121,7 @@
             not(feature = "replication"),
             not(feature = "core")
         ),
-        feature = "tls"
+        feature = "tls-no-provider"
     ),
     allow(unused_imports)
 )]
@@ -110,7 +132,7 @@
             not(feature = "replication"),
             not(feature = "core")
         ),
-        feature = "tls"
+        feature = "tls-no-provider"
     ),
     allow(dead_code)
 )]


### PR DESCRIPTION
Partially resolve (or unblock future work for) #2269 

Lets the builtin TLS connector be backed by aws-lc-rs, primarily to enable future FIPS work. rustls resolves its crypto provider from compiled-in features, so the selection is made explicit — which also makes single-provider (mobile) builds possible.

- New features: `ring`, `aws-lc-rs`, and `tls-no-provider` (connector without a bundled provider); `tls` = `tls-no-provider` + `ring`, so defaults are unchanged.
- `aws-lc-rs` takes precedence when both providers are enabled; the connector passes the provider to hyper-rustls explicitly.
- A build that constructs the connector without naming a provider fails with an actionable `compile_error!`; the C bindings expose matching `ring` (default) / `aws-lc-rs` features.
- CI checks the new feature combinations (including a must-fail check for the provider-less config); the Windows all-features build sets `AWS_LC_SYS_PREBUILT_NASM=1` since the runner has no nasm.

No behavior or public API change for existing users; defaults still use ring.

Of course, the cleaner way is to make a hard switch to aws-lc-rs, but it may be a breaking change.